### PR TITLE
docs: add series pages and nav entries for three new blog series

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -177,6 +177,10 @@ groups:
         url: /blog/series/tetra-end-to-end/
       - title: "Series: Weak-Signal Engineering"
         url: /blog/series/weak-signal-engineering/
+      - title: "Series: P25 End to End"
+        url: /blog/series/p25-end-to-end/
+      - title: "Series: From Spec to Shipping"
+        url: /blog/series/from-spec-to-shipping/
       - title: Tutorials
         url: /blog/category/tutorials/
       - title: "Series: Signal Lab"
@@ -187,6 +191,8 @@ groups:
         url: /blog/series/crypto-lab/
       - title: "Series: The Analog Edge"
         url: /blog/series/analog-edge/
+      - title: "Series: The Operator's Cookbook"
+        url: /blog/series/operator-cookbook/
       - title: Solution Postmortem
         url: /blog/category/solution-postmortem/
       - title: "Series: From the Issue Tracker"

--- a/docs/_posts/2026-09-03-from-spec-to-shipping-01-reading-a-radio-standard.md
+++ b/docs/_posts/2026-09-03-from-spec-to-shipping-01-reading-a-radio-standard.md
@@ -1,0 +1,332 @@
+---
+title: "From Spec to Shipping, Part 1: How to Read a Radio Standard"
+description: How ETSI EN and TIA-102 standards families are organized, the order a decoder author should read them — physical layer up to PDU layouts — and the constants to extract on day one: sync words, CRC definitions, and the exact bit offsets everything else leans on.
+category: deep-dives
+keywords: how to read a radio standard, etsi en 300 392-2, tia-102 document family, p25 specification structure, tetra air interface specification, crc polynomial from spec, bit order transmission order, writing a protocol decoder from a spec, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, standards, etsi, tia-102, protocols, methodology]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 1
+---
+
+*Part 1 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air. The
+[From the Issue Tracker]({{ '/blog/solution-postmortem/from-the-issue-tracker-01-first-p25-lock/' | relative_url }})
+series told these lessons as postmortems: fabricated framing, placeholder
+constants, green tests over a decoder no real system could feed. This series
+teaches the same discipline forward, as method — with one recurring villain,
+**the test that passes because both sides share the same assumption**, and
+one recurring hero, the independent reference. This opener starts where
+every decoder starts: the PDF itself — how to read it, and what to pull out
+of it first.*
+
+> **TL;DR:** A radio standard is a **family of documents**, not one PDF —
+> TETRA's air interface is ETSI EN 300 392-2, its voice codec EN 300 395-2,
+> its direct mode EN 300 396-2/-3; P25 spreads across the TIA-102 series
+> (BAAA physical layer, AABC/AABF trunking messages, BABA vocoder, BBAB/BBAC
+> Phase 2). Read in **decode order** — physical → burst geometry → channel
+> coding → CRCs → PDU layouts — and extract the load-bearing constants
+> first: sync patterns, CRC definitions, exact bit offsets. Every such
+> constant in GopherTrunk cites its section (grep `§8.2.5` in
+> `internal/radio/framing/scramble_tetra.go`) — because
+> [placeholder constants]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }})
+> are how GopherTrunk shipped a SmartNet decoder that could never lock
+> ([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)).
+
+**Key takeaways**
+
+- **The spec is a family with a division of labor.** One part owns the
+  modulation, another the burst geometry, another the codec. Knowing which
+  part owns your question is half of finding the answer — and a field
+  "defined in Part 3" is a trap when you only have Part 2.
+- **Read in decode order.** A decoder consumes physical symbols, then bursts,
+  then channel coding, then CRC-gated payloads, then PDUs. Reading the spec
+  in that order means every chapter you finish is testable against the last.
+- **Constants first, prose second.** Sync words, polynomial taps, interleave
+  strides and bit offsets are the facts everything else leans on. Extract
+  them into named, cited constants on day one; a wrong constant silently
+  poisons everything downstream.
+- **The spec alone is not enough.** Standards ship without test vectors,
+  define fields without naming their values, and leave bit order ambiguous.
+  Each gap is a place where your reading and your test can share the same
+  mistake — which is why Part 2 is about independent references.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| TETRA air interface | bursts, channel coding, scrambling, MAC/CMCE PDUs | ETSI EN 300 392-2; cited across `internal/radio/tetra/` |
+| TETRA voice codec | ACELP full-rate speech codec + reference C code | ETSI EN 300 395-2; `internal/voice/acelp/` |
+| TETRA direct mode | DMO radio layer (396-2) and MS-MS protocol (396-3) | ETSI EN 300 396-2/-3; `internal/radio/tetra/dmo.go` |
+| P25 physical + FDMA | C4FM, NID, frame structure, data units | TIA-102.BAAA; `internal/radio/p25/phase1/` |
+| P25 trunking messages | TSBK/MBT opcodes and field layouts | TIA-102.AABC / TIA-102.AABF; `phase1/opcodes.go` |
+| P25 vocoder | IMBE frame format, FEC, synthesis | TIA-102.BABA; `internal/voice/imbe/` |
+| Scrambling seed example | LFSR polynomial + seed packing, section-cited | `internal/radio/framing/scramble_tetra.go` (§8.2.5) |
+
+## In this post
+
+- **A standard is a family, not a document** — how ETSI and TIA carve up a
+  protocol, and which parts a decoder author needs.
+- **Read in decode order, not page order** — physical → bursts → coding →
+  CRCs → PDUs, so each chapter is testable.
+- **Extract the constants first** — sync patterns, CRC definitions, exact
+  bit offsets.
+- **The traps that break parsers silently** — bit order, transmission
+  order, fields defined elsewhere, "reserved" that isn't.
+- **What the spec cannot tell you** — the gaps that make Part 2 necessary.
+
+## A standard is a family, not a document
+
+Nobody publishes "the TETRA spec." ETSI publishes a *series*: EN 300 392 is
+"Voice plus Data," and its Part 2 — the air interface — is the ~1000-page
+volume a decoder author lives in. The speech codec is a different series
+entirely (EN 300 395-2, which ships reference C code — the anchor for
+[Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})).
+Direct mode is yet another: EN 300 396-2 covers the DMO radio layer, and the
+MS-to-MS call-control protocol riding on it is EN 300 396-3 — a separation
+GopherTrunk's `internal/radio/tetra/dmo.go` doc comment spells out, because
+burst slicing and call semantics arrive from two different books.
+
+TIA slices P25 just as finely. TIA-102.BAAA is the FDMA common air
+interface — modulation, NID, frame structure. The trunking control-channel
+*message layouts* GopherTrunk's `opcodes.go` decodes cite TIA-102.AABC and
+TIA-102.AABF throughout. The IMBE vocoder is TIA-102.BABA; Phase 2's
+two-slot TDMA splits across TIA-102.BBAB (physical) and TIA-102.BBAC (MAC);
+encryption is TIA-102.AACE. Revisions ride as suffixes —
+`internal/dsp/demod/c4fm_modulator.go` cites TIA-102.BAAA-**A** §6.1.1 for
+the deviation table, and a revision letter can silently change a constant
+you extracted from the base document.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two standards families side by side: the ETSI TETRA documents and the TIA-102 P25 documents, with the decoder-relevant parts highlighted and the conformance-testing, uplink-only and encryption parts muted; a note beneath says each highlighted document maps to one GopherTrunk package.">
+  <text x="150" y="22" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">ETSI TETRA family</text>
+  <rect x="30" y="34" width="240" height="30" rx="5" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="150" y="53" text-anchor="middle" fill="var(--accent)" font-size="10">EN 300 392-2 — V+D air interface</text>
+  <rect x="30" y="70" width="240" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="150" y="89" text-anchor="middle" fill="var(--accent)" font-size="10">EN 300 395-2 — ACELP codec + ref C</text>
+  <rect x="30" y="106" width="240" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="150" y="125" text-anchor="middle" fill="var(--accent)" font-size="10">EN 300 396-2 / -3 — DMO radio / protocol</text>
+  <rect x="30" y="142" width="240" height="26" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="150" y="159" text-anchor="middle" fill="var(--fg-muted)" font-size="10">conformance testing, uplink-only parts</text>
+  <text x="530" y="22" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">TIA-102 P25 family</text>
+  <rect x="410" y="34" width="240" height="30" rx="5" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="530" y="53" text-anchor="middle" fill="var(--accent)" font-size="10">BAAA — FDMA physical layer / CAI</text>
+  <rect x="410" y="70" width="240" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="530" y="89" text-anchor="middle" fill="var(--accent)" font-size="10">AABC / AABF — trunking messages</text>
+  <rect x="410" y="106" width="240" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="530" y="125" text-anchor="middle" fill="var(--accent)" font-size="10">BABA — IMBE · BBAB/BBAC — Phase 2</text>
+  <rect x="410" y="142" width="240" height="26" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="530" y="159" text-anchor="middle" fill="var(--fg-muted)" font-size="10">AACE — encryption (metadata only)</text>
+  <line x1="150" y1="176" x2="150" y2="200" stroke="var(--fg-muted)"/>
+  <line x1="530" y1="176" x2="530" y2="200" stroke="var(--fg-muted)"/>
+  <line x1="150" y1="200" x2="530" y2="200" stroke="var(--fg-muted)"/>
+  <line x1="340" y1="200" x2="340" y2="216" stroke="var(--fg-muted)"/>
+  <polygon points="336,214 340,222 344,214" fill="var(--fg-muted)"/>
+  <text x="340" y="238" text-anchor="middle" fill="currentColor" font-size="10">each highlighted document maps to a GopherTrunk package citing it by section</text>
+</svg>
+<figcaption>The decoder-relevant subset of two standards families: a handful of highlighted documents carry every constant a receive-only decoder needs.</figcaption>
+</figure>
+
+Two practical consequences. First, **get the right parts**: a receive-only
+scanner needs the air interface, the codec, and the trunking messages — not
+the conformance-testing or uplink-heavy parts. Second, **normative versus
+informative matters**: worked-example annexes are informative and can lag
+the normative clauses; when they disagree, the normative text wins — and the
+disagreement itself is a flag to find an independent reference.
+
+## Read in decode order, not page order
+
+Standards are organized for transmitter implementers as much as receivers,
+and page order rarely matches the order a decoder consumes the signal. The
+reading order that works is the decode chain itself:
+
+| Stage | What to read for | TETRA example (EN 300 392-2) |
+|---|---|---|
+| 1. Physical | modulation, symbol rate, pulse shaping | π/4-DQPSK, 18000 sym/s ([TETRA End to End Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})) |
+| 2. Burst geometry | burst types, training sequences, slot grid | §9.4.4 burst layouts, in dibits from the training sequence |
+| 3. Channel coding | convolutional/RM codes, interleaving, scrambling | RCPC mother code, §8.2.5 scrambling |
+| 4. CRCs | polynomial, init, span, complement rules | the CRC each logical channel gates on |
+| 5. PDU layouts | field-by-field bit offsets | MAC (§21) and CMCE (§14) PDU tables |
+
+The reason to hold this order is testability: each layer's output is the
+next layer's input, so a finished layer can be pinned before the next one
+exists. Finish the burst slicer and you can count training-sequence hits on
+a capture before you've written a single CRC; finish the channel coding and
+CRC-valid counts become your universal yield metric — the number the
+[Weak-Signal Engineering series]({{ '/blog/series/weak-signal-engineering/' | relative_url }})
+treats as the only verdict that cannot flatter you. Skip ahead to PDU
+parsing — the tempting part, where talkgroups live — and nothing you write
+is checkable until every layer below it also works. That is exactly how a
+stack of untested assumptions forms.
+
+## Extract the constants first
+
+Within each layer, the first pass is not to understand everything — it's a
+harvest. Three kinds of facts get extracted into named, cited constants
+before any logic is written:
+
+**Sync and training patterns.** The only thing a decoder can find in an
+unsynchronized dibit stream — and one wrong bit means zero decodes forever,
+with no error message.
+
+**CRC and scrambling definitions.** Polynomial, initialization, bit span,
+and any final complement — all four, because a CRC that's "almost right"
+fails exactly like a weak signal does. GopherTrunk's TETRA scrambler is the
+template for how these land in code:
+
+```go
+// internal/radio/framing/scramble_tetra.go (shape)
+// Connection polynomial (§8.2.5.2 eq. 8.40):
+//
+//	c(x) = 1 + X + X^2 + X^4 + X^5 + X^7 + X^8 + X^10 + X^11
+//	     + X^12 + X^16 + X^22 + X^23 + X^26 + X^32
+//
+// The recurrence is p(k) = sum_{i=1..32} c_i * p(k-i) (§8.2.5.2
+// eq. 8.41) with initialisation p(-31) = p(-30) = 1, p(-29) =
+// e(30), ..., p(0) = e(1) per §8.2.5.2 eq. 8.42.
+const scrambleTetraTapMask uint32 = 0x82608EDB
+```
+
+Equation numbers, section numbers, the exact seed packing — all in the
+comment, so the constant is *auditable* against the source years later.
+(That seed rule, eq. 8.42, is also why "colour code 0" is not a no-op — the
+LFSR seeds non-zero even with all colour bits zero, a fact that cost the
+[DMO investigation]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+weeks when one decode path skipped descrambling at colour 0.)
+
+**Exact bit offsets.** PDU field tables get transcribed as offsets with the
+spec's own field names, not paraphrased. The corollary is the hard lesson of
+[From the Issue Tracker Part 17]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }}):
+a constant you *couldn't* verify and wrote down anyway is worse than a
+`panic("unimplemented")`, because it fails silently. GopherTrunk's original
+SmartNet decoder was built on a 24-bit sync word and a BCH code matching
+**no real reference** — every synthetic test passed, no real system ever
+locked, and the framing had to be rebuilt from proven decoders
+([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143), Part 8's
+case study).
+
+## The traps that break parsers silently
+
+Four recurring traps, each drawn from a bug this project shipped or
+narrowly avoided:
+
+**Bit order and endianness.** A spec says "e(1) through e(30)" and you must
+determine whether e(1) is the MSB or LSB of the packed value. The vicious
+part: get it wrong and your encoder and decoder still agree. GopherTrunk's
+independent scrambler cross-check (`refScrambleTetraETSI` in
+`scramble_tetra_test.go`) documents it exactly: the wrong endianness "still
+round-trips and still passes BSCH, but does not match the sequence a real
+base station scrambles with, so no BNCH/SCH burst decodes." The series
+villain in its purest form — a self-consistent mistake, invisible to any
+test that doesn't bring in an outside fact.
+
+**Transmission order versus logical order.** Interleavers, bit-reversal
+conventions, and MSB-first-on-the-wire rules mean the bytes in the PDU table
+are not the bits in the air; the layers must be undone in reverse order, and
+an off-by-one in an interleave stride is wrong *everywhere* at once — see
+[From the Issue Tracker Part 8]({{ '/blog/solution-postmortem/from-the-issue-tracker-08-nineteen-dibits/' | relative_url }})
+for what nineteen dibits of slip looks like from the outside.
+
+**Fields defined by reference.** TETRA's D-SETUP carries a "basic service
+information" element whose sub-field layout is effectively defined through
+the ASN.1 description — GopherTrunk pinned the decomposition against
+Wireshark's generated dissector because the prose alone underdetermines it
+(`internal/radio/tetra/cmce_parse.go`). When a field's definition lives in
+another document — or another *format* — the spec you're holding tells you
+it exists, not what it means.
+
+**"Reserved" and vendor space that isn't.** P25's opcode space has
+manufacturer-specific regions, and rendering a vendor TSBK through the
+standard opcode name map actively *mislabels* it — MFID 0x90 opcode 0x00
+reads back as `GRP_V_CH_GRANT` if you let it, so GopherTrunk refuses to name
+vendor or undecoded opcodes through the standard map at all. Treat every
+"reserved" region as "defined somewhere you haven't looked yet."
+
+## What the spec cannot tell you
+
+Read perfectly, extract diligently, and you still hold a document with
+structural gaps. Most standards ship **no test vectors** for the receive
+chain — EN 300 395-2's reference codec is a happy exception, and Part 4
+builds a whole conformance harness on it. Fields get defined but their
+values left unnamed: the D-SETUP communication-type bits are decoded by
+three independent open decoders, yet *none names the enum values* — so
+GopherTrunk carries the spec-derived mapping as constants that are
+deliberately **not** wired into call classification until a capture
+confirms them. And some questions the spec answers only for the
+transmitter — which of several permitted broadcast forms a real network
+actually uses is an empirical fact (some P25 systems announce their
+neighbours *only* in AMBT form, which GopherTrunk once dropped as
+"non-control" spam).
+
+Every one of those gaps has the same resolution: an independent fact from
+outside your own head — another implementation, a reference codec, a
+capture.
+
+### How that principle shaped the Go code
+
+- **Every constant carries its citation.** Grepping `§8.2.5` or
+  `TIA-102.AABC` finds the constant *and* its provenance in one step; an
+  uncited constant is a review flag.
+- **Spec-derived but unconfirmed facts are quarantined.** The comms-type
+  constants exist (`CommsPointToPoint` and friends in `cmce_parse.go`) but
+  are logged for empirical confirmation, not wired into behaviour.
+- **Layer boundaries in the spec are package boundaries in the code.**
+  Channel coding in `internal/radio/framing`, protocol PDUs in
+  `internal/radio/tetra` and `internal/radio/p25`, vocoders in
+  `internal/voice/` — each layer pinnable at exactly the seams the reading
+  order established.
+- **Ambiguity gets a second implementation, not a decision.** Where the text
+  underdetermines bit order, the tree carries an independent re-derivation
+  built to disagree with the production code — the pattern
+  [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+  develops in full.
+
+## Where this goes next
+
+A spec plus your own reading of it is one source — and one source can be
+self-consistently wrong.
+[Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})
+assembles the reference stable — OP25, trunk-recorder, SDRTrunk, osmo-tetra,
+the ETSI reference codec, mbelib — what each is authoritative for, and the
+rules for trusting them, starting with the one that matters most: *proven on
+air beats popular*.
+
+## FAQ
+
+**Do I need to buy the standards to write a decoder?**
+ETSI standards are free downloads from etsi.org, including the EN 300 392
+and EN 300 395 families. The TIA-102 series is sold commercially; substantial
+layout knowledge is also recoverable from open implementations — Part 2's
+subject, with its own clean-room rules in Part 5.
+
+**What should I read first in a spec I've never opened?**
+The physical layer chapter and the burst/frame structure tables — then stop
+and find the sync patterns and CRC definitions wherever they live. Those let
+you build the first testable thing (a sync correlator counting hits on a
+capture) before you understand the other 900 pages.
+
+**Why extract constants before writing any parsing logic?**
+Because constants fail silently and logic fails loudly. A wrong branch
+produces garbage you notice; a wrong sync word or CRC polynomial produces
+*zero decodes*, indistinguishable from a weak signal. Named, cited constants
+can be audited and pinned by literal-vector tests (Part 3) independently of
+the logic around them.
+
+**How do I know which document in a family defines a given field?**
+Follow the layer: physical facts in the air-interface part, message layouts
+in the signalling part, codec bits in the codec series. GopherTrunk cites at
+every use, so the codebase doubles as an index — the fastest answer to
+"where is SCCB defined" is the comment on
+`ParseSecondaryControlChannelBroadcast`.
+
+**Is the newest revision of a standard always the right one to implement?**
+Implement what deployed systems transmit, which often trails the paper.
+When a revision and a fielded system disagree, the capture referees — a
+theme this series returns to in Parts 6 and 10.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: Choosing Reference Implementations You Can Trust]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})

--- a/docs/_posts/2026-09-03-from-spec-to-shipping-01-reading-a-radio-standard.md
+++ b/docs/_posts/2026-09-03-from-spec-to-shipping-01-reading-a-radio-standard.md
@@ -1,6 +1,6 @@
 ---
 title: "From Spec to Shipping, Part 1: How to Read a Radio Standard"
-description: How ETSI EN and TIA-102 standards families are organized, the order a decoder author should read them — physical layer up to PDU layouts — and the constants to extract on day one: sync words, CRC definitions, and the exact bit offsets everything else leans on.
+description: "How ETSI EN and TIA-102 standards families are organized, the order a decoder author should read them — physical layer up to PDU layouts — and the constants to extract on day one: sync words, CRC definitions, and the exact bit offsets everything else leans on."
 category: deep-dives
 keywords: how to read a radio standard, etsi en 300 392-2, tia-102 document family, p25 specification structure, tetra air interface specification, crc polynomial from spec, bit order transmission order, writing a protocol decoder from a spec, gophertrunk from spec to shipping
 tags: [from-spec-to-shipping, standards, etsi, tia-102, protocols, methodology]

--- a/docs/_posts/2026-09-03-from-spec-to-shipping-01-reading-a-radio-standard.md
+++ b/docs/_posts/2026-09-03-from-spec-to-shipping-01-reading-a-radio-standard.md
@@ -39,11 +39,10 @@ of it first.*
 
 - **The spec is a family with a division of labor.** One part owns the
   modulation, another the burst geometry, another the codec. Knowing which
-  part owns your question is half of finding the answer — and a field
-  "defined in Part 3" is a trap when you only have Part 2.
-- **Read in decode order.** A decoder consumes physical symbols, then bursts,
-  then channel coding, then CRC-gated payloads, then PDUs. Reading the spec
-  in that order means every chapter you finish is testable against the last.
+  part owns your question is half of finding the answer.
+- **Read in decode order.** A decoder consumes physical symbols, then
+  bursts, then channel coding, then CRC-gated payloads, then PDUs. Reading
+  in that order makes every finished chapter testable against the last.
 - **Constants first, prose second.** Sync words, polynomial taps, interleave
   strides and bit offsets are the facts everything else leans on. Extract
   them into named, cited constants on day one; a wrong constant silently
@@ -59,7 +58,7 @@ of it first.*
 |---|---|---|
 | TETRA air interface | bursts, channel coding, scrambling, MAC/CMCE PDUs | ETSI EN 300 392-2; cited across `internal/radio/tetra/` |
 | TETRA voice codec | ACELP full-rate speech codec + reference C code | ETSI EN 300 395-2; `internal/voice/acelp/` |
-| TETRA direct mode | DMO radio layer (396-2) and MS-MS protocol (396-3) | ETSI EN 300 396-2/-3; `internal/radio/tetra/dmo.go` |
+| TETRA direct mode | radio layer (396-2), MS-MS protocol (396-3) | ETSI EN 300 396-2/-3; `internal/radio/tetra/dmo.go` |
 | P25 physical + FDMA | C4FM, NID, frame structure, data units | TIA-102.BAAA; `internal/radio/p25/phase1/` |
 | P25 trunking messages | TSBK/MBT opcodes and field layouts | TIA-102.AABC / TIA-102.AABF; `phase1/opcodes.go` |
 | P25 vocoder | IMBE frame format, FEC, synthesis | TIA-102.BABA; `internal/voice/imbe/` |
@@ -82,9 +81,9 @@ of it first.*
 Nobody publishes "the TETRA spec." ETSI publishes a *series*: EN 300 392 is
 "Voice plus Data," and its Part 2 — the air interface — is the ~1000-page
 volume a decoder author lives in. The speech codec is a different series
-entirely (EN 300 395-2, which ships reference C code — the anchor for
+(EN 300 395-2, which ships reference C code — the anchor for
 [Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})).
-Direct mode is yet another: EN 300 396-2 covers the DMO radio layer, and the
+Direct mode is yet another: EN 300 396-2 is the DMO radio layer, and the
 MS-to-MS call-control protocol riding on it is EN 300 396-3 — a separation
 GopherTrunk's `internal/radio/tetra/dmo.go` doc comment spells out, because
 burst slicing and call semantics arrive from two different books.
@@ -92,12 +91,12 @@ burst slicing and call semantics arrive from two different books.
 TIA slices P25 just as finely. TIA-102.BAAA is the FDMA common air
 interface — modulation, NID, frame structure. The trunking control-channel
 *message layouts* GopherTrunk's `opcodes.go` decodes cite TIA-102.AABC and
-TIA-102.AABF throughout. The IMBE vocoder is TIA-102.BABA; Phase 2's
+TIA-102.AABF throughout; the IMBE vocoder is TIA-102.BABA; Phase 2's
 two-slot TDMA splits across TIA-102.BBAB (physical) and TIA-102.BBAC (MAC);
 encryption is TIA-102.AACE. Revisions ride as suffixes —
-`internal/dsp/demod/c4fm_modulator.go` cites TIA-102.BAAA-**A** §6.1.1 for
-the deviation table, and a revision letter can silently change a constant
-you extracted from the base document.
+`internal/dsp/demod/c4fm_modulator.go` cites TIA-102.BAAA-**A** §6.1.1, and
+a revision letter can silently change a constant you extracted from the
+base document.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two standards families side by side: the ETSI TETRA documents and the TIA-102 P25 documents, with the decoder-relevant parts highlighted and the conformance-testing, uplink-only and encryption parts muted; a note beneath says each highlighted document maps to one GopherTrunk package.">
@@ -129,12 +128,12 @@ you extracted from the base document.
 <figcaption>The decoder-relevant subset of two standards families: a handful of highlighted documents carry every constant a receive-only decoder needs.</figcaption>
 </figure>
 
-Two practical consequences. First, **get the right parts**: a receive-only
-scanner needs the air interface, the codec, and the trunking messages — not
-the conformance-testing or uplink-heavy parts. Second, **normative versus
+Two consequences. First, **get the right parts**: a receive-only scanner
+needs the air interface, the codec, and the trunking messages — not the
+conformance-testing or uplink-heavy parts. Second, **normative versus
 informative matters**: worked-example annexes are informative and can lag
-the normative clauses; when they disagree, the normative text wins — and the
-disagreement itself is a flag to find an independent reference.
+the normative clauses; when they disagree, the normative text wins — and
+the disagreement is itself a flag to find an independent reference.
 
 ## Read in decode order, not page order
 
@@ -145,9 +144,9 @@ reading order that works is the decode chain itself:
 | Stage | What to read for | TETRA example (EN 300 392-2) |
 |---|---|---|
 | 1. Physical | modulation, symbol rate, pulse shaping | π/4-DQPSK, 18000 sym/s ([TETRA End to End Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})) |
-| 2. Burst geometry | burst types, training sequences, slot grid | §9.4.4 burst layouts, in dibits from the training sequence |
-| 3. Channel coding | convolutional/RM codes, interleaving, scrambling | RCPC mother code, §8.2.5 scrambling |
-| 4. CRCs | polynomial, init, span, complement rules | the CRC each logical channel gates on |
+| 2. Burst geometry | burst types, training sequences, slot grid | §9.4.4 burst layouts |
+| 3. Channel coding | codes, interleaving, scrambling | RCPC mother code, §8.2.5 scrambling |
+| 4. CRCs | polynomial, init, span, complement | the CRC each logical channel gates on |
 | 5. PDU layouts | field-by-field bit offsets | MAC (§21) and CMCE (§14) PDU tables |
 
 The reason to hold this order is testability: each layer's output is the
@@ -190,14 +189,14 @@ const scrambleTetraTapMask uint32 = 0x82608EDB
 ```
 
 Equation numbers, section numbers, the exact seed packing — all in the
-comment, so the constant is *auditable* against the source years later.
-(That seed rule, eq. 8.42, is also why "colour code 0" is not a no-op — the
-LFSR seeds non-zero even with all colour bits zero, a fact that cost the
+comment, so the constant is *auditable* years later. (That seed rule,
+eq. 8.42, is also why "colour code 0" is not a no-op — the LFSR seeds
+non-zero even with all colour bits zero, a fact that cost the
 [DMO investigation]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
 weeks when one decode path skipped descrambling at colour 0.)
 
 **Exact bit offsets.** PDU field tables get transcribed as offsets with the
-spec's own field names, not paraphrased. The corollary is the hard lesson of
+spec's own field names. The corollary is the hard lesson of
 [From the Issue Tracker Part 17]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }}):
 a constant you *couldn't* verify and wrote down anyway is worse than a
 `panic("unimplemented")`, because it fails silently. GopherTrunk's original
@@ -217,10 +216,10 @@ determine whether e(1) is the MSB or LSB of the packed value. The vicious
 part: get it wrong and your encoder and decoder still agree. GopherTrunk's
 independent scrambler cross-check (`refScrambleTetraETSI` in
 `scramble_tetra_test.go`) documents it exactly: the wrong endianness "still
-round-trips and still passes BSCH, but does not match the sequence a real
-base station scrambles with, so no BNCH/SCH burst decodes." The series
-villain in its purest form — a self-consistent mistake, invisible to any
-test that doesn't bring in an outside fact.
+round-trips and still passes BSCH," but matches no real base station, so no
+BNCH/SCH burst ever decodes. The series villain in its purest form — a
+self-consistent mistake, invisible to any test that doesn't bring in an
+outside fact.
 
 **Transmission order versus logical order.** Interleavers, bit-reversal
 conventions, and MSB-first-on-the-wire rules mean the bytes in the PDU table
@@ -240,9 +239,9 @@ it exists, not what it means.
 **"Reserved" and vendor space that isn't.** P25's opcode space has
 manufacturer-specific regions, and rendering a vendor TSBK through the
 standard opcode name map actively *mislabels* it — MFID 0x90 opcode 0x00
-reads back as `GRP_V_CH_GRANT` if you let it, so GopherTrunk refuses to name
-vendor or undecoded opcodes through the standard map at all. Treat every
-"reserved" region as "defined somewhere you haven't looked yet."
+reads back as `GRP_V_CH_GRANT` if you let it, so GopherTrunk refuses to
+name vendor or undecoded opcodes through the standard map. Treat every
+"reserved" region as defined somewhere you haven't looked yet.
 
 ## What the spec cannot tell you
 
@@ -252,17 +251,15 @@ chain — EN 300 395-2's reference codec is a happy exception, and Part 4
 builds a whole conformance harness on it. Fields get defined but their
 values left unnamed: the D-SETUP communication-type bits are decoded by
 three independent open decoders, yet *none names the enum values* — so
-GopherTrunk carries the spec-derived mapping as constants that are
-deliberately **not** wired into call classification until a capture
-confirms them. And some questions the spec answers only for the
-transmitter — which of several permitted broadcast forms a real network
-actually uses is an empirical fact (some P25 systems announce their
+GopherTrunk carries the spec-derived mapping as constants deliberately
+**not** wired into call classification until a capture confirms them. And
+which of several permitted broadcast forms a real network uses is an
+empirical fact the spec never settles — some P25 systems announce their
 neighbours *only* in AMBT form, which GopherTrunk once dropped as
-"non-control" spam).
+"non-control" spam.
 
-Every one of those gaps has the same resolution: an independent fact from
-outside your own head — another implementation, a reference codec, a
-capture.
+Every gap has the same resolution: an independent fact from outside your
+own head — another implementation, a reference codec, a capture.
 
 ### How that principle shaped the Go code
 
@@ -297,9 +294,9 @@ air beats popular*.
 
 **Do I need to buy the standards to write a decoder?**
 ETSI standards are free downloads from etsi.org, including the EN 300 392
-and EN 300 395 families. The TIA-102 series is sold commercially; substantial
+and EN 300 395 families. The TIA-102 series is sold commercially; much
 layout knowledge is also recoverable from open implementations — Part 2's
-subject, with its own clean-room rules in Part 5.
+subject, with clean-room rules in Part 5.
 
 **What should I read first in a spec I've never opened?**
 The physical layer chapter and the burst/frame structure tables — then stop
@@ -308,11 +305,11 @@ you build the first testable thing (a sync correlator counting hits on a
 capture) before you understand the other 900 pages.
 
 **Why extract constants before writing any parsing logic?**
-Because constants fail silently and logic fails loudly. A wrong branch
-produces garbage you notice; a wrong sync word or CRC polynomial produces
-*zero decodes*, indistinguishable from a weak signal. Named, cited constants
-can be audited and pinned by literal-vector tests (Part 3) independently of
-the logic around them.
+Constants fail silently and logic fails loudly. A wrong branch produces
+garbage you notice; a wrong sync word or CRC polynomial produces *zero
+decodes*, indistinguishable from a weak signal. Named, cited constants can
+be pinned by literal-vector tests (Part 3) independently of the logic
+around them.
 
 **How do I know which document in a family defines a given field?**
 Follow the layer: physical facts in the air-interface part, message layouts

--- a/docs/_posts/2026-09-03-operator-cookbook-01-forty-dollar-p25-rig.md
+++ b/docs/_posts/2026-09-03-operator-cookbook-01-forty-dollar-p25-rig.md
@@ -1,0 +1,342 @@
+---
+title: "The Operator's Cookbook, Part 1: The $40 P25 Starter Rig"
+description: A complete first GopherTrunk build — one RTL-SDR dongle, the stock whip, and a laptop decoding a local P25 Phase 1 system, with a copy-paste config.yaml, the exact log lines a healthy first run prints, and a troubleshooting table for when it won't lock.
+category: tutorials
+keywords: rtl-sdr p25 scanner setup, gophertrunk config example, p25 phase 1 decoder software, cheap police scanner sdr, rtl-sdr trunking scanner, p25 control channel lock, sdr scanner under 50 dollars, first sdr scanner build, gophertrunk cookbook
+tags: [operator-cookbook, p25, rtl-sdr, config, getting-started, hardware]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 1
+---
+
+*Part 1 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+Every other tutorial series on this blog is organized by subsystem — RF, DSP,
+recording, operations. This one is organized by **what you're trying to
+build**: each part is one full recipe, hardware list to working config to the
+log lines that prove it's alive. The running thread is a rig that grows — the
+$40 starter you build today is the same box that streams to Broadcastify in
+Part 9 and runs headless in a closet by Part 11. We start with the most common
+first build there is: one cheap dongle on a local P25 Phase 1 system.*
+
+> **TL;DR:** One **RTL-SDR Blog V3/V4 (~$35)**, the whip it ships with, and a
+> laptop decode a P25 Phase 1 system end to end. The trick that makes a single
+> dongle work is `role: wideband` + `voice_taps: 2` — the control channel and
+> the voice grants all decode out of one 2.4 MS/s capture, no second radio.
+> You find your system on RadioReference (or with
+> [`gophertrunk hunt`]({{ '/blog/deep-dives/the-hunt-07-locking-a-p25-system/' | relative_url }})),
+> paste its control channels into `config.yaml`, run
+> `gophertrunk run -config config.yaml`, and watch for
+> `control channel locked` then `recorder: call started` in the log. The web
+> console at `http://127.0.0.1:8080` does the rest.
+
+**Key takeaways**
+
+- **$40 is a real number, not a teaser.** A ~$35 RTL-SDR with a TCXO plus the
+  antenna in the box decodes P25 Phase 1 cleanly on any system you have
+  reasonable signal from. The upgrades in later parts buy margin, not
+  possibility.
+- **One dongle carries control and voice.** `role: wideband` with
+  `voice_taps: 2` taps voice calls out of the same IQ capture the control
+  channel decodes from — as long as the system's voice channels fit inside the
+  2.4 MHz window.
+- **The config is four blocks.** SDR device, one system, its control channels,
+  and where recordings go. Everything else in
+  `config.example.yaml` is optional and defaulted.
+- **Healthy has a signature.** `control channel locked` → `call started` →
+  `recorder: call ended` is the heartbeat of a working rig; this post shows
+  the real lines so you know them on sight.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Hardware list | dongle + whip + adapter, well under $100 total | [what do I need?]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }}) |
+| Which dongle | V3 vs V4 — either decodes identically | [V3 vs V4 guide]({{ '/rtl-sdr-blog-v3-vs-v4/' | relative_url }}), [RTL-SDR]({{ '/reference/rtl-sdr/' | relative_url }}) |
+| One-dongle trunking | wideband capture + per-call voice taps | `sdr.devices[].role: wideband`, `voice_taps` |
+| System definition | protocol, control channels, talkgroup names | `trunking.systems[]`, `control_channels`, `talkgroup_file` |
+| Finding your system | RadioReference, or map it yourself | [`gophertrunk hunt`]({{ '/blog/deep-dives/the-hunt-06-control-channel-hunting/' | relative_url }}) |
+| Frequency error | per-device `ppm`, or let `autotune` suggest one | [ppm correction]({{ '/reference/ppm-frequency-correction/' | relative_url }}) |
+| First-run cockpit | web console on the API port | `api.http_addr`, [web guide]({{ '/web.html' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — one dongle, one P25 system, calls on disk and in the browser.
+- **The shopping list** — three items, round numbers.
+- **Finding your system** — RadioReference first, `hunt` when it isn't listed.
+- **The config** — a complete, minimal `config.yaml` with every key verified.
+- **First run — what healthy looks like** — the exact log lines and web panels.
+- **When it doesn't work** — symptom → cause → fix.
+
+## What you're building
+
+The finished rig is a laptop with a USB dongle hanging off it, doing what a
+$500 digital scanner does: camp a P25 Phase 1
+[control channel]({{ '/reference/control-channel/' | relative_url }}), decode
+every voice grant, follow calls to their voice channels, decode the IMBE audio,
+and write one WAV per call into a folder tree sorted by
+[talkgroup]({{ '/reference/talkgroup/' | relative_url }}) — with a live web
+console showing the system light up in real time.
+
+The architectural trick that makes one dongle enough: GopherTrunk's wideband
+engine treats the dongle's whole 2.4 MHz capture as a band, not a channel. One
+tap inside that capture decodes the control channel continuously; when a voice
+grant arrives, a `voice_taps` slot spins up a second down-converter *on the
+same IQ stream* at the granted frequency. No retuning, no second radio —
+provided the voice channels land inside the window. (When your system spreads
+wider than 2.4 MHz, that's the two-dongle variation at the end.)
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Signal chain of the one-dongle P25 starter rig: a whip antenna feeds an RTL-SDR dongle producing a 2.4 megasample wideband IQ stream; inside GopherTrunk one DDC tap feeds the P25 control-channel decoder which issues grants, and two voice taps on the same stream feed the IMBE vocoder, producing WAV recordings on disk and live panels in the web console">
+  <rect x="10" y="92" width="70" height="36" rx="4" fill="none" stroke="currentColor"/>
+  <text x="45" y="114" text-anchor="middle" fill="currentColor" font-size="10">whip</text>
+  <line x1="80" y1="110" x2="112" y2="110" stroke="currentColor"/>
+  <rect x="112" y="92" width="86" height="36" rx="4" fill="none" stroke="currentColor"/>
+  <text x="155" y="110" text-anchor="middle" fill="currentColor" font-size="10">RTL-SDR</text>
+  <text x="155" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="9">2.4 MS/s IQ</text>
+  <line x1="198" y1="110" x2="240" y2="110" stroke="currentColor"/>
+  <rect x="240" y="20" width="200" height="200" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="340" y="36" text-anchor="middle" fill="var(--fg-muted)" font-size="10">GopherTrunk (role: wideband)</text>
+  <rect x="256" y="52" width="168" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="66" text-anchor="middle" fill="var(--accent)" font-size="10">CC tap → P25 decoder</text>
+  <text x="340" y="79" text-anchor="middle" fill="var(--fg-muted)" font-size="9">TSBK grants</text>
+  <rect x="256" y="104" width="168" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="340" y="118" text-anchor="middle" fill="currentColor" font-size="10">voice tap 1 → IMBE</text>
+  <rect x="256" y="148" width="168" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="340" y="162" text-anchor="middle" fill="currentColor" font-size="10">voice tap 2 → IMBE</text>
+  <line x1="340" y1="86" x2="340" y2="104" stroke="var(--accent)"/>
+  <polygon points="336,98 340,106 344,98" fill="var(--accent)"/>
+  <line x1="440" y1="121" x2="490" y2="94" stroke="currentColor"/>
+  <line x1="440" y1="165" x2="490" y2="150" stroke="currentColor"/>
+  <rect x="490" y="76" width="176" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="578" y="90" text-anchor="middle" fill="currentColor" font-size="10">recordings/&lt;system&gt;/&lt;tg&gt;/*.wav</text>
+  <rect x="490" y="132" width="176" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="578" y="146" text-anchor="middle" fill="var(--accent)" font-size="10">web console :8080</text>
+  <text x="578" y="159" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Active · History · CC panel</text>
+  <text x="340" y="234" text-anchor="middle" fill="var(--fg-muted)" font-size="10">one IQ capture, decoded twice — control continuously, voice per grant</text>
+</svg>
+<figcaption>The whole $40 rig: one wideband capture carries the control channel and up to two concurrent voice calls, so a single dongle does what used to take two.</figcaption>
+</figure>
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| RTL-SDR Blog V3 or V4 | ~$35 | TCXO matters — `ppm: 0` actually holds. [V3 vs V4]({{ '/rtl-sdr-blog-v3-vs-v4/' | relative_url }}) |
+| Antenna | $0 | the kit's telescopic [whip]({{ '/reference/whip-antenna/' | relative_url }}) — extend ~one-quarter wavelength for your band |
+| Computer | $0 | any laptop/desktop from the last decade; a Pi works too (Part 11) |
+
+That's it — about $40 shipped. A no-name dongle without a
+[TCXO]({{ '/reference/tcxo/' | relative_url }}) still works; you'll just meet
+the `ppm` troubleshooting row sooner. The
+[full hardware checklist]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})
+covers adapters and upgrade paths; resist all of them until the rig works.
+
+## Finding your system
+
+You need two facts: your local system's **protocol** (this recipe wants P25
+Phase 1) and its **control channel frequencies**. RadioReference's database
+has both for nearly every public-safety system in North America — copy every
+frequency marked as a control channel (they rotate; list them all).
+
+No listing, or abroad? GopherTrunk maps unknown systems itself:
+
+```sh
+gophertrunk hunt -serial 00000001 -band 851:869
+```
+
+sweeps the band, identifies control channels, decodes their identity, and
+exports a ready-to-merge config (`-commit` writes it into `config.yaml` for
+you). The whole discovery pipeline has its own series —
+[The Hunt]({{ '/blog/deep-dives/the-hunt-06-control-channel-hunting/' | relative_url }})
+— and [Part 7]({{ '/blog/deep-dives/the-hunt-07-locking-a-p25-system/' | relative_url }})
+walks a P25 lock specifically. New to trunking as a concept? The
+[scanning module]({{ '/learn/scanning/' | relative_url }}) is the ten-minute
+primer on why one control channel governs a whole system.
+
+## The config
+
+Plug in the dongle and confirm GopherTrunk sees it:
+
+```sh
+gophertrunk sdr list
+```
+
+Note the serial. Then this is the entire `config.yaml` — every key verified
+against `config.example.yaml`:
+
+```yaml
+log:
+  level: info
+
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000001"          # from `gophertrunk sdr list`
+      role: wideband
+      gain: "auto"
+      center_freq_hz: 858_000_000 # middle of YOUR system's channels
+      voice_taps: 2
+      channels:
+        - frequency_hz: 857_262_500   # your control channel
+          system: "Metro-P25"
+
+trunking:
+  systems:
+    - name: "Metro-P25"
+      protocol: p25
+      control_channels:
+        - 857_262_500
+        - 858_487_500               # list the alternates too
+      talkgroup_file: "../config/talkgroups-p25.csv"   # optional
+```
+
+Three decisions worth explaining. **`center_freq_hz`** should sit near the
+middle of your system's full frequency list (control *and* voice channels), so
+as many as possible fall inside the ±1.2 MHz window — a channel must be within
+`center ± sample_rate/2` with a 5% edge guard, and voice grants outside it
+can't get a tap. **`gain: "auto"`** is deliberate: gain is in *tenths* of a dB
+in this file (`"496"` = 49.6 dB), the single most common config typo, and AGC
+sidesteps it entirely until [Part 6 of The Analog
+Edge]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+teaches you to stage it by hand. **`talkgroup_file`** is optional — a
+RadioReference-style CSV with a `Decimal` column plus optional `Alpha Tag`,
+`Description`, `Tag`, `Priority` columns. Skip it for now; calls record by
+number, and Part 13 is entirely about naming things.
+
+## First run — what healthy looks like
+
+```sh
+gophertrunk run -config config.yaml
+```
+
+Within a few seconds, three log lines tell the whole story. First the API
+comes up:
+
+```
+INF api: listening addr=127.0.0.1:8080 tls=false
+```
+
+Then — this is the moment — the control channel decoder finds P25 frame sync
+and reads the network ID:
+
+```
+INF control channel locked nac=659 freq=857262500 rot=0 delta=0.02
+```
+
+`nac` is the system's Network Access Code; check it against RadioReference to
+confirm you're on the system you think you are. From here the rig is a
+spectator to every grant. When someone keys up:
+
+```
+INF call started device=cc:wideband:... grant=... priority=5
+INF recorder: call started device=... wav=../recordings/Metro-P25/9001/... tg=9001 provoice=false vocoder=imbe
+INF recorder: call ended device=... wav=... duration=4.86s reason=released
+```
+
+Open `http://127.0.0.1:8080` and you get the same story visually: the
+**Dashboard** shows the locked system, **Active** lights up per call with live
+audio if you want it, and **History** is your searchable call log. The [web
+guide]({{ '/web.html' | relative_url }}) tours every panel; the
+[TUI]({{ '/tui.html' | relative_url }}) gives you the same cockpit in a
+terminal for the Part 11 headless build.
+
+Let it run ten minutes. A quiet system is normal; no
+`control channel locked` line is not — which brings us to:
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `cchunt: hunt failed — no control-channel lock` with a `diagnosis` field | wrong/stale CC frequencies, or no signal | Read the `diagnosis` — it distinguishes dead IQ from undecodable IQ. Re-check RadioReference, list *all* CC alternates, or run `gophertrunk hunt -candidates` on them |
+| Locks briefly, drops, hunts again | marginal signal or gain mis-staged | Move the whip to a window; see [gain staging]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }}) before buying anything |
+| `ccdecoder: control carrier offset far from configured frequency` (issue #815) | crystal ppm error, or you've locked an adjacent site's stronger carrier | Set the device `ppm`, or turn on `sdr.autotune: true` and paste the value it suggests; verify the reported site identity |
+| Locked, but `TSBK blocks are failing at a high rate while tuned at zero-IF` (issue #402) | the front end's DC spur sits on your control channel | Set `dc_avoid: true` on the device — GT tunes the LO off-channel and mixes back, like SDRTrunk/OP25 |
+| CC locked, grants logged, but `no voice device available for grant` | granted voice channel is outside the 2.4 MHz window | Re-pick `center_freq_hz`, or add a second dongle as `role: voice` (variation below) |
+| Dongle vanishes mid-run, then reappears | USB power/hub flakiness | The watchdog (`sdr.watchdog_interval_ms`) re-acquires by serial automatically; use a rear-panel port, no hub — see the [USB watchdog deep dive]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }}) |
+| Everything decodes but audio sounds thin/quiet | nothing is wrong — faithful decode is conservative | `recordings.enhance.enabled: true` for the louder OP25-style chain |
+
+One principle from the deep-dive side of the house applies on day one: when
+decode is bad, the samples are usually bad first. **The decoder can only be as
+good as the samples** — a rig that won't lock wants a better window sill before
+it wants a config change.
+
+### How this recipe shapes operator practice
+
+- **Trust log lines over vibes.** Each stage of this rig announces itself with
+  a specific string. Learn the healthy trio now; every later part's
+  troubleshooting table is written against lines like them.
+- **Change one knob at a time.** The config above has exactly three numbers
+  you chose (serial, center, control channels). When it misbehaves, that's
+  your entire search space — keep it that way as the rig grows.
+- **Keep `config.example.yaml` open.** Every key in this series exists there
+  with a comment; it's the authoritative reference between cookbook parts.
+
+## Variations
+
+- **Two dongles, classic split.** Delete the wideband block; give one device
+  `role: control` and a second `role: voice` (that's the `devices:` shape at
+  the top of `config.example.yaml`). No window limit — voice grants can land
+  anywhere the voice dongle can tune. Cost: one more ~$35 dongle.
+- **Monitor-only.** `role: control` alone, no voice device: you get the full
+  control-channel picture (grants, talkgroups, the CC panel) with zero voice.
+  Great for reconnaissance on a new system.
+- **More concurrent calls.** Raise `voice_taps` — CPU scales roughly linearly
+  per tap, and the daemon warns above 16. Two is right for a starter system.
+- **Better antenna.** The single highest-value upgrade, and Part 7 of
+  [The Analog Edge]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})
+  plus the [antenna guide]({{ '/best-scanner-antenna/' | relative_url }}) cover
+  it — but make the whip work first so you have a baseline.
+
+## Where this goes next
+
+This rig assumed the friendliest protocol in the fleet. [Part
+2]({{ '/blog/tutorials/operator-cookbook-02-dmr-tier3/' | relative_url }})
+points the same hardware at a DMR Tier III network — where the control channel
+hands out *logical channel numbers* instead of frequencies, and the config
+needs a band plan (or GopherTrunk's ability to learn one off the air) before a
+single call records.
+
+## FAQ
+
+**Can I really decode P25 with a $35 RTL-SDR?**
+Yes — P25 Phase 1 at 4800 baud is well within an RTL-SDR's dynamic range and
+stability, and GopherTrunk's whole P25 path was built and tested against
+exactly this hardware. What the cheap dongle costs you is margin on *weak*
+systems, which is what the antenna and RF parts of this series buy back.
+
+**Do I need one dongle or two for a trunked system?**
+One, if your system's control and voice channels fit inside the dongle's
+2.4 MHz window — the `role: wideband` + `voice_taps` config above decodes
+both from a single capture. Two, if the system spans more spectrum than that:
+keep the wideband CC tap and add a `role: voice` dongle for out-of-window
+grants.
+
+**How do I find my local P25 control channel frequency?**
+RadioReference lists control channels for most North American systems — use
+every frequency flagged as a primary or alternate CC. Without a listing, run
+`gophertrunk hunt` with a `-band` sweep; it finds control channels by decoding
+them, not by guessing from the license database.
+
+**Why is GopherTrunk's gain setting in tenths of a dB?**
+It matches the raw units the tuner driver speaks, so `"496"` means 49.6 dB.
+If you're translating a gain figure from SDRTrunk, OP25 or gqrx, multiply by
+ten — or start with `gain: "auto"` like this recipe and skip the issue.
+
+**Does this rig decode encrypted P25 calls?**
+No — encrypted calls are flagged and logged with their metadata (talkgroup,
+source, algorithm ID), but GopherTrunk does not decrypt P25. The per-system
+`encrypted_calls` policy controls whether encrypted grants tie up your voice
+taps at all; on a starter rig the default is fine.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: A DMR Tier III Network, End to End]({{ '/blog/tutorials/operator-cookbook-02-dmr-tier3/' | relative_url }})

--- a/docs/_posts/2026-09-03-p25-end-to-end-01-c4fm-carrier.md
+++ b/docs/_posts/2026-09-03-p25-end-to-end-01-c4fm-carrier.md
@@ -1,0 +1,347 @@
+---
+title: "P25 End to End, Part 1: C4FM & the Shape of a P25 Carrier"
+description: What a P25 Phase 1 carrier actually is — 4800 symbols per second of four-level FSK in a 12.5 kHz channel, dibits riding on ±600 and ±1800 Hz deviations, and the FM-discriminator → matched-filter → slicer chain GopherTrunk sizes around a 48 kHz channel rate.
+category: deep-dives
+keywords: p25 c4fm modulation, c4fm four level fsk, p25 4800 symbols per second, p25 deviation 1800 hz, fm discriminator demodulation, p25 phase 1 decoder, c4fm matched filter, p25 12.5 khz channel, gophertrunk p25
+tags: [p25-end-to-end, p25, c4fm, dsp, demodulation, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 1
+---
+
+*Part 1 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice. Where
+[TETRA End to End]({{ '/blog/series/tetra-end-to-end/' | relative_url }})
+followed one European carrier, this series follows the protocol GopherTrunk
+locks most often — and its running thread is that P25 is a *family* of twins:
+Phase 1 and Phase 2, C4FM and CQPSK, single-channel and wideband, live and
+replay. Every twin pair is a place where a fix can land on one side and miss
+the other — the
+[Two Pipelines lesson]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }}),
+applied layer by layer. This opener is the physical layer: what a P25 carrier
+actually is, and why information riding in *amplitudes* — not phase
+transitions — shapes everything downstream.*
+
+> **TL;DR:** P25 Phase 1 is **C4FM: four-level FSK at 4800 symbols/s** in a
+> 12.5 kHz channel — one dibit per symbol, carried as a deviation of ±600 or
+> ±1800 Hz. An FM discriminator turns that into a four-level waveform, a
+> matched filter cleans it, and a slicer maps {−3, −1, +1, +3} to dibits
+> (`phase1.SymbolToDibit`). GopherTrunk channelizes the 4800-baud family to
+> **48 kHz — 10 samples/symbol** (`ddcTargetForProtocol`,
+> `internal/scanner/ccdecoder/ddc.go`), and the receiver
+> (`internal/radio/p25/phase1/receiver`) is a discriminator → spec matched
+> filter → CoarseAFC → Mueller-Müller → slicer chain sized entirely from that
+> rate. One early surprise: the matched filter is **not an RRC** — real P25
+> shapes with a raised-cosine plus inverse-sinc, and modelling it as RRC was
+> self-consistent in tests while leaving residual ISI on every real capture
+> (issue #275).
+
+**Key takeaways**
+
+- **The dibit lives in the amplitude, not the transition.** After the
+  discriminator a C4FM symbol is a level — an absolute question, where TETRA
+  asks a relative one. That decides what the chain needs: level calibration,
+  offset control and an AFC, rather than a rotation-tolerant differential
+  decode.
+- **C4FM is not an RRC matched-pair system.** The transmitter shapes with a
+  raised-cosine cascaded with an inverse-sinc; the correct receive filter is
+  a sinc (`demod.P25C4FMRxTaps`). The original RRC model passed every
+  synthetic test and failed real captures — the series' first
+  self-consistency trap.
+- **A carrier offset is a slicer bias, not a nuisance.** The discriminator
+  maps frequency to amplitude, so tuner error becomes a DC shift that pushes
+  inner symbols over outer thresholds — why this chain carries a `CoarseAFC`
+  stage TETRA's differential path never needed.
+- **48 kHz is a design rate, not a detail.** Ten samples per symbol sizes the
+  matched filter, the AFC time constants and the Mueller-Müller loop. Feed
+  the receiver raw 2.048 MHz IQ and the frame sync word never correlates —
+  the failure mode issue #275 started from.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| FM discriminator | IQ → per-sample frequency (rad/sample) | `internal/dsp/demod/fm.go` (`demod.FM`) |
+| Matched filter | spec C4FM receive filter (sinc, not RRC) | `internal/dsp/demod/c4fm_p25.go` (`P25C4FMRxTaps`, `NewC4FMP25`) |
+| Carrier-offset removal | tracks/subtracts the discriminator DC bias | `internal/dsp/demod/afc.go` (`demod.CoarseAFC`) |
+| Symbol timing | Mueller-Müller clock recovery on the real waveform | `internal/dsp/sync` (`sync.MuellerMuller`) |
+| 4-level slicer + dibit map | {−3,−1,+1,+3} → dibits per TIA-102.BAAA | `demod.C4FM.Slice`; `phase1.SymbolToDibit` (`sync.go`) |
+| Channel rate | 48 kHz for the 4800-baud C4FM family | `internal/scanner/ccdecoder/ddc.go` (`ddcTargetForProtocol`) |
+| The composed chain | IQ → dibits, both demod paths | `internal/radio/p25/phase1/receiver/receiver.go` (`Receiver.Process`) |
+
+## In this post
+
+- **The amplitude question** — C4FM vs π/4-DQPSK, the TETRA table with the roles reversed.
+- **The deviation ladder** — ±600/±1800 Hz, and how four frequencies become dibits.
+- **The filter that isn't an RRC** — the transmit/receive pair real P25 actually uses.
+- **48 kHz and ten samples per symbol** — why the channel rate is a named constant.
+- **The receiver in one pass** — the chain from IQ to dibits, and the hooks later parts use.
+
+## The amplitude question
+
+[TETRA End to End Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})
+opened with a table contrasting the two great demodulation families from
+TETRA's side. Here it is with the roles reversed — this time the C4FM column
+is the protagonist:
+
+| Axis | P25 Phase 1 (C4FM) | TETRA TMO |
+|---|---|---|
+| Modulation | 4-level FSK (frequency → amplitude) | π/4-DQPSK (differential phase) |
+| Symbol rate | 4800 sym/s | 18000 sym/s |
+| Channel width | 12.5 kHz | 25 kHz |
+| Channel bit rate | 9.6 kbps | 36 kbps before slot muxing |
+| The demod question | "what amplitude is this symbol?" | "how far did the phase move?" |
+| Sensitive to | carrier offset (slicer bias), level error | phase wander between symbols |
+| GT channel rate | 48 kHz (10 sps) | 144 kHz (8 sps) |
+| Vocoder | IMBE (MBE family) | ACELP (EN 300 395-2) |
+
+A TETRA demodulator asks a *relative* question, so a constant phase rotation
+cancels in `s·conj(last)`. A C4FM slicer asks an *absolute* one: after the FM
+discriminator each symbol is a level, and the receiver must know where the
+four levels sit. That difference explains most of what this chain carries
+that TETRA's doesn't — a symbol AGC to calibrate levels, a `CoarseAFC` to
+remove the DC bias a tuner error injects, and slicer thresholds that are
+physical quantities derived from the deviation. The
+[demodulation primer]({{ '/blog/deep-dives/sdr-internals-06-demodulation/' | relative_url }})
+covers both families in the abstract, and the
+[DSP learning track]({{ '/learn/dsp/' | relative_url }}) builds the theory up
+from IQ; here we care about what the absolute question costs on air.
+
+## The deviation ladder
+
+C4FM — *Compatible 4-level FM* — encodes each dibit as one of four deviations
+from the carrier: outer symbols at ±1800 Hz, inner symbols at ±600 Hz. The
+mapping is fixed by TIA-102.BAAA and lives in one place in the tree:
+
+```go
+// internal/radio/p25/phase1/sync.go (shape)
+// C4FM symbol-to-dibit mapping per TIA-102.BAAA: +3→01, +1→00, -1→10, -3→11.
+func SymbolToDibit(sym int8) uint8 {
+    switch sym {
+    case 1:
+        return 0 // +600 Hz
+    case 3:
+        return 1 // +1800 Hz
+    case -1:
+        return 2 // −600 Hz
+    case -3:
+        return 3 // −1800 Hz
+    }
+    return 0
+}
+```
+
+Note the ordering: the dibit values do **not** climb the ladder with the
+deviation. `+1` maps to dibit 00 and `+3` to dibit 01 — the high bit is the
+sign, the low bit selects inner/outer, so the most likely slicer error
+(inner ↔ outer on the same side) corrupts only one bit.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="The C4FM deviation ladder: four frequency levels at plus and minus 1800 and 600 hertz around the carrier, each labelled with its symbol and dibit, dashed slicer thresholds between them, and a note that a carrier offset shifts the whole ladder against the fixed thresholds">
+  <line x1="60" y1="120" x2="430" y2="120" stroke="var(--fg-muted)" stroke-dasharray="2 4"/>
+  <text x="434" y="124" fill="var(--fg-muted)" font-size="10">carrier (0 Hz)</text>
+  <!-- levels -->
+  <line x1="80" y1="40" x2="400" y2="40" stroke="var(--accent)" stroke-width="2"/>
+  <text x="60" y="44" text-anchor="end" fill="var(--accent)" font-size="10">+1800 Hz</text>
+  <text x="408" y="44" fill="currentColor" font-size="10">+3 → dibit 01</text>
+  <line x1="80" y1="93" x2="400" y2="93" stroke="currentColor" stroke-width="2"/>
+  <text x="60" y="97" text-anchor="end" fill="currentColor" font-size="10">+600 Hz</text>
+  <text x="408" y="97" fill="currentColor" font-size="10">+1 → dibit 00</text>
+  <line x1="80" y1="147" x2="400" y2="147" stroke="currentColor" stroke-width="2"/>
+  <text x="60" y="151" text-anchor="end" fill="currentColor" font-size="10">−600 Hz</text>
+  <text x="408" y="151" fill="currentColor" font-size="10">−1 → dibit 10</text>
+  <line x1="80" y1="200" x2="400" y2="200" stroke="var(--accent)" stroke-width="2"/>
+  <text x="60" y="204" text-anchor="end" fill="var(--accent)" font-size="10">−1800 Hz</text>
+  <text x="408" y="204" fill="currentColor" font-size="10">−3 → dibit 11</text>
+  <!-- thresholds -->
+  <line x1="80" y1="66" x2="400" y2="66" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <line x1="80" y1="174" x2="400" y2="174" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="240" y="62" text-anchor="middle" fill="var(--fg-muted)" font-size="9">slicer threshold ±1200 Hz</text>
+  <text x="240" y="186" text-anchor="middle" fill="var(--fg-muted)" font-size="9">slicer threshold</text>
+  <!-- offset annotation -->
+  <text x="530" y="60" fill="currentColor" font-size="11" font-weight="bold">absolute levels,</text>
+  <text x="530" y="76" fill="currentColor" font-size="11" font-weight="bold">fixed thresholds</text>
+  <text x="530" y="100" fill="var(--fg-muted)" font-size="10">a tuner offset shifts the</text>
+  <text x="530" y="114" fill="var(--fg-muted)" font-size="10">whole ladder against the</text>
+  <text x="530" y="128" fill="var(--fg-muted)" font-size="10">thresholds — inner symbols</text>
+  <text x="530" y="142" fill="var(--fg-muted)" font-size="10">mis-slice as outer</text>
+  <text x="530" y="166" fill="var(--fg-muted)" font-size="10">high bit = sign,</text>
+  <text x="530" y="180" fill="var(--fg-muted)" font-size="10">low bit = inner/outer —</text>
+  <text x="530" y="194" fill="var(--fg-muted)" font-size="10">a one-step slice error</text>
+  <text x="530" y="208" fill="var(--fg-muted)" font-size="10">costs one bit, not two</text>
+</svg>
+<figcaption>The C4FM ladder: four absolute frequency levels sliced against fixed thresholds — why a few hundred hertz of carrier offset is a decode problem, not a cosmetic one.</figcaption>
+</figure>
+
+The figure also shows the trap. The discriminator maps frequency linearly to
+amplitude, so a static tuner error of Δf shifts every level by the same
+amount — and against ±600 Hz inner deviations, offsets ≥ ~1 kHz start pushing
+inner symbols across outer thresholds (issue #402's territory). That is the
+structural reason this chain carries a `CoarseAFC` tracking and subtracting
+the discriminator's DC bias, and why later parts keep returning to carrier
+offset as a first-class failure mode.
+
+## The filter that isn't an RRC
+
+Between the discriminator and the slicer sits the matched filter, and here
+P25 holds the series' first self-consistency lesson. The obvious model — the
+one GopherTrunk originally shipped — is a root-raised-cosine pair. Textbook.
+Also wrong for P25:
+
+```go
+// internal/dsp/demod/c4fm_p25.go (shape)
+// P25 C4FM is NOT a root-raised-cosine matched-pair system. The transmit
+// baseband filter is a raised-cosine (α=0.2) cascaded with an inverse-sinc
+// compensation; the receive filter is a sinc (a one-symbol-period
+// integrate-and-dump). The transmit inverse-sinc and the receive sinc
+// cancel, so the cascade transmit×receive is a plain raised-cosine —
+// ISI-free at the symbol instants.
+func NewC4FMP25(sampleRate, deviation float64) *C4FM {
+    return NewC4FMWithTaps(P25C4FMRxTaps(sampleRate), deviation)
+}
+```
+
+The RRC model was *self-consistent*: GopherTrunk's synthetic C4FM modulator
+shaped with an RRC too, so every round-trip test passed while real captures
+carried residual inter-symbol interference the receiver could never remove
+(issue #275). The fix cross-checked the filter against OP25's
+`c4fm_const.py` and now generates the taps from the spec transfer functions —
+raised-cosine flat to 1920 Hz rolling off to 2880 Hz, times the inverse-sinc,
+on transmit; `sinc(f/4800)` on receive (`P25C4FMRxTaps`). This is the pattern
+the whole series keeps meeting: **a test whose encoder and decoder share an
+assumption validates the assumption against nothing.** The villain returns in
+Part 3 (a byte-offset bug) and Part 13 (the testing playbook), wearing
+different clothes each time.
+
+One subtlety worth planting: `P25C4FMRxTaps` is normalised to a DC gain of
+sps, so the matched-filtered symbol centres land at ±2π·1800/48000 ≈ 0.2356
+rad/sample — a *physical* level the slicer thresholds are calibrated against,
+with a symbol AGC bridging the gap when real signal levels drift.
+
+## 48 kHz and ten samples per symbol
+
+GopherTrunk channelizes every protocol to a fixed per-protocol rate, chosen
+in one function — the same one the TETRA opener showed from the other side:
+
+```go
+// internal/scanner/ccdecoder/ddc.go (shape)
+func ddcTargetForProtocol(p trunking.Protocol) float64 {
+    switch p {
+    case trunking.ProtocolTETRA, trunking.ProtocolTETRADMO:
+        return tetraDDCTargetRateHz // 144_000 — 8 sps at 18000 baud
+    case trunking.ProtocolMotorola:
+        return motorolaDDCTargetRateHz // 18_000 — 5 sps at 3600 baud
+    }
+    return ddcTargetRateHz // 48_000 — the 4800-baud C4FM family
+}
+```
+
+At 4800 sym/s, 48 kHz is exactly **10 samples per symbol**, and everything in
+the receiver is sized from it: the matched-filter span (13 symbols per the
+OP25 reference), the CoarseAFC time constant, the Mueller-Müller loop gain,
+the AGC's ~256-symbol settling. The constant's doc comment records what
+happens without it: feed the receiver a raw 2.048 MHz SDR stream and you get
+≈427 samples per symbol, a matched filter spanning a ±1 MHz swath, and a frame
+sync word that never correlates (issue #275). The exported `DDCTargetRateHz`
+exists so the replay subcommand builds an *identical* down-converter — a
+replay path that channelizes differently from the live path is a twin pair
+waiting to drift, and Part 11 covers the time exactly that happened between
+the single-channel `Downconverter` and the wideband `DDCBank`.
+
+## The receiver in one pass
+
+`internal/radio/p25/phase1/receiver` composes the chain. On the default
+`DemodC4FM` path, `Receiver.Process` runs: an optional pre-discriminator DC
+blocker (voice chains only — never the control-channel DDC path) → FM
+discriminator → spec C4FM matched filter → `CoarseAFC` → Mueller-Müller
+symbol clock
+([timing recovery in general form]({{ '/blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/' | relative_url }}))
+→ symbol AGC → 4-level slicer → `SymbolToDibit`. The output dibit stream, in
+the TIA-102.BAAA convention, feeds a `DibitSink` (the control-channel state
+machine, Part 2) and/or an LDU assembler (the voice path, Part 8).
+
+Three hooks for later parts:
+
+- **There is a second demod path.** `Options.DemodMode` selects `DemodCQPSK`:
+  a complex RRC → Gardner → blind-equalizer → differential-decode chain for
+  P25 sites transmitting a linear/LSM waveform, on which the FM discriminator
+  produces near-random dibits. Same dibits out, entirely different physics —
+  the first twin pair this series tracks, and Part 6's whole subject.
+- **The soft information already flows.** `SoftSink` surfaces per-symbol soft
+  samples, `EyeSink` the oversampled eye, and `BitLLRSink` two
+  log-likelihood ratios per dibit — sign-axis distance for the high bit,
+  inner/outer-threshold distance for the low — feeding the soft-decision TSBK
+  path. All nil by default, all free when unused.
+- **The dibit stream is demod-agnostic by contract.** FSW detection, NID
+  parsing and the TSBK trellis (Parts 2–3) never know which physics produced
+  their dibits — one control-channel state machine serves both paths, a seam
+  [Protocol Decoders Part 2]({{ '/blog/deep-dives/protocol-decoders-02-p25-phase-1-physical-layer/' | relative_url }})
+  surveyed in brief.
+
+### How the amplitude question shaped the Go code
+
+- **Levels are calibrated, not assumed.** `Options.DeviationHz` derives the
+  slicer scale, the matched filter's DC gain restores it, and the symbol AGC
+  holds mean|x| at the slicer's expected value — a calibration chain a
+  differential decoder doesn't need.
+- **Carrier offset gets a dedicated stage.** `CoarseAFC` exists because
+  frequency error *is* slicer bias here; its decision-directed refinement
+  (issue #402) ships opt-in behind `EnableDecisionDirectedAFC` because it can
+  stably false-lock.
+- **One mapping, one owner.** `SymbolToDibit` is the single source of truth
+  for the ladder, exactly as `TetraBitsToDibits` is for TETRA's Gray map —
+  deliberately separate functions, because mixing the conventions produces
+  garbage that looks like a demod bug.
+
+## Where this goes next
+
+A dibit stream at 4800/s is a firehose with no punctuation.
+[Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})
+adds the structure: the 48-bit frame sync word, the BCH-protected NID naming
+each frame's NAC and type, the status symbols interleaved every 36th dibit —
+and what GopherTrunk requires before it logs `control channel locked`.
+
+## FAQ
+
+**Is C4FM the same thing as 4FSK?**
+It's a constrained form of it: four-level FSK with a specific pulse shaping
+(raised-cosine + inverse-sinc at the transmitter) chosen so the signal fits a
+12.5 kHz channel *and* demodulates on a simple FM discriminator. The
+"compatible" in the name is the point — the same family of waveforms also
+receives as a phase modulation, the door Phase 1's CQPSK/LSM twin path
+(Part 6) walks through.
+
+**Why does GopherTrunk demodulate with an FM discriminator instead of
+coherently?**
+It's simple, robust and sufficient on a clean channel: frequency maps
+straight to amplitude and a slicer finishes the job, with no carrier-phase
+loop to lose lock. The honest cost is Part 12's subject — the discriminator
+path has no equalizer and hard-decision FEC, and on weak or simulcast-smeared
+signals that is the gap between GopherTrunk and better hardware.
+
+**What does a P25 carrier look like on a spectrum display?**
+A roughly 8–10 kHz-wide hump inside 12.5 kHz spacing — no sub-carriers, no
+TDMA slot rhythm on Phase 1 (the control channel transmits continuously;
+voice channels key up per call). The four deviation levels are invisible in
+the spectrum; they only appear in the demodulated eye diagram, which is why
+the receiver exposes an `EyeSink` fold for the diagnostics panels.
+
+**Why 48 kHz and not something lower?**
+Ten samples per symbol is a comfortable operating point for the
+Mueller-Müller loop, and every loop constant in the receiver was tuned at
+10 sps. The rate is also shared by the whole 4800-baud family (DMR, NXDN,
+dPMR), so one DDC design serves five protocols.
+
+**Does the receiver care about the ±600/±1800 numbers, or just their ratio?**
+Both. The 3:1 ratio fixes the slicer geometry (thresholds at ±2/3 of the
+outer level); the absolute values calibrate the slicer scale in physical
+units via `DeviationHz` — and the small inner deviation is what makes a
+~1 kHz carrier offset dangerous here while TETRA, whose information rides in
+phase differences, shrugs off far more.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: Frame Sync, the NID & What 'Locked' Means]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})

--- a/docs/_posts/2026-09-04-from-spec-to-shipping-02-choosing-references.md
+++ b/docs/_posts/2026-09-04-from-spec-to-shipping-02-choosing-references.md
@@ -1,0 +1,331 @@
+---
+title: "From Spec to Shipping, Part 2: Choosing Reference Implementations You Can Trust"
+description: The reference stable a protocol decoder is built against — OP25, trunk-recorder, SDRTrunk, osmo-tetra, the ETSI reference codec, mbelib — what each is authoritative for, why proven-on-air beats popular, and how to know what a reference does not decide.
+category: deep-dives
+keywords: op25 reference implementation, trunk-recorder smartnet parser, sdrtrunk field layouts, osmo-tetra scrambler, etsi reference codec, mbelib vocoder ground truth, validating a protocol decoder, independent decoder cross-check, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, op25, sdrtrunk, osmo-tetra, references, methodology]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 2
+---
+
+*Part 2 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})
+read the spec and ended on its gaps: no test vectors, unnamed enum values,
+ambiguous bit order. Every gap gets filled the same way — with an
+independent fact from outside your own head. This part is about where those
+facts come from: the open implementations, reference codecs and dissectors
+GopherTrunk validates against, what each one is authoritative for, and the
+rules that separate a reference you can trust from one that quietly hands
+you its own bugs.*
+
+> **TL;DR:** GopherTrunk's reference stable, each trusted for a specific
+> layer: **OP25** for P25 PDU/CRC spans (`process_PDU`) and the real
+> SmartNet framing (`rx_smartnet.cc`), **trunk-recorder** for SmartNet band
+> plans (`SmartnetParser`), **SDRTrunk** for per-field bit offsets (the
+> AMBTC classes behind `internal/radio/p25/phase1/mbt.go`), **osmo-tetra /
+> osmo-tetra-dmo** for scrambler seeds (`tetra_scramb_get_init`) and SYNC
+> PDU offsets, the **ETSI EN 300 395-2 reference C codec** for bit-exact
+> ACELP, **mbelib/DSD-FME** for vocoder ground truth, and
+> **Wireshark/tetra-kit/sq5bpf** for CMCE PDU layouts. The rules: prefer
+> implementations *proven on air*; two independent references that agree
+> byte-for-byte beat one popular one; and know what a reference does NOT
+> decide — three decoders confirmed TETRA's comms-type bits and none names
+> the enum values.
+
+**Key takeaways**
+
+- **A reference earns trust by decoding real air, not by stars on GitHub.**
+  OP25 and trunk-recorder run daily against live networks; that operational
+  history is the evidence a spec reading can never provide.
+- **References are scoped, not global.** Each one is authoritative for the
+  layer it demonstrably gets right on air — SDRTrunk for field offsets,
+  osmo-tetra for scrambler seeds — and merely suggestive everywhere else.
+- **Two independent agreements beat one authority.** GopherTrunk's MBT
+  decoder pins layouts against OP25 *and* SDRTrunk; where implementations
+  share ancestry, their agreement counts once.
+- **Know what the reference does not decide.** A field three decoders parse
+  but none interprets is still an open question — writing down the boundary
+  of a reference's authority is as valuable as using it.
+
+## Cheat sheet
+
+| Reference | Authoritative for | Where GopherTrunk cites it |
+|---|---|---|
+| OP25 | P25 MBT/PDU CRC spans; SmartNet framing | `phase1/mbt.go` (`process_PDU`), `internal/radio/motorola/frame.go` (`rx_smartnet.cc`) |
+| trunk-recorder | SmartNet band plans, OSW semantics | `motorola/bandplan.go` (`SmartnetParser::get_freq`) |
+| SDRTrunk | P25 per-field bit offsets, Phase 2 dibit map | `phase1/mbt.go` (AMBTC classes), `demod/piover4_dqpsk_modulator.go` (`Dibit.java`) |
+| osmo-tetra / osmo-tetra-dmo | scrambler seeds, SYNC PDU offsets, MAC PDUs | `tetra/dmo_decode.go` (`tetra_scramb_get_init`), `tetra/mac.go` |
+| ETSI EN 300 395-2 ref codec | bit-exact ACELP decode | `internal/voice/acelp/etsi_reference_test.go` |
+| mbelib / DSD-FME | IMBE/AMBE synthesis ground truth | `internal/voice/imbe/params.go`; [vocoders guide]({{ '/vocoders.html' | relative_url }}) |
+| Wireshark / tetra-kit / sq5bpf | TETRA CMCE (D-SETUP) layouts | `tetra/cmce_parse.go`, `tetra/llc.go`, `tetra/freq.go` |
+
+## In this post
+
+- **What makes a reference trustworthy** — proven on air, independent
+  lineage, inspectable output.
+- **The stable, layer by layer** — who decides what, from framing to
+  vocoder.
+- **Two agreeing references beat one popular one** — the MBT and SmartNet
+  cross-checks.
+- **Knowing what a reference does not decide** — the comms-type lesson.
+- **When your only reference is wrong** — inherited bugs, and the capture
+  as the court of appeal.
+
+## What makes a reference trustworthy
+
+The question to ask of any candidate reference is not "is it maintained?"
+or "is it popular?" but **"has this exact code decoded real transmissions,
+recently, for people who would notice if it stopped?"** That is the property
+a spec reading cannot have and a synthetic test cannot manufacture — the
+running villain of this series is the test that passes because both sides
+share an assumption, and an on-air implementation is the one artifact that
+provably doesn't share *your* assumptions.
+
+GopherTrunk learned this by counterexample. The original SmartNet decoder
+was written from prose descriptions and shipped with green tests; it matched
+no real reference and never locked on air
+([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)). The
+rebuild inverted the method: every constant and transform in
+`internal/radio/motorola/frame.go` is ported from OP25's `rx_smartnet.cc`
+and cross-checked against trunk-recorder's `SmartnetParser` — two codebases
+that decode live SmartNet systems daily. The package doc comment says so
+explicitly, and says *why*: these are "implementations proven against live
+SmartNet/SmartZone systems — NOT prose specs."
+
+Three secondary properties matter when candidates tie:
+
+- **Independent lineage.** Two decoders that both descend from the same
+  ancestor agree for free; their agreement is one vote, not two.
+- **Inspectable intermediate output.** A reference that can print its
+  deinterleaved bits or CRC inputs is worth far more than one that only
+  emits final talkgroups — you can pin *layers*, not just outcomes
+  ([Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+  whole method depends on this).
+- **A community that files bugs.** OP25's and SDRTrunk's issue trackers are
+  themselves references: a field layout that survived years of operator
+  scrutiny has been tested by thousands of antennas.
+
+## The stable, layer by layer
+
+Here is the actual matrix — which reference decides which layer, and the
+GopherTrunk code that leans on it:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="A matrix of reference implementations against protocol layers. Rows are framing and sync, channel coding and CRC, PDU field layouts, and vocoder. Columns are OP25, trunk-recorder, SDRTrunk, osmo-tetra, the ETSI reference codec, and mbelib. Filled accent dots mark where each reference is authoritative and proven on air; muted rings mark useful but secondary coverage.">
+  <text x="14" y="42" fill="currentColor" font-size="10">framing / sync</text>
+  <text x="14" y="82" fill="currentColor" font-size="10">coding / CRC</text>
+  <text x="14" y="122" fill="currentColor" font-size="10">PDU layouts</text>
+  <text x="14" y="162" fill="currentColor" font-size="10">vocoder</text>
+  <text x="160" y="16" text-anchor="middle" fill="currentColor" font-size="10">OP25</text>
+  <text x="250" y="16" text-anchor="middle" fill="currentColor" font-size="10">trunk-rec.</text>
+  <text x="340" y="16" text-anchor="middle" fill="currentColor" font-size="10">SDRTrunk</text>
+  <text x="430" y="16" text-anchor="middle" fill="currentColor" font-size="10">osmo-tetra</text>
+  <text x="520" y="16" text-anchor="middle" fill="currentColor" font-size="10">ETSI codec</text>
+  <text x="610" y="16" text-anchor="middle" fill="currentColor" font-size="10">mbelib</text>
+  <circle cx="160" cy="38" r="7" fill="var(--accent)"/>
+  <circle cx="250" cy="38" r="7" fill="none" stroke="var(--fg-muted)"/>
+  <circle cx="430" cy="38" r="7" fill="var(--accent)"/>
+  <circle cx="160" cy="78" r="7" fill="var(--accent)"/>
+  <circle cx="430" cy="78" r="7" fill="var(--accent)"/>
+  <circle cx="520" cy="78" r="7" fill="none" stroke="var(--fg-muted)"/>
+  <circle cx="250" cy="118" r="7" fill="var(--accent)"/>
+  <circle cx="340" cy="118" r="7" fill="var(--accent)"/>
+  <circle cx="430" cy="118" r="7" fill="none" stroke="var(--fg-muted)"/>
+  <circle cx="160" cy="118" r="7" fill="none" stroke="var(--fg-muted)"/>
+  <circle cx="520" cy="158" r="7" fill="var(--accent)"/>
+  <circle cx="610" cy="158" r="7" fill="var(--accent)"/>
+  <circle cx="60" cy="200" r="7" fill="var(--accent)"/>
+  <text x="76" y="204" fill="currentColor" font-size="10">authoritative, proven on air</text>
+  <circle cx="290" cy="200" r="7" fill="none" stroke="var(--fg-muted)"/>
+  <text x="306" y="204" fill="var(--fg-muted)" font-size="10">useful cross-check, secondary</text>
+  <text x="340" y="228" text-anchor="middle" fill="var(--fg-muted)" font-size="10">no single reference covers every layer — the stable is chosen per layer, per protocol</text>
+</svg>
+<figcaption>The reference matrix: each layer of each protocol gets its own authoritative reference, and no single project covers the whole decode chain.</figcaption>
+</figure>
+
+**Framing and channel coding: OP25.** For P25's Multi-Block Trunking,
+OP25's `p25p1_fdma::process_PDU` is GopherTrunk's validation reference for
+both CRC algorithms and the header extraction — when an operator's log
+showed "MBT data CRC failed" lines whose identity fields matched decoded
+broadcasts, the CRC span was re-verified byte-for-byte against `process_PDU`
+before anyone was allowed to chase a parser bug. For SmartNet, `rx_smartnet`
+supplied the whole framing: the 8-bit `0xAC` sync, the stride-19
+deinterleave, the convolutional parity rule, the XOR masks.
+
+**Field layouts: SDRTrunk.** OP25 proves spans; SDRTrunk's message classes
+document *per-field bit offsets* with unusual clarity. GopherTrunk's MBT
+header comment names both:
+
+```go
+// internal/radio/p25/phase1/mbt.go (shape) — package comment
+// Layouts are cross-checked against two independent decoders — OP25's
+// p25p1_fdma::process_PDU (header/format/SAP/opcode extraction, both
+// CRC algorithms) and SDRTrunk's PDUHeader / AMBTCHeader / AMBTC*
+// message classes (per-field bit offsets) — so this is not a working
+// model.
+```
+
+"Not a working model" is the point: a layout confirmed by two independent
+implementations stops being a hypothesis.
+
+**Scramblers and sync PDUs: osmo-tetra.** LFSR seed packing is exactly the
+kind of fact a spec underdetermines
+([Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})'s
+endianness trap), and osmo-tetra's `tetra_scramb_get_init` is the
+executable answer. When the DMO colour-code saga reached the MNI question,
+GopherTrunk's `ParseSyncPDU` offsets and extended-colour seed were verified
+byte-for-byte against osmo-tetra-dmo — and cross-checked against a *second*
+independent DMO receiver — before the fix landed
+([TETRA End to End Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})).
+
+**Vocoders: the reference codec and mbelib.** EN 300 395-2 ships reference
+C code, which upgrades validation from "plausible audio" to **bit-identical
+PCM** — [Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})
+is entirely about that harness. On the MBE side there is no reference
+source, so mbelib (via DSD-FME) serves as behavioral ground truth: when an
+operator reported DMR audio "sounds awful," the diagnosis came from decoding
+the *same* `.amb` frames through both stacks and comparing octave-band
+energies — mbelib's output localized the deficit to one quantization table
+family in GopherTrunk's 3600×2450 path, turning an opinion about audio into
+a measured, file-pinned defect.
+
+**Dissectors: Wireshark and friends.** For TETRA's CMCE PDUs, GopherTrunk
+pinned the D-SETUP basic-service decomposition against Wireshark's generated
+dissector and confirmed the LLC handling against sq5bpf's telive lineage and
+tetra-kit (`internal/radio/tetra/llc.go` cites both). A dissector is a weak
+reference for *behavior* — it never has to act on what it parses — but a
+strong one for *layout*, because it is generated from the ASN.1.
+
+## Two agreeing references beat one popular one
+
+The strongest form of evidence this method produces is **independent
+byte-for-byte agreement**. One reference can be wrong; two references with
+separate lineages that agree on every field of a layout are wrong together
+only if they share an ancestor — which is why lineage is worth a check
+before counting the votes. OP25's `rx_smartnet` itself descends from
+gr-smartnet (its header credits the line), so agreement inside that family
+counts as one vote; GopherTrunk leans on trunk-recorder where it
+contributes independently — the band-plan arithmetic
+(`SmartnetParser::get_freq`), which its users exercise against live
+800 MHz systems every day.
+
+The TETRA DMO seed work shows the full pattern: the extended-colour formula
+was confirmed against osmo-tetra-dmo *and* an independent DMO receiver
+project, and GopherTrunk's regression for the MNI fix scrambles its test
+vector with the osmo formula — the *independent* derivation — so the test
+cannot inherit GopherTrunk's own packing assumptions. A reference is most
+valuable when it is wired into your tests as the adversary, not quoted in a
+comment.
+
+## Knowing what a reference does not decide
+
+The subtlest skill is reading a reference's *silence*. TETRA's D-SETUP
+carries a 2-bit communication-type field. Three independent decoders —
+sq5bpf's, tetra-kit, Wireshark — all parse it; GopherTrunk used them to
+confirm the bit positions. But **none of the three names the enum values**,
+and none classifies calls from it — they defer to downstream tooling keyed
+on other evidence. So the layout is reference-confirmed while the meaning
+is only spec-derived, and `cmce_parse.go` marks the boundary in code: the
+`CommsPointToPoint` constants exist, the raw value is logged on every
+D-SETUP for empirical confirmation, and classification refuses to use it
+until an operator's known individual-vs-group capture pins the mapping.
+
+That is the general rule: a reference's authority extends exactly as far as
+behavior it demonstrably exercises on air. A field a reference parses but
+never acts on is *layout-confirmed, semantics-open* — and conflating those
+two levels is how spec-derived guesses sneak into shipping behavior wearing
+a reference's credibility.
+
+## When your only reference is wrong
+
+Sometimes the stable fails you. osmo-tetra-dmo — the best available DMO
+reference — carries TMO-copied burst-geometry offsets (−115/+19 relative to
+the training sequence) that measurably underperform on real DMO air;
+GopherTrunk's −108/+11 (`dmDNB*Start` in `internal/radio/tetra/dmo.go`) won
+not by argument from authority but by a sharp CRC-yield optimum on an
+operator's capture. A reference's bug becomes your bug the moment it is
+your *only* input — which is why every reference-derived layout still faces
+the capture eventually
+([Part 6]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})
+tells that arbitration story in full, and
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+makes the gate explicit).
+
+The failure mode to fear most is inheriting a reference's *assumption*
+rather than its code: port a decoder's parsing and its test fixtures
+together and you have recreated the self-consistent trap at one remove.
+The antidote is the next part's subject — literal vectors harvested from a
+reference's *output*, pinned in your tests as bytes.
+
+### How that principle shaped the Go code
+
+- **The citation names the function, not just the project.**
+  `motorola/bandplan.go` cites `SmartnetParser::get_freq`;
+  `dmo_decode.go` cites `tetra_scramb_get_init` — auditable to the line.
+- **Two-reference layouts are labelled as such.** `mbt.go`'s "cross-checked
+  against two independent decoders … not a working model" tells the next
+  reader how much to trust the file, and what evidence re-opening it
+  requires.
+- **Reference-derived vs spec-derived is an explicit split.** Compare the
+  MBT comment with `cmce_parse.go`'s "SPEC-DERIVED, not capture-confirmed"
+  on `CommsType` — the tree distinguishes its evidence classes.
+- **References live in tests, not only comments.** The MNI regression
+  scrambles with the osmo formula; the SmartNet tests pin OP25's literals —
+  the reference actively disagrees with drift instead of decorating it.
+
+## Where this goes next
+
+A trusted reference gives you facts; the discipline is keeping them from
+degrading into assumptions once they're inside your codebase.
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+is about the mechanics: pinning parsers with literal byte vectors
+cross-checked against an independent decoder — and the SCCB bug that showed
+exactly how a round-trip test lets an off-by-one live for months.
+
+## FAQ
+
+**How do I find a reference implementation for an obscure protocol?**
+Start from the ecosystem that *uses* the protocol: scanner communities
+(OP25, SDRTrunk, DSD-FME for North American trunking; osmo-tetra, tetra-kit,
+telive for TETRA), Wireshark dissectors, and academic or SDR-framework
+projects. Then verify the on-air property — look for user reports of live
+decodes, not just a README claiming support.
+
+**What if the only available reference is GPL and my project isn't?**
+Use it as a *validation oracle* — run it, compare outputs, pin its literals
+in tests — rather than as source to translate. That line, and the licensing
+hygiene around it, is exactly
+[Part 5]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})'s
+subject.
+
+**Is a hardware radio a valid reference?**
+As an end-to-end oracle, yes — an operator's Astro Spectra decoding a
+marginal P25 call that GopherTrunk drops is hard evidence the samples
+contain the call. But hardware exposes no intermediate layers, so it can
+tell you *that* you're wrong, rarely *where*. Pair it with a software
+reference that prints its work.
+
+**Why not just trust the most popular implementation?**
+Popularity measures usefulness, not per-layer correctness — and popular
+projects share code more than their download counts suggest. The DNB
+geometry case is the standing warning: the best DMO reference available
+carried a measurably wrong offset pair. Scope trust per layer, demand
+on-air evidence for that layer, and let captures referee.
+
+**How many references are enough?**
+One proven-on-air reference plus the spec is a workable floor; two with
+independent lineage agreeing byte-for-byte is the standard GopherTrunk
+aims for on anything load-bearing (MBT layouts, scrambler seeds, SmartNet
+framing). Below that floor, the fact stays quarantined the way the
+comms-type mapping is — decoded, logged, but not driving behavior.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: How to Read a Radio Standard]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})
+· Next →
+[Part 3: Literal Vectors, Not Round-Trips]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})

--- a/docs/_posts/2026-09-04-from-spec-to-shipping-02-choosing-references.md
+++ b/docs/_posts/2026-09-04-from-spec-to-shipping-02-choosing-references.md
@@ -98,16 +98,16 @@ SmartNet/SmartZone systems — NOT prose specs."
 
 Three secondary properties matter when candidates tie:
 
-- **Independent lineage.** Two decoders that both descend from the same
-  ancestor agree for free; their agreement is one vote, not two.
-- **Inspectable intermediate output.** A reference that can print its
-  deinterleaved bits or CRC inputs is worth far more than one that only
-  emits final talkgroups — you can pin *layers*, not just outcomes
-  ([Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
-  whole method depends on this).
-- **A community that files bugs.** OP25's and SDRTrunk's issue trackers are
-  themselves references: a field layout that survived years of operator
-  scrutiny has been tested by thousands of antennas.
+| Property | Why it matters | What it looks like |
+|---|---|---|
+| Independent lineage | shared ancestry means agreement counts once | check headers/credits before counting votes |
+| Inspectable intermediates | you can pin *layers*, not just outcomes | prints deinterleaved bits, CRC inputs, parameters |
+| A community that files bugs | years of operator scrutiny = thousands of antennas | active trackers on OP25, SDRTrunk |
+
+The second row is the quiet one:
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+whole method — harvesting literal vectors from a reference's output —
+depends on references that show their work, not just their verdicts.
 
 ## The stable, layer by layer
 

--- a/docs/_posts/2026-09-04-operator-cookbook-02-dmr-tier3.md
+++ b/docs/_posts/2026-09-04-operator-cookbook-02-dmr-tier3.md
@@ -1,0 +1,332 @@
+---
+title: "The Operator's Cookbook, Part 2: A DMR Tier III Network, End to End"
+description: A complete GopherTrunk build for trunked DMR — one wideband dongle on a Tier III control channel, the LCN-to-frequency band plan problem (and letting GopherTrunk learn the plan off the air), plus the log lines, colour codes and timeslots that tell you it's working.
+category: tutorials
+keywords: dmr tier 3 scanner setup, dmr trunking decoder, dmr lcn frequency mapping, dmr band plan config, capacity max scanner sdr, dmr colour code, gophertrunk dmr config, dmr csbk grants, gophertrunk cookbook
+tags: [operator-cookbook, dmr, tier-3, trunking, lcn, config]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 2
+---
+
+*Part 2 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})
+built the $40 P25 starter and taught you the healthy-rig heartbeat: lock,
+grant, recording. This part points the same hardware at trunked DMR — Tier III
+— where one new problem changes the whole recipe: the control channel never
+tells you a frequency. It hands out **logical channel numbers**, and until
+those resolve to hertz, every voice grant on the system is a call you can hear
+about but not hear.*
+
+> **TL;DR:** Trunked DMR is `protocol: dmr` on a `role: wideband` dongle with
+> `voice_taps`. A Tier III voice grant references its traffic channel by a
+> 12-bit **LCN**, never a frequency, so the decoder needs a `dmr_band_plan`
+> (linear `base_hz`/`spacing_hz`/`offset`, or an explicit table) — **or you
+> omit the key and GopherTrunk learns the plan off the air** by correlating
+> granted LCNs against which carriers key up in the IQ band
+> (`dmrlcn: band plan learned (linear)`), then writes it back into your
+> `config.yaml`. Healthy looks like `dmr cc locked freq=… cc=… sysid=…`
+> followed by grants resolving to real frequencies; broken looks like grants
+> logged and zero recordings, with `decode.error` `stage=no-bandplan`.
+
+**Key takeaways**
+
+- **DMR grants are indirect.** A [Tier III]({{ '/reference/dmr-tier-3/' | relative_url }})
+  grant CSBK carries `(LCN, timeslot)`, and the LCN→frequency mapping is
+  site-specific configuration the air interface never broadcasts in full. The
+  band plan is the recipe's load-bearing ingredient.
+- **You can let the rig learn the plan.** Omit `dmr_band_plan` on a wideband
+  dongle and GopherTrunk watches grants, detects which carriers key up in
+  response, and fits base + spacing for the whole LCN enumeration — then
+  persists it.
+- **A wrong plan fails quietly; a missing one fails loudly.** No plan drops
+  grants with `stage=no-bandplan`. A plan with the wrong offset tunes taps to
+  live carriers *the wrong calls* are on — the nastier failure this post's
+  table covers.
+- **Timeslots come for free here.** Each Tier III carrier is 2-slot TDMA and
+  grants name their slot; the two-slot interleaved voice decoder is the
+  default for DMR, so concurrent calls on one carrier resolve cleanly.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| System definition | trunked DMR control channel | `trunking.systems[]` with `protocol: dmr` |
+| LCN → frequency | linear grid or explicit table | `dmr_band_plan.linear` (`base_hz`, `spacing_hz`, `offset`) or `dmr_band_plan.table` |
+| Auto-learning | fit the plan from grants vs. keyed carriers | omit `dmr_band_plan` + `role: wideband`; [LCN correlation deep dive]({{ '/blog/deep-dives/the-hunt-08-dmr-lcn-correlation/' | relative_url }}) |
+| Voice on one dongle | per-grant DDC taps in the IQ window | `sdr.devices[].voice_taps` |
+| Colour code | per-site interference discriminator, decoded off the CC | [color code]({{ '/reference/color-code/' | relative_url }}) — no config key needed for Tier III |
+| Talkgroup names | RadioReference-style CSV | `talkgroup_file` |
+| Protocol background | how the CSBK chain works | [Protocol Decoders Part 5]({{ '/blog/deep-dives/protocol-decoders-05-dmr-tier-2-3/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — the Part 1 rig, retargeted at a Tier III network.
+- **The LCN problem** — why DMR needs a band plan and P25 mostly didn't.
+- **The config** — with the band plan omitted on purpose.
+- **First run — what healthy looks like** — lock, learning, grants, calls.
+- **When it doesn't work** — the wrong-offset trap and friends.
+- **Variations** — explicit plans, tables, and multi-carrier realities.
+
+## What you're building
+
+Hardware is unchanged from [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}):
+one RTL-SDR, the whip, a computer. The target is different — a DMR Tier III
+trunked network (Hytera and Motorola sell these as Capacity Max-class systems;
+utilities, transit and commercial fleets run them everywhere). Like P25, one
+control channel governs the system: radios affiliate, request calls, and get
+granted a traffic channel. Unlike P25, the grant names that channel as a
+**logical channel number** — an index into a numbering plan the system
+operator chose — plus a **timeslot**, because every DMR carrier is two-slot
+TDMA carrying two independent channels.
+
+So the decode chain grows one box the P25 rig didn't have: an LCN resolver
+between the grant and the voice tap. Everything downstream — the AMBE+2
+vocoder, the recorder, the web console — is the machinery you already ran.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the DMR Tier III rig: antenna and RTL-SDR feed a wideband IQ stream; the control-channel tap decodes CSBK grants carrying LCN and timeslot; a highlighted band-plan box resolves LCN 7 to a frequency, either from config or learned off the air by the LCN correlator; the resolved grant drives a voice tap into the AMBE+2 vocoder and out to recordings and the web console">
+  <rect x="8" y="100" width="64" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="40" y="121" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="72" y1="117" x2="100" y2="117" stroke="currentColor"/>
+  <rect x="100" y="100" width="76" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="138" y="121" text-anchor="middle" fill="currentColor" font-size="10">RTL-SDR</text>
+  <line x1="176" y1="117" x2="204" y2="117" stroke="currentColor"/>
+  <rect x="204" y="36" width="150" height="36" rx="4" fill="none" stroke="currentColor"/>
+  <text x="279" y="51" text-anchor="middle" fill="currentColor" font-size="10">CC tap → CSBK decoder</text>
+  <text x="279" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">grant: LCN 7, TS 2, TG 101</text>
+  <rect x="204" y="100" width="150" height="46" rx="4" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="279" y="118" text-anchor="middle" fill="var(--accent)" font-size="10">band plan: LCN → Hz</text>
+  <text x="279" y="132" text-anchor="middle" fill="var(--fg-muted)" font-size="9">config, or learned (dmrlcn)</text>
+  <rect x="204" y="170" width="150" height="36" rx="4" fill="none" stroke="currentColor"/>
+  <text x="279" y="185" text-anchor="middle" fill="currentColor" font-size="10">voice tap @ 465.287500</text>
+  <text x="279" y="198" text-anchor="middle" fill="var(--fg-muted)" font-size="9">slot-filtered → AMBE+2</text>
+  <line x1="279" y1="72" x2="279" y2="100" stroke="var(--accent)"/>
+  <polygon points="275,94 279,102 283,94" fill="var(--accent)"/>
+  <line x1="279" y1="146" x2="279" y2="170" stroke="currentColor"/>
+  <polygon points="275,164 279,172 283,164" fill="currentColor"/>
+  <line x1="354" y1="188" x2="420" y2="188" stroke="currentColor"/>
+  <rect x="420" y="152" width="240" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="540" y="171" text-anchor="middle" fill="currentColor" font-size="10">recordings/Regional-DMR-T3/101/*.wav</text>
+  <rect x="420" y="192" width="240" height="30" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="540" y="211" text-anchor="middle" fill="var(--accent)" font-size="10">web console — Active / History / CC</text>
+  <line x1="420" y1="167" x2="380" y2="184" stroke="currentColor"/>
+  <text x="470" y="60" fill="var(--fg-muted)" font-size="10">the box P25 didn't need:</text>
+  <text x="470" y="74" fill="var(--fg-muted)" font-size="10">a grant is not a frequency</text>
+  <text x="470" y="88" fill="var(--fg-muted)" font-size="10">until the plan says so</text>
+  <text x="340" y="240" text-anchor="middle" fill="var(--fg-muted)" font-size="10">wrong plan ⇒ the tap tunes a real carrier carrying the wrong call — the failure that looks like success</text>
+</svg>
+<figcaption>The Tier III chain is the P25 chain plus one resolver: every grant passes through the LCN→frequency band plan, so the plan's correctness decides whether voice exists at all.</figcaption>
+</figure>
+
+## The LCN problem
+
+Why doesn't the control channel just send frequencies? Because DMR's grant
+CSBK has 12 bits for the channel field, and because the protocol was designed
+so a site's channel lineup lives in radio codeplugs, not on the air. Every
+radio on the system was programmed with the same LCN→frequency table; a
+scanner has to reconstruct it. RadioReference sometimes lists LCNs for
+documented systems — but the numbering is *per system*, `1`-indexed on some
+and `0`-indexed on others, and nothing on the air validates your guess.
+
+GopherTrunk's answer, when you don't know the plan: **watch the system prove
+it**. On a wideband dongle, the daemon sees the whole IQ band, so when the
+control channel grants LCN 7 and a carrier at 465.2875 MHz keys up 200 ms
+later — and that correlation repeats across many grants — the plan fits
+itself: base frequency, spacing, offset, with a confidence score. The
+correlator, its onset detector, and the false-match defenses are the subject
+of [The Hunt Part 8]({{ '/blog/deep-dives/the-hunt-08-dmr-lcn-correlation/' | relative_url }});
+here we just use it.
+
+## The config
+
+Every key verified against `config.example.yaml`. Note what's *absent*:
+
+```yaml
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000001"
+      role: wideband
+      gain: "auto"
+      center_freq_hz: 465_500_000   # middle of the site's carrier cluster
+      voice_taps: 2
+      channels:
+        - frequency_hz: 465_237_500 # the Tier III control channel
+          system: "Regional-DMR-T3"
+
+trunking:
+  systems:
+    - name: "Regional-DMR-T3"
+      protocol: dmr
+      control_channels:
+        - 465_237_500
+      talkgroup_file: "../config/talkgroups-dmr.csv"   # optional
+      # dmr_band_plan: deliberately omitted — learned off the air
+```
+
+If you *do* know the plan (from RadioReference or a codeplug), configure it
+and learning is disabled — your plan is authoritative:
+
+```yaml
+      dmr_band_plan:
+        linear:
+          base_hz: 465_212_500   # LCN 1's frequency…
+          spacing_hz: 12_500     # …12.5 kHz per LCN step
+          offset: 1              # 1 ⇒ LCN 1 == base_hz; 0 for 0-indexed sites
+```
+
+For sites whose carriers aren't on a regular grid, `table:` takes explicit
+`{ lcn, freq_hz }` rows instead. One thing you do **not** configure for
+Tier III: the [colour code]({{ '/reference/color-code/' | relative_url }}).
+It's decoded straight off the control channel (the `color_code` config key
+exists only to pin *conventional* DMR, next part's topic).
+
+## First run — what healthy looks like
+
+Start the daemon and watch for the DMR lock line — it carries the colour code
+and the decoded system ID:
+
+```
+INF dmr cc locked freq=465237500 cc=1 sysid=4242
+```
+
+With no band plan configured, the learner announces itself:
+
+```
+INF dmrlcn: learning DMR band plan center_hz=465500000 sample_rate_hz=2400000
+```
+
+Now wait for traffic. Every grant during the learning window is a data point;
+on a moderately busy system the fit converges in minutes:
+
+```
+INF dmrlcn: band plan learned (linear) base_hz=465212500 spacing_hz=12500 offset=1 pairs=9 confidence=0.97 residual_hz=31
+```
+
+Watch what that line buys you: it applies **live** (grants that were being
+dropped start following voice immediately), and because you started the daemon
+with `-config`, the plan is **written back into your config.yaml** so the next
+start skips the apprenticeship. From here the rhythm is Part 1's, with DMR
+fields — at `log.level: debug` you'll see the raw grants
+(`dmr/tier3: tv-grant … tg=101 src=2054 lcn=7 ts=2 freq_hz=465287500`), and at
+`info` the familiar pair:
+
+```
+INF call started device=… grant=… priority=5
+INF recorder: call started … tg=101 … vocoder=ambe2-dmr
+```
+
+In the web console, the **CC panel** streams CSBK activity, and **History**
+fills with calls whose vocoder column reads `ambe2-dmr`. If DMR audio sounds
+different from your P25 rig's — a bit bright, a bit synthetic — that's a known,
+measured property of the software AMBE+2 path, not your antenna; the
+[DMR voice quality page]({{ '/dmr-voice-quality.html' | relative_url }}) and
+[Voice Coding Part 7]({{ '/blog/deep-dives/voice-coding-07-ambe-plus-2/' | relative_url }})
+have the honest details.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No `dmr cc locked` at all | wrong frequency, or it's a conventional (Tier II) repeater, not a trunked CC | Verify against RadioReference; run `gophertrunk hunt -candidates` to identify what's actually there. Tier II is [Part 3]({{ '/blog/tutorials/operator-cookbook-03-conventional-dmr-two-slots/' | relative_url }}) |
+| CC locked, grants visible, **zero recordings**; `decode.error` events with `stage=no-bandplan` | no band plan and no wideband dongle to learn one from | Use `role: wideband` (learning needs the whole band in view), or configure `dmr_band_plan` explicitly |
+| Learner runs but never prints `band plan learned` | quiet system (too few grants), or voice carriers fall outside the 2.4 MHz window | Be patient on quiet systems; re-center `center_freq_hz` on the carrier cluster, not the CC |
+| Recordings exist but carry the **wrong conversations** for their talkgroup | right frequencies, wrong LCN order — usually `offset: 1` vs `offset: 0`, or a table sorted by frequency instead of LCN | Flip the offset, or delete the plan and let the correlator re-derive it from the air — the learned fit is empirical, not guessed |
+| Two talkgroups' audio interleaved or ping-ponging in one file | interleaved two-slot decode forced off | `dmr_interleaved_voice` defaults **on** for DMR — remove any `false` override; see Part 3 for the slot-routing story |
+| Calls decode but tear down late | nothing wrong — DMR teardown rides terminator + hangtime | Tune `trunking.voice_hangtime_ms` (default 3500) if you want tighter files |
+
+The wrong-offset row deserves emphasis because it's this series' first
+instance of a recurring villain: **a config that's self-consistently wrong
+looks exactly like success**. Every tap tunes a real, keyed carrier; audio
+decodes; files land on disk — and every file is mislabeled. The only check
+that catches it is external validation: listen to a call against its talkgroup
+name, or trust the learned fit over a transcribed one. The deep-dive series
+tells the same story about test vectors —
+[green synthetic ≠ on-air correct]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}) —
+and it starts applying to *configs* here.
+
+### How this recipe shapes operator practice
+
+- **Prefer learned plans to transcribed ones.** The correlator's plan is
+  validated by the system's own behaviour; a forum post's LCN table is not.
+- **Center on the cluster, not the CC.** The control channel only needs to be
+  *inside* the window; the voice carriers need to be too.
+- **Debug level is your CSBK microscope.** `log.level: debug` shows every
+  grant with its LCN, slot and resolved frequency — the first thing to read
+  when recordings and reality disagree.
+
+## Variations
+
+- **Explicit table plan.** Non-grid sites: `dmr_band_plan.table` with one
+  `{ lcn, freq_hz }` row per channel. Pin it from a learned run's output if
+  the linear fit's `residual_hz` is high.
+- **Second dongle for out-of-window voice.** Keep the wideband CC tap, add a
+  `role: voice` device; grants the window can't serve spill over to it
+  automatically.
+- **Scan-list mode.** With a talkgroup CSV loaded, `scanner.scan_mode: list`
+  follows only talkgroups marked `Scan` — the right posture on a huge fleet
+  system where you care about ten groups out of hundreds.
+- **Encrypted fleets.** DMR Enhanced Privacy (RC4) traffic can be decrypted
+  *only* with operator-supplied keys via the system's `encryption_keys` list —
+  GopherTrunk does no key recovery. Without keys, encrypted calls still log
+  their metadata.
+
+## Where this goes next
+
+Tier III assumed a trunked network with a control channel to camp. Most DMR
+in the wild is humbler: one conventional repeater, no trunking, two timeslots
+carrying two independent conversations at once. [Part
+3]({{ '/blog/tutorials/operator-cookbook-03-conventional-dmr-two-slots/' | relative_url }})
+builds that rig — including the newly rebuilt two-slot decode path that turns
+"one garbled call" into two clean ones, and the honest edge cases that ships
+with.
+
+## FAQ
+
+**What is an LCN in DMR and why do I need a band plan?**
+A Logical Channel Number is the index a Tier III grant uses to name a traffic
+channel — the air interface never sends the frequency itself. The band plan is
+the LCN→frequency mapping the system's radios were programmed with; without
+it, a scanner can decode every grant and still tune nothing.
+
+**Can GopherTrunk figure out the LCN order by itself?**
+Yes — omit `dmr_band_plan` on a system monitored by a `role: wideband` dongle
+and the daemon correlates granted LCNs against which carriers key up across
+the band, fits base + spacing + offset, applies the plan live, and writes it
+back to `config.yaml`. It needs real traffic and the voice carriers inside
+the dongle's IQ window.
+
+**Do I need to configure the DMR colour code?**
+Not for Tier III — the decoder reads it off the control channel and logs it in
+the `dmr cc locked` line (`cc=1`). The `color_code` config key exists to pin
+conventional Tier II/Tier I channels, where it acts like a squelch
+discriminator between co-channel systems.
+
+**Why do my DMR recordings sound harsher than P25?**
+The software AMBE+2 decoder for DMR's 3600×2450 mode currently reproduces
+less high-band energy than reference decoders — a measured, localized
+deficit, not an RF problem. `recordings.enhance.enabled: true` shapes the
+audio louder and cleaner; the underlying vocoder work is tracked openly in
+the [voice-coding series]({{ '/blog/deep-dives/voice-coding-07-ambe-plus-2/' | relative_url }}).
+
+**Does one dongle really handle a whole Tier III site?**
+If the site's carriers fit inside ~2.4 MHz — common for single-site systems —
+yes: the CC tap and `voice_taps: 2` decode control plus two concurrent calls
+from one capture. Multi-carrier sites spread wider need the spill-over voice
+dongle, and multi-*system* rigs are [Part 7's]({{ '/blog/series/operator-cookbook/' | relative_url }}) territory.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: The $40 P25 Starter Rig]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})
+· Next →
+[Part 3: One Repeater, Two Conversations — Conventional DMR]({{ '/blog/tutorials/operator-cookbook-03-conventional-dmr-two-slots/' | relative_url }})

--- a/docs/_posts/2026-09-04-p25-end-to-end-02-sync-nid-lock.md
+++ b/docs/_posts/2026-09-04-p25-end-to-end-02-sync-nid-lock.md
@@ -1,0 +1,327 @@
+---
+title: "P25 End to End, Part 2: Frame Sync, the NID & What 'Locked' Means"
+description: How GopherTrunk turns a raw P25 dibit stream into frames — the 48-bit frame sync word, the BCH(63,16)-protected NID carrying NAC and DUID, the status symbols hiding every 36th dibit, and the tiered alignment search that decides when a control channel is really locked.
+category: deep-dives
+keywords: p25 frame sync word, p25 nid nac duid, bch 63 16 error correction, p25 status symbols, p25 control channel lock, p25 duid types, tsdu ldu1 ldu2 hdu, p25 sync detection, gophertrunk p25
+tags: [p25-end-to-end, p25, framing, fec, sync, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 2
+---
+
+*Part 2 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice.
+[Part 1]({{ '/blog/deep-dives/p25-end-to-end-01-c4fm-carrier/' | relative_url }})
+built the chain that turns IQ into dibits at 4800 a second. This part gives
+that firehose punctuation: the frame sync word that marks a frame, the NID
+that names it, the status symbols interleaved through everything — and the
+deliberately conservative moment at which GopherTrunk is willing to log
+`control channel locked`. Getting that moment wrong in either direction cost
+real debugging weeks, and the machinery here carries the scars.*
+
+> **TL;DR:** Every P25 Phase 1 frame opens with a **48-bit frame sync word**
+> (hex `0x5575F5FF77FF`, 24 dibits — `phase1.FrameSyncWord`) followed by the
+> **64-bit NID**: a 12-bit NAC plus 4-bit DUID protected by **BCH(63,16,11)**
+> and a per-DUID flag bit (`ParseNID`,
+> `internal/radio/p25/phase1/nid.go`). One 2-bit **status symbol** rides after
+> every 35 data dibits (`p25StatusStride = 36`), so nothing downstream can
+> count on-air dibits naively. `searchNID` probes a bounded grid of alignment
+> hypotheses in two tiers — clean BCH decodes (≤ 6 corrections) are trusted,
+> marginal ones (7–11) are admitted only when the frame's TSBK CRC
+> corroborates the same alignment — and **only a TSDU locks the channel**: a
+> PDU is Multi-Block Trunking (Part 4), and voice DUIDs never flip the flag.
+
+**Key takeaways**
+
+- **Sync is a correlation, not an equality.** The FSW detector tolerates up
+  to 4 mismatched dibits and tries dibit-alphabet rotations — restricted to
+  {0, 2} on the C4FM path, where rotations 1 and 3 can only be BCH
+  miscorrections (issue #275).
+- **The NID's last bit is a per-DUID flag, not a parity bit.** Assuming
+  "obviously it's overall parity" masked issue #275 for a long time; the real
+  rule (1 for LDU1/LDU2, 0 for the rest) is pinned against OP25.
+- **A frame straddling chunk boundaries must still assemble.** A 16 KiB
+  RTL-SDR USB transfer carries ~19 P25 symbols; without cross-call buffering
+  every FSW hit was discarded and nothing ever locked — the original issue
+  #275 field symptom.
+- **Lock is an event with a name attached.** `KindCCLocked` fires on a
+  corrected NID with a TSDU DUID, carries frequency and NAC, and the decoder
+  honours lock edges only for its own carrier — a foreign system's lock on
+  the shared bus must not flip your flag.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Frame sync word | 24-dibit pattern, tolerance-4 correlator | `internal/radio/p25/phase1/sync.go` (`FrameSyncWord`, `SyncDetector`) |
+| Rotation search | {0,2} on C4FM, all four on CQPSK | `sync.go` (`RotationsC4FM`, `RotationsAll`) |
+| NID parse | BCH(63,16,11) + per-DUID flag → NAC + DUID | `nid.go` (`ParseNID`, `framing.BCHDecode63_16`) |
+| Status symbols | one 2-bit symbol per 35 data dibits | `control.go` (`p25StatusStride`) |
+| Alignment search | ±6-dibit grid, two acceptance tiers | `control.go` (`searchNID`, `NIDSearchSpan`, `NIDAcceptErrs`) |
+| Cross-call assembly | frame buffering across IQ chunks | `control.go` (`ControlChannel.Process`, `frameLookahead`) |
+| Lock event | TSDU-only, per-carrier filtered | `control.go` (`parseFrame`); `decoder.go` (`lockEventMatchesActive`) |
+
+## In this post
+
+- **The flag in the stream** — the FSW correlator, tolerance, rotations and margins.
+- **The NID: name tag and type tag** — NAC, the DUID zoo, and BCH(63,16,11).
+- **The stowaways** — status symbols and why dibit arithmetic is never simple.
+- **When the FSW isn't enough** — the tiered NID alignment search.
+- **What "locked" actually means** — the TSDU rule, the event, and the hunt.
+
+## The flag in the stream
+
+The frame sync word is P25's punctuation mark: 48 bits — 24 dibits —
+opening every data unit:
+
+```go
+// internal/radio/p25/phase1/sync.go (shape)
+// FrameSyncWord is the 48-bit P25 Phase 1 frame sync word, expressed as
+// 24 dibits (TIA-102.BAAA §6.1.1). Hex: 0x5575F5FF77FF, MSB-first dibits.
+var FrameSyncWord = [24]uint8{
+    1, 1, 1, 1, 1, 3, 1, 1, 3, 3, 1, 1,
+    3, 3, 3, 3, 1, 3, 1, 3, 3, 3, 3, 3,
+}
+```
+
+Notice the alphabet: only dibits 1 and 3 — the FSW rides entirely on the
+*outer* ±1800 Hz symbols, giving the correlator maximum eye separation.
+`SyncDetector` slides a 24-dibit window over the stream and fires when the
+mismatch count is within tolerance (default 4 of 24). Two refinements matter.
+First, the detector tries **cyclic rotations** of the dibit alphabet, because
+a front-end quirk (conjugated IQ, discriminator polarity) can present the
+whole stream rotated; on the C4FM path the search is restricted to
+`RotationsC4FM = {0, 2}` — identity and polarity flip — because rotations 1
+and 3 are physically impossible on a discriminator stream, and leaving them
+in let the BCH stage "correct" misaligned garbage into a parity-valid
+pseudo-NID at rot 3 (issue #275). Second, `ProcessWithMargin` reports how
+*comfortably* each hit cleared tolerance — a margin distribution pressed
+against 1 says a lock is barely holding before it drops.
+
+## The NID: name tag and type tag
+
+After the FSW comes the Network ID — 64 bits answering two questions: *whose
+system is this* and *what kind of frame follows*.
+
+| Field | Bits | Meaning |
+|---|---|---|
+| NAC | 12 | Network Access Code — the system's colour code; a receiver filters on it |
+| DUID | 4 | Data Unit ID — what the rest of the frame is |
+| BCH parity | 47 | BCH(63,16,11) over the first 63 bits — corrects up to 11 bit errors |
+| Flag bit | 1 | fixed per-DUID value (1 for LDU1/LDU2, 0 otherwise) |
+
+The DUID is the frame-type switch this entire series will keep returning to:
+
+| DUID | Name | What it is | Covered in |
+|---|---|---|---|
+| 0x0 | HDU | voice call header (MI/ALGID/KID) | Parts 8–9 |
+| 0x3 | TDU | terminator, no link control | Part 8 |
+| 0x5 | LDU1 | voice superframe half, link control | Part 8 |
+| 0x7 | TSDU | trunking signalling (TSBKs) — **the control channel** | Part 3 |
+| 0xA | LDU2 | voice superframe half, encryption sync | Parts 8–9 |
+| 0xC | PDU | packet data — **or Multi-Block Trunking** | Part 4 |
+| 0xF | TDULC | terminator with link control | Part 8 |
+
+Two details in `ParseNID` earn their comments. The BCH(63,16,11) decoder
+corrects up to 11 bit errors — generous armour that needs supervision (next
+section), because a code that can move 11 bits can also *manufacture* a
+valid-looking codeword from a misaligned window. And the 64th bit is **not**
+an overall parity bit, however obvious that feels: it is a fixed per-DUID
+flag — 1 for LDU1 and LDU2, 0 for everything else — confirmed against OP25.
+The obvious-but-wrong parity reading masked issue #275 longer than any other
+single mistake. The
+[framing & FEC deep dive]({{ '/blog/deep-dives/sdr-internals-09-framing-fec/' | relative_url }})
+covers the BCH machinery itself; here it's enough that the NID arrives with
+an error count, and that count feeds the acceptance logic below.
+
+## The stowaways
+
+P25 interleaves a 2-bit **status symbol** into the stream after every 35 data
+dibits — `p25StatusStride = 36` in `control.go`, counting from the FSW's
+first dibit. On the air these carry channel-status signalling; for a decoder
+their main effect is arithmetic sabotage: nothing that indexes "N dibits past
+the FSW" is correct until the stowaways are counted. The 32-dibit NID plus
+first 98-dibit TSBK block — 130 data dibits — occupies 134 on-air dibits
+(`frameLookahead = 130 + 4`), and a voice LDU carries 24 of them scattered
+through its 1728 bits. Every parser either strips them
+(`StripStatusSymbols`) or counts around them, and the alignment search treats
+"stripped or not" as an explicit hypothesis axis — a status-phase fault looks
+exactly like a corrupted NID until you probe both ways.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="P25 frame layout: the 24-dibit frame sync word, the 32-dibit NID holding NAC, DUID and BCH parity, then up to three 98-dibit TSBK blocks, with status-symbol ticks every 36th on-air dibit">
+  <!-- stream bar -->
+  <rect x="20" y="70" width="110" height="34" rx="4" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="75" y="86" text-anchor="middle" fill="var(--accent)" font-size="10">FSW</text>
+  <text x="75" y="99" text-anchor="middle" fill="var(--accent)" font-size="9">24 dibits</text>
+  <rect x="130" y="70" width="150" height="34" rx="4" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="205" y="86" text-anchor="middle" fill="currentColor" font-size="10">NID — 32 dibits</text>
+  <text x="205" y="99" text-anchor="middle" fill="var(--fg-muted)" font-size="9">NAC(12) · DUID(4) · BCH(47) · flag(1)</text>
+  <rect x="280" y="70" width="120" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="340" y="86" text-anchor="middle" fill="currentColor" font-size="10">TSBK block 1</text>
+  <text x="340" y="99" text-anchor="middle" fill="var(--fg-muted)" font-size="9">98 dibits</text>
+  <rect x="400" y="70" width="120" height="34" rx="4" fill="none" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="460" y="86" text-anchor="middle" fill="currentColor" font-size="10">TSBK block 2</text>
+  <text x="460" y="99" text-anchor="middle" fill="var(--fg-muted)" font-size="9">optional</text>
+  <rect x="520" y="70" width="120" height="34" rx="4" fill="none" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="580" y="86" text-anchor="middle" fill="currentColor" font-size="10">TSBK block 3</text>
+  <text x="580" y="99" text-anchor="middle" fill="var(--fg-muted)" font-size="9">LB=1 on last</text>
+  <!-- status symbol ticks -->
+  <line x1="128" y1="52" x2="128" y2="70" stroke="var(--accent)" stroke-width="3"/>
+  <line x1="236" y1="52" x2="236" y2="70" stroke="var(--accent)" stroke-width="3"/>
+  <line x1="344" y1="52" x2="344" y2="70" stroke="var(--accent)" stroke-width="3"/>
+  <line x1="452" y1="52" x2="452" y2="70" stroke="var(--accent)" stroke-width="3"/>
+  <line x1="560" y1="52" x2="560" y2="70" stroke="var(--accent)" stroke-width="3"/>
+  <text x="345" y="40" text-anchor="middle" fill="var(--accent)" font-size="10">status symbols — one 2-bit stowaway every 36th on-air dibit</text>
+  <!-- annotations -->
+  <line x1="130" y1="118" x2="400" y2="118" stroke="var(--fg-muted)"/>
+  <line x1="130" y1="112" x2="130" y2="124" stroke="var(--fg-muted)"/>
+  <line x1="400" y1="112" x2="400" y2="124" stroke="var(--fg-muted)"/>
+  <text x="265" y="136" text-anchor="middle" fill="var(--fg-muted)" font-size="10">NID + first TSBK = 130 data dibits → 134 on-air (frameLookahead)</text>
+  <text x="340" y="170" text-anchor="middle" fill="currentColor" font-size="10">DUID = TSDU → decode TSBKs, lock · DUID = PDU → decode MBT, no lock (Part 4)</text>
+  <text x="340" y="188" text-anchor="middle" fill="var(--fg-muted)" font-size="10">voice DUIDs (HDU/LDU1/LDU2/TDU) → "non-control DUID", recorded but never locked on</text>
+</svg>
+<figcaption>One P25 data unit on the air: FSW, NID, up to three TSBK blocks — with a status symbol shifting every count by one per 36 dibits, and only a TSDU allowed to lock the channel.</figcaption>
+</figure>
+
+## When the FSW isn't enough
+
+Issue #275's most stubborn field shape: a reliably detected FSW followed by a
+NID that *never* BCH-decoded. The NID dibits had to be individually sound —
+the FSW wouldn't correlate otherwise — so the fault was alignment, not noise.
+`searchNID` is the answer, a small case study in refusing both kinds of
+error:
+
+- It probes a bounded grid: NID start ± `NIDSearchSpan` (6 dibits), status
+  symbols stripped or not, each allowed rotation.
+- A hypothesis whose BCH decode needs **≤ `NIDAcceptErrs` (6) corrections**
+  and passes the flag-bit check is *trusted* — accepted on the code's
+  strength alone.
+- A hypothesis needing **7–11 corrections** lands in the *marginal tier* — as
+  likely a miscorrection of a misaligned guess as a real noisy NID — and is
+  admitted only if the frame's TSBK **also decodes CRC-clean under the same
+  alignment**. A wrong alignment cannot realistically fake both.
+- A total reject isn't silent: the diag line carries an `err_pattern` — the
+  per-dibit error map of the closest miss — so a reporter can see whether
+  errors cluster at one end (timing slip), near dibit 31 (status-phase
+  fault) or uniformly (SNR-limited), without re-running anything.
+
+FSW hits found only by a looser fallback tolerance go through with
+`requireCorroboration` set — even a clean NID must bring a CRC-valid TSBK —
+so extended reach never bypasses the false-lock guard (issue #771's
+discipline). And all of it runs over a buffer spanning `Process` calls: a
+live RTL-SDR delivers IQ in chunks holding ~19 symbols, far short of a
+154-dibit frame, and before the cross-call buffer existed every FSW hit was
+discarded before its NID arrived. The
+[anatomy of a CC decoder]({{ '/blog/deep-dives/protocol-decoders-01-anatomy-of-a-cc-decoder/' | relative_url }})
+covers this buffering pattern across protocols; P25 is where it was learned.
+
+## What "locked" actually means
+
+`parseFrame` makes the final call, and the rule is one line with a long
+history behind it:
+
+```go
+// internal/radio/p25/phase1/control.go (shape) — parseFrame
+if best.nid.DUID == DUIDPacketDataUnit {
+    // Multi-Block Trunking — decode it, but it does not lock the
+    // channel. Only a TSDU proves a control channel.
+    /* … resumeMBTBlocks … */
+}
+if best.nid.DUID != DUIDTrunkingSignaling {
+    c.log.Debug("non-control DUID", "duid", best.nid.DUID, "nac", best.nid.NAC)
+    return pendingHit{}, false
+}
+if !c.locked || c.lastNAC != best.nid.NAC {
+    c.locked = true
+    c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: LockState{ /* … */ }})
+    c.log.Info("control channel locked", "nac", best.nid.NAC, "freq", c.freqHz, /* … */)
+}
+```
+
+**Only a TSDU proves a control channel.** A voice DUID means you're parked on
+a traffic channel; a PDU is Multi-Block Trunking, decoded in full (Part 4)
+but never lock-worthy on its own. When the flag flips, `KindCCLocked` carries
+a `LockState` with frequency and NAC — and the consumer is as careful as the
+producer: the ccdecoder honours lock and loss edges **only when the payload's
+frequency matches its own active carrier** (`lockEventMatchesActive`),
+because the bus is shared by every decoder in the process and a foreign
+system's lock must not gate this one's autotune or its decode-quality chip.
+
+Lock is also only the *end* of a longer story. Finding which frequency to
+park on is the hunt machinery, told in
+[control-channel hunting]({{ '/blog/deep-dives/the-hunt-06-control-channel-hunting/' | relative_url }})
+and, for this exact protocol,
+[locking a P25 system]({{ '/blog/deep-dives/the-hunt-07-locking-a-p25-system/' | relative_url }});
+the first time it all worked end-to-end is
+[its own war story]({{ '/blog/solution-postmortem/from-the-issue-tracker-01-first-p25-lock/' | relative_url }}).
+This part's contribution is the contract at the boundary: by the time the
+hunt hands over a frequency, "locked" means *a validated TSDU decoded here* —
+nothing weaker.
+
+### How the framing shaped the Go code
+
+- **Acceptance is tiered, never binary.** `NIDAcceptErrs` splits trust from
+  corroboration; the marginal tier borrows the TSBK CRC as a second witness.
+- **Every reject is a measurement.** The closest-miss `err_pattern` diag
+  turned "it doesn't lock" into "errors cluster at dibit 31, suspect the
+  status phase".
+- **Rotations are a physics question.** `RotationsC4FM` exists because the
+  demod mode determines which alphabet rotations are possible; CQPSK keeps
+  all four for its genuine phase ambiguity.
+- **The buffer is part of the protocol.** `frameLookahead` and the
+  pending-hit continuation make frame assembly independent of IQ chunking —
+  the difference between a decoder that works on files and one that works on
+  USB.
+
+## Where this goes next
+
+A locked control channel is a promise of content: TSDUs arrive many times a
+second, each packing up to three 98-dibit signalling blocks.
+[Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
+opens them up — trellis, deinterleaver, CRC, the opcode families that run a
+trunking system — and tells the SCCB byte-offset story, where a round-trip
+test blessed a parser reading a field one byte early.
+
+## FAQ
+
+**What is a NAC in P25?**
+A 12-bit Network Access Code carried in every frame's NID — functionally the
+system's colour code, used to reject co-channel traffic from other systems.
+GopherTrunk logs it on lock (`control channel locked nac=…`) and re-publishes
+the lock event if the NAC changes mid-stream, since that means a different
+system has appeared on the frequency.
+
+**Why does GopherTrunk log `nid corrected errs=…` — is that bad?**
+Not by itself: a few BCH corrections per NID is normal on a marginal signal.
+The number to watch is the tier — `errs` above 6 means the NID was only
+admitted because a TSBK CRC corroborated it, and a stream living permanently
+in that band is SNR-limited, the demod-quality territory of Part 12.
+
+**Can GopherTrunk lock on a voice channel by mistake?**
+No — that is what the TSDU rule prevents. A voice DUID produces a
+`non-control DUID` debug line (suppressible via `QuietNonControlDUID`) and
+nothing else. Camping on a traffic channel is a hunt-layer mistake; the
+framing layer refuses to bless it.
+
+**What are status symbols actually for?**
+On the air, channel-status signalling between subscriber units and the
+repeater. For a receive-only decoder their content is mostly irrelevant but
+their *positions* are everything — they shift every dibit count by one per 36
+on-air dibits. GopherTrunk treats them as geometry: stripped before parsing,
+probed as a hypothesis when alignment fails.
+
+**How likely is a false FSW hit at tolerance 4?**
+Individually unlikely, and it doesn't survive scrutiny anyway: a random hit
+must still produce a NID that BCH-decodes with the right per-DUID flag — and
+in the marginal tier a CRC-valid TSBK too. A false sync costs a little
+compute, never a false lock.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: C4FM & the Shape of a P25 Carrier]({{ '/blog/deep-dives/p25-end-to-end-01-c4fm-carrier/' | relative_url }})
+· Next →
+[Part 3: TSBKs — The Control Channel's Workhorse]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})

--- a/docs/_posts/2026-09-05-from-spec-to-shipping-03-literal-vectors.md
+++ b/docs/_posts/2026-09-05-from-spec-to-shipping-03-literal-vectors.md
@@ -1,0 +1,323 @@
+---
+title: "From Spec to Shipping, Part 3: Literal Vectors, Not Round-Trips"
+description: Why round-trip tests let parser bugs live — the P25 SCCB opcode that read channel B one byte early while its test stayed green — and the fix as method: pin every parser with literal byte vectors cross-checked against an independent decoder, kept as bytes in the test, never generated.
+category: deep-dives
+keywords: round-trip test trap, literal test vectors, parser regression testing, p25 sccb tsbk 0x39, self-consistent test bug, byte layout off by one, cross-check independent decoder, pinning constants in tests, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, testing, p25, tsbk, go, methodology]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 3
+---
+
+*Part 3 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})
+assembled the reference stable and ended on a warning: a reference quoted in
+a comment decorates your code, while a reference wired into your tests
+disagrees with it. This part is the wiring. It opens with the cleanest
+specimen of the series villain this project owns — a P25 parser that read a
+field one byte early for as long as it existed, under a green test — and
+turns the fix into a rule you can apply to any wire format: literal
+vectors, not round-trips.*
+
+> **TL;DR:** GopherTrunk's P25 SCCB parser (TSBK opcode 0x39,
+> `internal/radio/p25/phase1/opcodes.go`) read secondary channel B from
+> payload bytes 4–5 instead of 5–6 — splicing the service-class byte into
+> the channel field and inventing a phantom control channel — and its
+> round-trip test **passed the whole time**, because the test's assembler
+> encoded the same wrong layout. Encode∘decode = identity proves
+> *consistency*, never *correctness*. The fix as method: pin parsers with
+> **literal byte vectors** cross-checked against an independent decoder or
+> a real capture — like the four on-air LOC_REG_RSP payloads in
+> `tsbk_test.go`, or the SmartNet tests that pin sync bits, the stride-19
+> interleave permutation and the `0xCC38`/`0x0D5` XOR masks against OP25's
+> literals — and keep the vectors as bytes in the test, never generated.
+
+**Key takeaways**
+
+- **A round-trip test has zero external information.** Parse(Assemble(x)) ==
+  x holds for *every* self-consistent layout, including wrong ones — the
+  assembler and parser are the same hypothesis written twice.
+- **Literal vectors import a fact from outside.** A byte string from a
+  capture, a spec example, or another decoder's output constrains your
+  parser against the world instead of against itself.
+- **Reference-literal tests are the only tests that catch constant drift.**
+  A sync word, an interleave stride, an XOR mask — if the test computes the
+  expected value from the same constant, it verifies nothing.
+- **Vectors live in the test as bytes.** The moment a "vector" is generated
+  by code under test — or by a sibling that shares its tables — it stops
+  being evidence.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The specimen bug | SCCB channel B read at bytes 4–5, not 5–6 | `internal/radio/p25/phase1/opcodes.go` (`ParseSecondaryControlChannelBroadcast`) |
+| On-air vectors | four real LOC_REG_RSP payloads pin the layout | `phase1/tsbk_test.go` (`TestParseLocationRegistrationResponse`) |
+| Constant pins | sync bits, interleave permutation, XOR masks vs OP25 literals | `internal/radio/motorola/frame_test.go` |
+| Opcode pins | RPC ids vs upstream `SoapyRemoteDefs.hpp` literals | `internal/sdr/soapyremote/driver_test.go` (`TestOpenSetAntennaUsesUpstreamOpcode`) |
+| Independent re-derivation | scrambler rebuilt from the recurrence, not the LFSR | `internal/radio/framing/scramble_tetra_test.go` (`refScrambleTetraETSI`) |
+| The postmortem twin | the trap's greatest hits, told as failures | [From the Issue Tracker Part 20]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}) |
+
+## In this post
+
+- **The SCCB story in full** — one byte early, green the whole time.
+- **Why round-trips can't catch it** — the geometry of self-consistency.
+- **Literal vectors, and where to harvest them** — captures, references,
+  spec examples, independent re-derivations.
+- **Pinning constants, not just layouts** — sync words, permutations,
+  masks, opcodes.
+- **The rules** — five habits that transfer to any wire format.
+
+## The SCCB story in full
+
+P25's Secondary Control Channel Broadcast (TSBK opcode 0x39) announces
+alternate control-channel frequencies for a site. Its 8-byte payload packs
+two channels: RFSS and site IDs, channel A in bytes 2–3, channel A's
+service class in byte 4, channel B in bytes 5–6, channel B's service class
+in byte 7 — per TIA-102.AABC and SDRTrunk's
+`SecondaryControlChannelBroadcast`.
+
+GopherTrunk's parser read channel B from bytes **4–5**. One byte early:
+the high byte of its "channel" was actually service class A, and the field
+that should have been read as class B was half of a channel number. The
+result was a **phantom secondary control channel** — a plausible-looking
+but nonexistent frequency fed into the control-channel hunt machinery.
+The comment now in the tree tells the rest:
+
+```go
+// internal/radio/p25/phase1/opcodes.go (shape)
+// The previous working model read channel B from bytes 4-5 — one byte
+// early, splicing service class A into the channel field and producing a
+// phantom secondary CC; the round-trip test passed because the assembler
+// encoded the same wrong layout (the self-consistent-synthetic trap).
+func ParseSecondaryControlChannelBroadcast(p [8]byte) SecondaryControlChannelBroadcast {
+    cA := binary.BigEndian.Uint16(p[2:4])
+    cB := binary.BigEndian.Uint16(p[5:7]) // was p[4:6]
+    /* … */
+}
+```
+
+Note what the bug was *not*: not a logic error, not a misunderstanding of
+the protocol, not a weak-signal artifact. A transcription slip — the kind
+Part 1 warned lives in exact bit offsets — protected from discovery by the
+exact test that appeared to cover it.
+
+## Why round-trips can't catch it
+
+The SCCB test called `Parse(Assemble(x))` and compared the result to `x`.
+It passed before the fix and passes after, because assembler and parser
+were written by the same person from the same (wrong) reading, and each is
+the other's inverse *by construction*. A round-trip test verifies one
+proposition: "these two functions agree." It says nothing about whether
+either agrees with the air.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="Two testing topologies compared. Left: a round-trip loop where an assembler with a wrong layout feeds a parser with the same wrong layout, the comparison passes, and a green check sits on a closed loop labelled zero external information. Right: a literal vector — bytes from a capture or an independent decoder — feeds only the parser, whose output is compared to independently known field values; the wrong parser now fails, marked with an accent cross labelled the outside fact wins.">
+  <text x="160" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">round-trip: a closed loop</text>
+  <rect x="60" y="40" width="200" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="160" y="59" text-anchor="middle" fill="currentColor" font-size="10">Assemble — wrong layout (B at 4–5)</text>
+  <rect x="60" y="110" width="200" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="160" y="129" text-anchor="middle" fill="currentColor" font-size="10">Parse — same wrong layout</text>
+  <path d="M 250 70 C 290 80 290 100 250 110" fill="none" stroke="var(--fg-muted)"/>
+  <polygon points="255,106 246,113 258,116" fill="var(--fg-muted)"/>
+  <path d="M 70 110 C 30 100 30 80 70 70" fill="none" stroke="var(--fg-muted)"/>
+  <polygon points="65,74 74,67 62,64" fill="var(--fg-muted)"/>
+  <text x="160" y="170" text-anchor="middle" fill="currentColor" font-size="11">✓ passes — forever</text>
+  <text x="160" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="10">zero external information:</text>
+  <text x="160" y="204" text-anchor="middle" fill="var(--fg-muted)" font-size="10">both sides share one hypothesis</text>
+  <line x1="340" y1="30" x2="340" y2="210" stroke="var(--fg-muted)" stroke-dasharray="3 4"/>
+  <text x="520" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">literal vector: one side pinned</text>
+  <rect x="410" y="40" width="220" height="30" rx="5" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="520" y="59" text-anchor="middle" fill="var(--accent)" font-size="10">bytes from capture / independent decoder</text>
+  <line x1="520" y1="70" x2="520" y2="94" stroke="currentColor"/>
+  <polygon points="516,92 520,100 524,92" fill="currentColor"/>
+  <rect x="410" y="100" width="220" height="30" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="520" y="119" text-anchor="middle" fill="currentColor" font-size="10">Parse — wrong layout</text>
+  <line x1="520" y1="130" x2="520" y2="154" stroke="currentColor"/>
+  <polygon points="516,152 520,160 524,152" fill="currentColor"/>
+  <text x="520" y="176" text-anchor="middle" fill="var(--accent)" font-size="11" font-weight="bold">✗ fails: fields ≠ known values</text>
+  <text x="520" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the outside fact wins — the bug</text>
+  <text x="520" y="210" text-anchor="middle" fill="var(--fg-muted)" font-size="10">cannot hide on both sides at once</text>
+</svg>
+<figcaption>A round-trip constrains two functions to each other; a literal vector constrains the parser to the world — only the second can fail on a shared mistake.</figcaption>
+</figure>
+
+This is not an isolated species. The same trap, at other layers of this
+one codebase: the fabricated SmartNet framing decoded its own synthetic
+fixtures perfectly while no real system could feed it
+([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)); the
+SoapyRemote fake server switched on the same opcode constant the client
+sent, so a wrong opcode moved both sides together
+([From the Issue Tracker Part 13]({{ '/blog/solution-postmortem/from-the-issue-tracker-13-soapyremote-handshake/' | relative_url }}));
+a TETRA DMO descramble skip survived because the test's encode side
+skipped scrambling under the same condition
+([TETRA End to End Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})).
+The [postmortem edition]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
+collects the wreckage; this part is the constructive mirror.
+
+Round-trips still earn their keep — they catch asymmetric typos, shift
+errors that don't invert, mask mismatches between the two directions. Keep
+them. Just never let one be the *only* test on a layout, because the class
+of bug it cannot see is precisely the class that ships.
+
+## Literal vectors, and where to harvest them
+
+A literal vector is a byte string whose correct decode is known from
+somewhere *other than the code under test*. Four harvesting grounds, in
+rising order of authority:
+
+**Spec worked examples.** Some standards include encoded examples in
+annexes. Cheap when they exist; remember Part 1's caveat that informative
+annexes can lag normative text.
+
+**An independent decoder's output.** Run OP25, SDRTrunk, Wireshark or
+osmo-tetra over a stream and transcribe what they print. This is how the
+SCCB-class layouts get their second opinion — SDRTrunk's field offsets are
+effectively vectors in prose form.
+
+**An independent re-derivation.** When no external implementation is
+available, write a *second* implementation from the spec by a different
+route, structured so it cannot share the failure mode. GopherTrunk's
+scrambler cross-check is the template: `refScrambleTetraETSI` builds the
+sequence directly from the §8.2.5.2 recurrence "precisely so it can not
+share a shift-direction bug with the production `ScramblerTetra`," which is
+a register-shift LFSR. Same spec, different mechanics — a shared mistake
+now requires two independent misreadings to align.
+
+**A real capture's decoded bytes.** The gold standard. When GopherTrunk's
+LOC_REG_RSP layout needed confirmation, the pin became four payloads lifted
+from a live Motorola P25 site, asserted field by field:
+
+```go
+// internal/radio/p25/phase1/tsbk_test.go (shape) — TestParseLocationRegistrationResponse
+// All four name the same camped site — RFSS 1, Site 1 — with plausible
+// group addresses and 24-bit registering-unit IDs, which is how the
+// layout (response, group, RFSS@p3, Site@p4, target) was confirmed.
+vectors := []struct {
+    payload [8]byte
+    group   uint16
+    target  uint32
+}{
+    {[8]byte{0x00, 0x05, 0x79, 0x01, 0x01, 0x02, 0x45, 0x01}, 0x0579, 0x024501},
+    {[8]byte{0x00, 0x05, 0x15, 0x01, 0x01, 0x02, 0x13, 0x4A}, 0x0515, 0x02134A},
+    /* … two more on-air payloads … */
+}
+```
+
+The bytes are written out. Not built by an assembler, not loaded from a
+fixture generator — *typed into the test*. The expected values carry their
+own plausibility argument (same site in all four, sensible unit IDs), so
+the vector documents its provenance alongside its content. The adjacent
+`TestParseAdjacentSiteStatusBroadcast` does the same with an on-air
+ADJ_STS_BCST payload from the Mt Anakie captures — the same site the
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764)
+investigation verified against.
+
+## Pinning constants, not just layouts
+
+Layouts are one drift surface; bare constants are the other, and they need
+the same treatment. The rebuilt SmartNet decoder
+([Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})'s
+case study) ships three reference-literal tests in
+`internal/radio/motorola/frame_test.go`, one per constant class:
+
+| Pin | Against | Why a weaker test fails |
+|---|---|---|
+| sync bits: `0xAC` MSB-first | OP25 `frame_sync_magics.h` literal | any self-consistent sync "works" in a round-trip |
+| deinterleave permutation | OP25's mapping, as the explicit sequence {1, 20, 39, 58, 2, 21, 40, 59, …} | encode/decode interleavers invert each other at *any* stride |
+| XOR masks `0xCC38` / `0x0D5` | `rx_smartnet.h` `ID_XOR 0x33C7` / `CMD_XOR 0x32A`, complemented | masks applied symmetrically cancel in a loop |
+
+And the pattern is not radio-specific. When the SoapyRemote antenna bug
+was fixed, the regression pinned sixteen RPC opcodes against upstream
+`SoapyRemoteDefs.hpp` values — with the comment doing the teaching:
+"Written as literals on purpose: comparing the constant to itself proves
+nothing" (`TestOpenSetAntennaUsesUpstreamOpcode`). An enum copied from a
+`.hpp` is exactly as much a wire constant as a sync word;
+[Part 9]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})
+runs that story in full.
+
+The test smell to hunt in review: an expected value that mentions the
+production constant's *name*. `want := OutboundSyncHex` verifies the
+compiler; `want := 0xAC // OP25 frame_sync_magics.h` verifies the world.
+
+## The rules
+
+Distilled, and none of them are about radio:
+
+1. **Every parser gets at least one literal vector** whose expected decode
+   comes from outside the codebase — a capture, an independent
+   implementation, or a spec example. Round-trips are supplements.
+2. **Vectors are bytes in the test file.** Generated input is code under
+   test wearing a disguise. If a helper builds it, the helper must not
+   share tables, masks or layout constants with the parser.
+3. **Wire constants are pinned against upstream literals**, re-typed by
+   hand at the pin site, with the source named in a comment.
+4. **Record the vector's provenance in the test.** "Four payloads from a
+   live Motorola site, all naming the camped site" is what lets a future
+   maintainer trust — or correctly distrust — the pin when the layout
+   question reopens.
+5. **When you fix a layout bug, the failing vector goes in first.** The
+   SCCB fix, the SmartNet rebuild and the DMO descramble fix each landed
+   with a test that fails against the old code — the failing-first
+   discipline [Part 12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})
+   makes general, and the habit
+   [/learn/testing/]({{ '/learn/testing/' | relative_url }}) teaches from
+   the ground up.
+
+## Where this goes next
+
+Literal vectors pin fields and constants — discrete facts. But a vocoder
+or a channel-coding chain is thousands of arithmetic operations whose
+correctness only shows in the aggregate, and for those the vector becomes
+a *stream* and the assertion becomes **bit-identical output against a
+reference implementation**.
+[Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})
+builds that harness around the ETSI ACELP codec — same bitstream into both
+decoders, zero sample mismatches allowed — and meets the LP64 gotcha that
+makes the reference itself lie on a modern machine.
+
+## FAQ
+
+**Are round-trip tests worthless, then?**
+No — they cheaply catch asymmetries: a shift that doesn't invert, a mask
+applied on one side only, a field dropped in reassembly. The rule is about
+sufficiency: a round-trip must never be the only test on a wire layout,
+because the shared-hypothesis bug class is invisible to it by construction.
+
+**Where do I get literal vectors for an encrypted or rare protocol?**
+Work down the authority ladder: an independent decoder's output over any
+sample you can find, a second in-house implementation built by a different
+route (the `refScrambleTetraETSI` pattern), or spec worked examples. Even
+one confirmed vector beats a thousand round-trips — it is the only test in
+the file carrying outside information.
+
+**How many vectors does a parser need?**
+Enough to make each field's offset load-bearing — usually two to four
+well-chosen ones. GopherTrunk pinned LOC_REG_RSP with four on-air payloads
+because they jointly confirm response, group, RFSS, site and target
+occupy distinct, correct bytes; one all-zeros vector would pin almost
+nothing.
+
+**Should vectors live in testdata files instead of source?**
+Short vectors belong inline — visible in review, diffed with the code,
+impossible to regenerate accidentally. Bulk streams (a captured control
+channel, an IQ fixture) belong in `testdata/` with a checksum or a
+documented origin; the danger is not the file, it's any *pipeline* that
+can silently rebuild it from the code under test.
+
+**What's the fastest way to audit an existing codebase for this trap?**
+Grep the tests for calls to your own assemblers and encoders. Every parser
+whose only inputs are produced by its own inverse is unpinned — list them,
+then harvest one literal vector each, worst-consequences first. The SCCB
+bug lived precisely in that unpinned set, and only an independent
+cross-check dislodged it.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: Choosing Reference Implementations You Can Trust]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})
+· Next →
+[Part 4: The Conformance Harness — Bit-Identical or Bust]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})

--- a/docs/_posts/2026-09-05-from-spec-to-shipping-03-literal-vectors.md
+++ b/docs/_posts/2026-09-05-from-spec-to-shipping-03-literal-vectors.md
@@ -1,6 +1,6 @@
 ---
 title: "From Spec to Shipping, Part 3: Literal Vectors, Not Round-Trips"
-description: Why round-trip tests let parser bugs live — the P25 SCCB opcode that read channel B one byte early while its test stayed green — and the fix as method: pin every parser with literal byte vectors cross-checked against an independent decoder, kept as bytes in the test, never generated.
+description: "Why round-trip tests let parser bugs live — the P25 SCCB opcode that read channel B one byte early while its test stayed green — and the fix as method: pin every parser with literal byte vectors cross-checked against an independent decoder, kept as bytes in the test, never generated."
 category: deep-dives
 keywords: round-trip test trap, literal test vectors, parser regression testing, p25 sccb tsbk 0x39, self-consistent test bug, byte layout off by one, cross-check independent decoder, pinning constants in tests, gophertrunk from spec to shipping
 tags: [from-spec-to-shipping, testing, p25, tsbk, go, methodology]

--- a/docs/_posts/2026-09-05-operator-cookbook-03-conventional-dmr-two-slots.md
+++ b/docs/_posts/2026-09-05-operator-cookbook-03-conventional-dmr-two-slots.md
@@ -1,0 +1,337 @@
+---
+title: "The Operator's Cookbook, Part 3: One Repeater, Two Conversations — Conventional DMR"
+description: A single-dongle GopherTrunk build for a conventional DMR Tier II repeater — two independent talkgroups on TS1 and TS2 decoded as two simultaneous calls, with the interleaved two-slot voice path, embedded-LC routing, colour-code pinning, and the honest edge cases.
+category: tutorials
+keywords: dmr tier 2 scanner, conventional dmr decode, dmr timeslot ts1 ts2, dmr repeater sdr, dmr embedded link control, dmr colour code config, two slot dmr recording, mototrbo scanner sdr, gophertrunk cookbook
+tags: [operator-cookbook, dmr, tier-2, tdma, timeslots, config]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 3
+---
+
+*Part 3 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 2]({{ '/blog/tutorials/operator-cookbook-02-dmr-tier3/' | relative_url }})
+decoded a trunked Tier III network and its LCN band plan. This part drops the
+trunking entirely: one conventional DMR repeater, no control channel handing
+out anything — and yet still *two* simultaneous conversations, because every
+DMR carrier is two-slot TDMA. Until recently GopherTrunk collapsed those two
+slots into one garbled call; the rebuilt two-slot path decodes them as two.
+This recipe is the cheapest complete build in the series: one dongle, no voice
+radio, no band plan.*
+
+> **TL;DR:** A DMR Tier II repeater carries **TS1 and TS2 interleaved on one
+> carrier**, each able to hold its own talkgroup at the same time. Config is
+> `protocol: dmr-tier2` with the repeater's output frequency in
+> `control_channels` — one `role: control` dongle suffices, because
+> conventional DMR voice rides the **same carrier** the decoder camps
+> (GopherTrunk registers two same-carrier voice taps automatically). The
+> interleaved two-slot decoder is the **default** for DMR: concurrent calls
+> get their own recordings, routed by each superframe's embedded Link Control
+> talkgroup, and a Terminator-with-LC ends only its own slot's call. Healthy
+> looks like `dmr/tier2 cc locked` then, on a busy afternoon, two
+> `recorder: call started` lines at once.
+
+**Key takeaways**
+
+- **Two conversations were always there.** [Tier II]({{ '/reference/dmr-tier-2/' | relative_url }})
+  TDMA gives one 12.5 kHz repeater two logical channels; a decoder that treats
+  the carrier as one stream produces "DJ scratchy" audio — both calls' AMBE
+  frames spliced together (issue #644's signature).
+- **The wire doesn't label slots — talkgroups do.** A base-station burst
+  carries no reliable physical-slot number, so GopherTrunk assigns each
+  concurrent call a *synthetic* timeslot identity and routes audio by the
+  [embedded Link Control]({{ '/reference/dmr-embedded-lc/' | relative_url }})'s
+  talkgroup, not by slot position.
+- **This is the one-dongle-no-voice-radio build.** Voice lives on the decoded
+  carrier itself, so the same-carrier taps make a second SDR pointless here.
+- **It's new — verify it on your repeater.** The two-slot path is pinned by
+  regression tests, but the on-air A/B on a real concurrent-traffic capture is
+  still open. If your repeater misbehaves, a capture report is genuinely
+  valuable.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| System definition | conventional carrier, camped not hunted | `protocol: dmr-tier2`, `control_channels: [<repeater Hz>]` |
+| Two-slot decode | interleaved voice, per-slot calls | `dmr_interleaved_voice` (tri-state; **default on** for DMR) |
+| Slot routing | which audio belongs to which call | embedded LC talkgroup — [dmr-embedded-lc]({{ '/reference/dmr-embedded-lc/' | relative_url }}) |
+| Co-channel rejection | drop bursts from the wrong system | `color_code: 0..15` ([color code]({{ '/reference/color-code/' | relative_url }})) |
+| Call teardown | Terminator-with-LC ends its own slot only | [dmr-full-link-control]({{ '/reference/dmr-full-link-control/' | relative_url }}); hangtime backstop `voice_hangtime_ms` |
+| Protocol background | bursts, CACH, superframes | [Protocol Decoders Part 5]({{ '/blog/deep-dives/protocol-decoders-05-dmr-tier-2-3/' | relative_url }}), [dmr-voice-superframe]({{ '/reference/dmr-voice-superframe/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — a camped repeater that yields two calls at once.
+- **The shopping list** — Part 1's, minus nothing, plus nothing.
+- **How two slots become two calls** — the decode story, briefly.
+- **The config** — the shortest one in this series.
+- **First run — what healthy looks like** — beacons, locks, concurrent calls.
+- **When it doesn't work** — scratchy audio, ping-pong, double records.
+
+## What you're building
+
+The target is the workhorse of commercial and amateur DMR: a single
+conventional repeater — a warehouse fleet, a linked amateur repeater, a
+municipal works channel. No trunking, no grants-to-elsewhere: radios transmit
+on the repeater's input, the repeater retransmits on its output, and your rig
+camps that output frequency full-time.
+
+What makes it interesting is the TDMA. The repeater's carrier alternates
+30 ms bursts between timeslot 1 and timeslot 2, and the two slots are fully
+independent channels — dispatch on TS1 while two techs talk on TS2. A correct
+decoder therefore has to *demultiplex before it decodes voice*: pull each
+call's own slot cadence out of the interleaved stream, decode its AMBE+2
+superframes separately, and keep two recordings open at once. That's exactly
+what the rebuilt Tier II path does, and it's on by default.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 235" width="680" height="235" role="img" aria-label="A conventional DMR carrier timeline showing alternating 30 millisecond bursts, timeslot 1 bursts accented and timeslot 2 bursts plain, interleaved on one carrier; below, the interleaved stream splits into two independent call chains routed by each superframe's embedded Link Control talkgroup, producing two simultaneous recordings, talkgroup 9 dispatch and talkgroup 12 operations">
+  <text x="14" y="26" fill="currentColor" font-size="11" font-weight="bold">one carrier, alternating 30 ms bursts</text>
+  <line x1="14" y1="62" x2="666" y2="62" stroke="var(--fg-muted)"/>
+  <rect x="30" y="40" width="72" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="66" y="55" text-anchor="middle" fill="var(--accent)" font-size="10">TS1</text>
+  <rect x="106" y="40" width="72" height="22" fill="none" stroke="currentColor"/>
+  <text x="142" y="55" text-anchor="middle" fill="currentColor" font-size="10">TS2</text>
+  <rect x="182" y="40" width="72" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="218" y="55" text-anchor="middle" fill="var(--accent)" font-size="10">TS1</text>
+  <rect x="258" y="40" width="72" height="22" fill="none" stroke="currentColor"/>
+  <text x="294" y="55" text-anchor="middle" fill="currentColor" font-size="10">TS2</text>
+  <rect x="334" y="40" width="72" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="370" y="55" text-anchor="middle" fill="var(--accent)" font-size="10">TS1</text>
+  <rect x="410" y="40" width="72" height="22" fill="none" stroke="currentColor"/>
+  <text x="446" y="55" text-anchor="middle" fill="currentColor" font-size="10">TS2</text>
+  <text x="560" y="55" fill="var(--fg-muted)" font-size="10">… 60 ms period</text>
+  <line x1="218" y1="62" x2="180" y2="120" stroke="var(--accent)"/>
+  <line x1="294" y1="62" x2="480" y2="120" stroke="currentColor"/>
+  <rect x="60" y="120" width="240" height="52" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="180" y="139" text-anchor="middle" fill="var(--accent)" font-size="10">call A — embedded LC says TG 9</text>
+  <text x="180" y="154" text-anchor="middle" fill="var(--fg-muted)" font-size="9">own superframe cadence → AMBE+2</text>
+  <text x="180" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ends on its own Terminator-with-LC</text>
+  <rect x="380" y="120" width="240" height="52" rx="4" fill="none" stroke="currentColor"/>
+  <text x="500" y="139" text-anchor="middle" fill="currentColor" font-size="10">call B — embedded LC says TG 12</text>
+  <text x="500" y="154" text-anchor="middle" fill="var(--fg-muted)" font-size="9">decoded in parallel, second tap</text>
+  <text x="500" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">unaffected by TS1's teardown</text>
+  <text x="180" y="196" text-anchor="middle" fill="var(--accent)" font-size="10">recordings/…/9/….wav</text>
+  <text x="500" y="196" text-anchor="middle" fill="currentColor" font-size="10">recordings/…/12/….wav</text>
+  <text x="340" y="224" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the wire never labels a burst's physical slot — the talkgroup inside the embedded LC is the routing key</text>
+</svg>
+<figcaption>Two-slot demultiplex: the interleaved carrier splits into two independent call chains, each identified by its embedded-LC talkgroup — because base-station bursts carry no trustworthy physical slot number.</figcaption>
+</figure>
+
+## The shopping list
+
+Identical to [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}):
+one ~$35 RTL-SDR, the kit whip, any computer. This recipe actually *uses less*
+of it — no wideband window juggling, no voice taps to size. Conventional DMR
+is the friendliest possible target for the
+[starter checklist]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})
+hardware, and most repeaters run enough power that the stock whip indoors is
+plenty within a few miles.
+
+## How two slots become two calls
+
+Three facts about the decode path, because they explain both the config and
+the troubleshooting table.
+
+**First: interleaved decode is the default.** The `dmr_interleaved_voice`
+key is a tri-state override; unset, DMR systems get the interleaved two-slot
+decoder, which auto-detects each call's on-air cadence (with or without an
+inter-burst [CACH]({{ '/reference/dmr-cach/' | relative_url }})) and pulls its
+slot out of the stream. The single-slot decoder that used to splice both
+slots into one call — the "DJ scratchy" audio of issue #644 — is now the
+thing you'd have to opt *into*.
+
+**Second: identity is per-destination, not per-slot.** The base-station wire
+format shares its sync words across both slots and the slot-type field
+carries only colour code + data type — so GopherTrunk assigns concurrent
+calls a *synthetic* timeslot (1/2) as an engine identity token and routes
+audio by the embedded Link Control's talkgroup. Two consecutive
+transmissions on different talkgroups become two calls even if the repeater
+juggles them across physical slots.
+
+**Third: teardown respects the boundary.** A
+Terminator-with-LC decodes its own destination, so a TS1 terminator releases
+only the TS1 call. When a terminator's LC *doesn't* decode and two calls are
+active, GopherTrunk deliberately releases nothing — a guess could tear down
+the wrong conversation — and lets each call's own hangtime
+(`trunking.voice_hangtime_ms`, default 3.5 s) close it. One active call with
+an undecodable terminator still tears down promptly, keeping the snappy
+single-call behaviour.
+
+## The config
+
+The shortest complete config in this series — every key verified against
+`config.example.yaml`:
+
+```yaml
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000001"
+      role: control
+      gain: "auto"
+
+trunking:
+  systems:
+    - name: "Ridge-Repeater"
+      protocol: dmr-tier2
+      control_channels:
+        - 452_662_500      # the repeater's OUTPUT frequency
+      talkgroup_file: "../config/talkgroups-dmr.csv"   # optional
+      # color_code: 3      # optional: drop bursts from co-channel systems
+      # dmr_interleaved_voice: false   # force single-slot (don't, normally)
+```
+
+Notes. `control_channels` here means "the carrier to camp" — the cc-hunt
+supervisor treats a conventional system as a channel to sit on and wait, not
+hunt. **No voice device appears anywhere**: because Tier II voice rides the
+same carrier the state machine decodes, the daemon registers two
+same-carrier voice taps for the system automatically — one per timeslot. And
+`color_code` is worth setting once you know your repeater's
+[colour code]({{ '/reference/color-code/' | relative_url }}): unset,
+GopherTrunk accepts and reports whatever it reads off the air, which is right
+for exploration and wrong on a shared frequency where a distant co-channel
+system on a different colour code would pollute your call log.
+
+## First run — what healthy looks like
+
+Start the daemon. On a quiet repeater the first sign of life is the camp
+announcement and, if the repeater beacons idle CSBKs, a periodic keepalive:
+
+```
+INF cchunt: camped on conventional channel — idle, waiting for traffic
+INF dmr/tier2 site alive (beacon) freq=452662500 cc=3 csbk=... system=Ridge-Repeater
+```
+
+The lock line fires on the first decoded voice activity:
+
+```
+INF dmr/tier2 cc locked freq=452662500 cc=3 system=Ridge-Repeater
+INF recorder: call started device=cc:same-carrier:1 wav=../recordings/Ridge-Repeater/9/... tg=9 provoice=false vocoder=ambe2-dmr
+```
+
+And the moment this build exists for — a busy afternoon, both slots keyed:
+
+```
+INF recorder: call started device=cc:same-carrier:1 ... tg=9 ...
+INF recorder: call started device=cc:same-carrier:2 ... tg=12 ...
+INF recorder: call ended ... duration=6.32s reason=released
+```
+
+Two `call started` lines with different talkgroups, overlapping in time, each
+ending on its own terminator (`reason=released`) or hangtime
+(`reason=timeout`). In the web console, **Active** shows both calls
+simultaneously; at `log.level: debug` you can watch the raw grants
+(`dmr/tier2: grant … dst=9 src=2054 individual=false`) and terminators
+(`dmr/tier2: terminator dst=9 slot=1`) drive the lifecycle.
+
+Honesty checkpoint, in the spirit this blog keeps repeating: the two-slot
+path is pinned by failing-first regression tests against synthetic
+interleaved carriers, but its **on-air A/B against a real concurrent-traffic
+capture is still pending** — the only IQ grab contributed so far was
+undecodable (~−75 dBFS). Green synthetic ≠ on-air correct is
+[this project's most expensive lesson]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}),
+so treat this recipe as *new in this release*: run it, and if your repeater
+produces anything from the table below, a
+[capture]({{ '/decoder-capture-needs.html' | relative_url }}) is the most
+useful bug report there is.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| "DJ scratchy" audio — two voices chopped together in one file | both slots spliced into one call: the pre-rebuild behaviour, or `dmr_interleaved_voice: false` forced | Remove the override (default is interleaved-on); if it persists on defaults, capture IQ and report — that's the exact #644 signature the rebuild targets |
+| One recording ping-pongs between two talkgroups | slot demux failing, calls being folded to one identity | Same as above — this is the second face of the same bug class; verify you're on a current build |
+| Same transmission recorded **twice**, once per tap | embedded LC never decodes, so both slot routers fall back to phase parity and can bind the same phase | Known sharp edge (#644 family): weak signal usually underlies the LC failures — improve RF first, and report the capture |
+| No lock, but the repeater is definitely transmitting | wrong frequency (input vs output), or a colour-code pin mismatch | Camp the repeater's **output**; unset `color_code` while diagnosing so GT reports what it actually reads (`cc=` in the lock line) |
+| Bursts decode, calls log, but from a system 40 miles away | co-channel sharing — DMR reuses frequencies aggressively | Now set `color_code:` to your system's value; wrong-colour bursts are dropped before they grant or lock |
+| Calls end several seconds after the voice clearly stopped | terminator LC undecodable with two calls active — teardown deferred to hangtime by design | Expected under weak signal; lower `voice_hangtime_ms` if the tail bothers you, at the cost of splitting long pauses |
+| Constant `dmr/tier2: CSBK CRC mismatch (between-beacon noise)` at debug | normal — noise between transmissions probed and rejected | Nothing; that's the decoder declining to invent traffic |
+
+### How this recipe shapes operator practice
+
+- **Concurrent `call started` lines are the health check.** One busy hour
+  with both slots active proves the whole demux; a repeater that never shows
+  two concurrent calls might just be single-slot-provisioned — check with a
+  local before suspecting the decoder.
+- **Unset the colour code to diagnose, set it to operate.** GT reporting
+  `cc=` off the air is your measurement; the pin is your filter.
+- **New paths earn trust through your captures.** The regression suite proves
+  the code against the bug it fixed; only the field proves it against radios.
+
+## Variations
+
+- **Several repeaters, one dongle.** If multiple conventional carriers fit in
+  one 2.4 MHz window, use a `role: wideband` device with one `channels:`
+  entry per repeater, each pointing at its own `protocol: dmr-tier2` system —
+  every carrier gets its own state machine, decoded in parallel.
+- **Tier I / direct mode.** `protocol: dmr-tier1` covers 446 MHz
+  license-free DMR — same family, single-slot by design
+  ([dmr-tier-1]({{ '/reference/dmr-tier-1/' | relative_url }})), and it stays
+  on the single-slot voice path.
+- **AMBE frame sidecars.** DMR calls always write a `.raw` vocoder-frame
+  sidecar; add `recordings.mbe_files: true` for DSD-FME-playable `.amb`
+  files if you want to A/B GopherTrunk's vocoder against mbelib — the
+  workflow [vocoders.md]({{ '/vocoders.html' | relative_url }}) documents.
+- **Names over numbers.** The same talkgroup CSV from Part 2 works here;
+  conventional talkgroups especially benefit since the numbers are often
+  fleet-internal.
+
+## Where this goes next
+
+Three parts, three protocols from the same 4-level-FSK family. [Part
+4]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})
+leaves it entirely: TETRA — π/4-DQPSK, a continuously transmitting four-slot
+downlink, a clean-room ACELP vocoder, and a control-channel equalizer that
+ships enabled because real networks needed it. Different modulation, same
+recipe skeleton.
+
+## FAQ
+
+**Can one SDR dongle decode both DMR timeslots at the same time?**
+Yes — both slots live on one 12.5 kHz carrier, so one dongle captures
+everything. The work is demultiplexing, not bandwidth: GopherTrunk's
+interleaved decoder separates each call's burst cadence and decodes two AMBE+2
+streams in parallel from the same capture.
+
+**Why does my DMR recording contain two conversations chopped together?**
+That's the classic single-slot-decoder-on-a-two-slot-carrier failure: both
+timeslots' voice frames sliced into one superframe stream. In current
+GopherTrunk the interleaved decoder is the DMR default, so if you hear it,
+check that `dmr_interleaved_voice` isn't forced `false` — and if it happens
+on defaults, report it with IQ.
+
+**Do I need to know my repeater's colour code before configuring it?**
+No — leave `color_code` unset and GopherTrunk decodes and logs the colour
+code it hears (`cc=3` in the lock line). Once confirmed, pin it: on shared
+frequencies the pin keeps a co-channel system on another colour code out of
+your call log entirely.
+
+**How does GopherTrunk know which timeslot a burst belongs to?**
+Strictly speaking, it doesn't — a base-station burst carries no reliable
+physical slot label. It separates calls by their decoded identity instead:
+each concurrent destination gets its own call with a synthetic slot token,
+and voice routes by the embedded Link Control's talkgroup. The physical slot
+number is the one thing this rig never actually needs.
+
+**Is conventional DMR the same as MOTOTRBO?**
+MOTOTRBO is Motorola's product line built on the DMR standard; a MOTOTRBO
+conventional repeater is exactly what this recipe decodes. IPSC-linked
+multi-repeater MOTOTRBO systems work per-carrier too — each repeater is just
+another `dmr-tier2` entry.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: A DMR Tier III Network, End to End]({{ '/blog/tutorials/operator-cookbook-02-dmr-tier3/' | relative_url }})
+· Next →
+[Part 4: A TETRA TMO Rig]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})

--- a/docs/_posts/2026-09-05-p25-end-to-end-03-tsbk-workhorse.md
+++ b/docs/_posts/2026-09-05-p25-end-to-end-03-tsbk-workhorse.md
@@ -1,0 +1,340 @@
+---
+title: "P25 End to End, Part 3: TSBKs — The Control Channel's Workhorse"
+description: Inside the P25 Trunking Signaling Block — 12 bytes through a 1/2-rate trellis and interleaver into 98 channel dibits, the CRC variant many references get wrong, the opcode families that run a trunked system, and the SCCB byte-offset bug a round-trip test blessed.
+category: deep-dives
+keywords: p25 tsbk decoding, trunking signaling block, p25 trellis code, p25 opcode list, group voice channel grant, p25 crc ccitt, p25 vendor mfid 0x90, sccb secondary control channel, gophertrunk p25
+tags: [p25-end-to-end, p25, tsbk, trunking, fec, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 3
+---
+
+*Part 3 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice.
+[Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})
+found the frames and defined what "locked" means. This part opens the frame
+that earns the lock: the TSDU and its Trunking Signaling Blocks — the 12-byte
+messages that grant calls, publish band plans, and describe whole systems.
+It also tells two of this series' best cautionary tales: a CRC algorithm the
+references document wrong, and a byte-offset bug that a passing round-trip
+test protected for as long as nobody checked a literal vector.*
+
+> **TL;DR:** A TSBK is **12 bytes** — LB/P flags, a 6-bit opcode, an MFID, 8
+> payload bytes and a CRC-16 — trellis-encoded 1/2-rate into **98 channel
+> dibits** and block-interleaved (`EncodeTSBKChannel` /
+> `DecodeTSBKChannel`, `internal/radio/p25/phase1/tsbk.go`). One TSDU packs
+> up to **three** blocks; decoding only the first dropped two-thirds of a
+> busy site's signalling (issue #402). The trailer is the **augmented-
+> codeword CRC-CCITT** (init 0, final XOR 0xFFFF), not the widely-documented
+> CRC-CCITT/FALSE — the wrong variant failed 195 of 197 real TSBKs at trellis
+> metric 0. Grants flow through the band plan into `trunking.Grant`; vendor
+> opcodes (MFID 0x90) must never render through the standard
+> `Opcode.String()` map; and the SCCB (0x39) parser once read channel B a
+> byte early — with a green round-trip test — until literal vectors
+> cross-checked against SDRTrunk caught it.
+
+**Key takeaways**
+
+- **The TSBK is the atom of P25 trunking.** Every grant, band-plan entry,
+  neighbour announcement and registration reply on a Phase 1 control channel
+  is one of these 12-byte blocks, arriving several per TSDU, many TSDUs per
+  second.
+- **The trellis is table-driven, not textbook.** P25's 1/2-rate code is a
+  16-entry constellation table whose state is the previous input dibit
+  (TIA-102.BAAA-A Annex A) — not the standard (7,5) convolutional code — and
+  its Viterbi path metric doubles as a per-block quality gauge.
+- **Two independent validators beat one strong one.** The trellis can decode
+  garbage confidently; the CRC-16 behind it is what actually gates
+  acceptance — and Part 2's marginal NID tier borrows it as a witness.
+- **A round-trip test cannot see a layout bug.** The SCCB parser and
+  assembler shared the same wrong byte offsets, so encode→decode was
+  perfect while every real 0x39 produced a phantom secondary control
+  channel. Pin parsers with literal vectors from an independent decoder.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Block parse + CRC | 12 bytes → LB/P/opcode/MFID/payload, augmented CRC | `internal/radio/p25/phase1/tsbk.go` (`ParseTSBK`) |
+| Trellis code | 48 info dibits ↔ 98 channel dibits, Viterbi metric | `trellis.go` (`EncodeTrellis`, `DecodeTrellis`) |
+| Interleave | block permutation over the 98 dibits | `interleaver.go` (`InterleaveTSBK`, `DeinterleaveTSBK`) |
+| Soft-decision twin | per-bit LLRs through the same pipeline | `tsbk.go` (`DecodeTSBKChannelSoft`) |
+| Opcode namespace | 6-bit OSP opcodes, TIA mnemonics | `opcodes.go` (`Opcode`, `Opcode.String`) |
+| Vendor TSBKs | MFID 0x90/0xA4 patches, aliases, grants | `tsbk_vendor.go` (`MFIDMotorola`, `IsVendorMFID`) |
+| Grant publish | band-plan lookup → `trunking.Grant` on the bus | `control.go` (`publishVoiceGrant`) |
+
+## In this post
+
+- **Twelve bytes that run a system** — the TSBK layout, and why three per TSDU matters.
+- **Through the trellis** — the channel pipeline, and the CRC the references get wrong.
+- **The opcode families** — grants, identifiers, status, unit business.
+- **From opcode to `trunking.Grant`** — what leaves this layer, and where it goes.
+- **Names that lie** — the vendor namespace and the AMBT labelling rule.
+- **The SCCB bug** — the round-trip test that validated nothing.
+
+## Twelve bytes that run a system
+
+Strip away the channel coding and a TSBK is compact:
+
+| Field | Size | Meaning |
+|---|---|---|
+| LB | 1 bit | last block in this TSDU |
+| P | 1 bit | protected (encrypted signalling) |
+| Opcode | 6 bits | what this block says |
+| MFID | 8 bits | manufacturer ID — 0x00 standard, 0x90 Motorola, 0xA4 Harris |
+| Payload | 8 bytes | opcode-specific |
+| CRC | 16 bits | trailer over the whole block |
+
+One TSDU carries up to **three** TSBKs back to back (`maxTSBKBlocks`), the
+last flagged LB=1. That plural is load-bearing: GopherTrunk originally
+decoded only the first block per frame, and on a busy site — which fills all
+three — that silently discarded roughly two-thirds of the signalling (fixed
+under issue #402, with `resumeTSBKBlocks` continuing a block train across IQ
+chunks). "Locks fine but misses grants" is exactly what a first-block-only
+decoder looks like from outside.
+
+## Through the trellis
+
+On the air, each 12-byte block becomes 98 channel dibits: 96 info bits split
+into 48 dibits, trellis-encoded at rate 1/2, then block-interleaved to spread
+burst errors. The code itself is worth a look because it is *not* the
+convolutional code you'd guess:
+
+```go
+// internal/radio/p25/phase1/trellis.go (shape)
+// This is NOT the standard (7,5) octal NASA convolutional code; it's a
+// table-driven code whose state IS the most-recent input dibit and whose
+// transition outputs come from a 16-entry constellation table
+// (TIA-102.BAAA-A Annex A Table A.1).
+func EncodeTrellis(info []uint8) []uint8 {
+    out := make([]uint8, 0, 98)
+    state := 0
+    for _, d := range info {
+        next := int(d & 0x3)
+        idx := trellisStates[state][next]
+        out = append(out, trellisPairs[idx][0], trellisPairs[idx][1])
+        state = next
+    }
+    /* … finisher dibit flushes state to 0 → the 98th output dibit … */
+    return out
+}
+```
+
+`DecodeTrellis` runs hard-decision Viterbi and returns a **path metric** —
+0 for a clean channel, climbing with corrections — which downstream code uses
+as a per-block confidence gauge, and `DecodeTSBKChannelSoft` runs the same
+pipeline on per-bit LLRs from the receiver's `BitLLRSink` (Part 1's hook,
+closing the loop). The general theory lives in the
+[framing & FEC deep dive]({{ '/blog/deep-dives/sdr-internals-09-framing-fec/' | relative_url }});
+what's P25-specific is the trap behind the trellis.
+
+The trailer CRC looks like a solved problem — CRC-CCITT, every reference
+says so. But the variant matters: many P25 references document
+CRC-CCITT/FALSE (init 0xFFFF, no final XOR), and that is **not what the air
+uses**. Real TSBKs verify under the *augmented-codeword* variant — init 0,
+final XOR 0xFFFF, run over all 12 bytes, expect 0
+(`framing.CRCCCITTAugmented`). The field symptom that forced the fix: on the
+Mt Anakie capture, **195 of 197 TSBKs failed CRC while the trellis reported
+metric 0** — a clean channel whose every block was rejected by arithmetic.
+When a strong FEC says clean and a checksum says corrupt, suspect the
+checksum's pedigree before the radio.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 200" width="680" height="200" role="img" aria-label="The TSBK receive pipeline as five boxes: 98 channel dibits enter a deinterleaver, then a Viterbi decoder over the table-driven trellis emitting 48 info dibits and a path metric, then a repack into 12 bytes, then the augmented CRC-CCITT gate, then the opcode dispatch; a note marks the CRC as the acceptance gate and the metric as advisory">
+  <rect x="12" y="60" width="108" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="66" y="79" text-anchor="middle" fill="currentColor" font-size="10">98 channel dibits</text>
+  <text x="66" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">per block, ×3 per TSDU</text>
+  <line x1="120" y1="82" x2="140" y2="82" stroke="currentColor"/><polygon points="138,78 146,82 138,86" fill="currentColor"/>
+  <rect x="146" y="60" width="100" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="196" y="79" text-anchor="middle" fill="currentColor" font-size="10">deinterleave</text>
+  <text x="196" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DeinterleaveTSBK</text>
+  <line x1="246" y1="82" x2="266" y2="82" stroke="currentColor"/><polygon points="264,78 272,82 264,86" fill="currentColor"/>
+  <rect x="272" y="60" width="110" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="327" y="79" text-anchor="middle" fill="currentColor" font-size="10">Viterbi (trellis)</text>
+  <text x="327" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">48 dibits + metric</text>
+  <line x1="382" y1="82" x2="402" y2="82" stroke="currentColor"/><polygon points="400,78 408,82 400,86" fill="currentColor"/>
+  <rect x="408" y="60" width="96" height="44" rx="6" fill="none" stroke="currentColor"/>
+  <text x="456" y="79" text-anchor="middle" fill="currentColor" font-size="10">repack</text>
+  <text x="456" y="93" text-anchor="middle" fill="var(--fg-muted)" font-size="9">12 bytes</text>
+  <line x1="504" y1="82" x2="524" y2="82" stroke="currentColor"/><polygon points="522,78 530,82 522,86" fill="currentColor"/>
+  <rect x="530" y="60" width="138" height="44" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="599" y="79" text-anchor="middle" fill="var(--accent)" font-size="10">augmented CRC-16</text>
+  <text x="599" y="93" text-anchor="middle" fill="var(--accent)" font-size="9">the acceptance gate</text>
+  <line x1="599" y1="104" x2="599" y2="128" stroke="currentColor"/><polygon points="595,126 599,134 603,126" fill="currentColor"/>
+  <rect x="470" y="134" width="198" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="569" y="151" text-anchor="middle" fill="currentColor" font-size="10">dispatch on opcode + MFID</text>
+  <text x="569" y="165" text-anchor="middle" fill="var(--fg-muted)" font-size="9">grants · identifiers · status · vendor</text>
+  <text x="200" y="140" fill="var(--fg-muted)" font-size="10">the Viterbi metric is advisory (0 = clean);</text>
+  <text x="200" y="155" fill="var(--fg-muted)" font-size="10">the CRC decides — the wrong CRC variant</text>
+  <text x="200" y="170" fill="var(--fg-muted)" font-size="10">rejected 195/197 clean blocks (Mt Anakie)</text>
+</svg>
+<figcaption>The TSBK receive pipeline: interleaving and the trellis fight the channel, but the augmented CRC-16 is the only gate — get its variant wrong and a clean site decodes nothing.</figcaption>
+</figure>
+
+## The opcode families
+
+The 6-bit opcode space (`opcodes.go`, per TIA-102.AABC-D Table 7-1) sorts
+into four working families:
+
+| Family | Representative opcodes | What they do |
+|---|---|---|
+| Voice grants & updates | 0x00 GRP_V_CH_GRANT, 0x02/0x03 updates, 0x04 UU_V_CH_GRANT | start and refresh calls — the reason to listen |
+| Channel identifiers | 0x3D IDEN_UP, 0x34 IDEN_UP_VU, 0x33 IDEN_UP_TDMA | publish the band plan (Part 5's subject) |
+| Site & system status | 0x3B NET_STS_BCST, 0x3A RFSS_STS_BCST, 0x3C ADJ_STS_BCST, 0x39 SCCB | identity, neighbours, secondary CCs (Part 10) |
+| Unit business | 0x28 GRP_AFF_RSP, 0x2C U_REG_RSP, 0x18 STS_UPDT, 0x1F CALL_ALRT | registration, affiliation, paging |
+
+`Opcode.String()` renders the canonical TIA mnemonic so logs read in spec
+terms, falling back to `OSP(0xNN)` for opcodes the decoder doesn't name.
+That method carries a scope rule we'll return to below: it is only
+meaningful for **standard** (MFID 0x00) outbound opcodes.
+
+## From opcode to `trunking.Grant`
+
+A grant TSBK carries no frequency — only a 4-bit channel ID and 12-bit
+channel number that the band plan (built from IDEN_UP blocks) resolves to
+hertz. `publishVoiceGrant` does the translation and publishes the result:
+
+```go
+// internal/radio/p25/phase1/control.go (shape) — publishVoiceGrant
+freq, err := c.bandPlan.Frequency(g.channelID, g.channelNumber)
+if err != nil {
+    // Grant before its IDEN_UP: buffer it and surface a
+    // stage="no-bandplan" decode error, then drain when the slot lands.
+    c.pendingGrants.add(g.channelID, g, nac, c.now())
+    return
+}
+c.bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{
+    System: c.systemName, Protocol: protocol, // "p25", or "p25-phase2" on a TDMA channel
+    GroupID: g.groupID, SourceID: g.sourceID, FrequencyHz: freq,
+    NAC: nac, Encrypted: so.Encrypted(), Emergency: so.Emergency(),
+    /* … RFSS/Site, priority, demod mode, Phase 2 decode config … */
+}})
+```
+
+Two details preview later parts. A grant arriving *before* its identifier
+update isn't dropped — it waits in `pendingGrants` and publishes when the
+band plan fills in (Part 5 covers the band plan itself). And a grant on a
+channel advertised via IDEN_UP_TDMA (0x33) ships as
+`Protocol: "p25-phase2"` so the voice composer routes it into the H-DQPSK
+chain — the first place the Phase 1/Phase 2 twins meet (Part 7). What the
+engine does with the event — dedup, voice pool, recording — is the
+[grant-to-call story]({{ '/blog/deep-dives/trunking-engine-01-grant-to-call/' | relative_url }})
+and its
+[grants deep dive]({{ '/blog/deep-dives/trunking-engine-03-grants/' | relative_url }});
+this layer's job ends at a well-formed `trunking.Grant`.
+
+## Names that lie
+
+The MFID byte partitions the opcode space: under MFID 0x90 (Motorola) or
+0xA4 (Harris), the same 6-bit value means something entirely different —
+patch-group adds, dynamic regroups, talker aliases (`tsbk_vendor.go`). Which
+makes logging a trap with teeth: **never render a vendor opcode through the
+standard `Opcode.String()` map.** MFID 0x90 opcode 0x00 is a Motorola
+patch-group message; the OSP map would happily label it `GRP_V_CH_GRANT`,
+and an operator chasing a grant bug would be reading fiction. The same rule
+covers AMBT opcodes (Part 4): `ambtOpcodeLabel` names only the three AMBT
+forms GopherTrunk decodes and renders everything else numerically —
+`AMBT(0x00)`, never a borrowed name — pinned by a test asserting exactly the
+mislabel case. A wrong-but-plausible name in a log is worse than a hex
+number.
+
+## The SCCB bug: a round-trip test that lied
+
+Opcode 0x39, the Secondary Control Channel Broadcast, announces the site's
+alternate control channels — two (channel, service class) pairs in eight
+payload bytes. The parser read channel B from `p[4:6]`. The correct offset is
+`p[5:7]`:
+
+```go
+// internal/radio/p25/phase1/opcodes.go (shape) — the fixed layout
+//	bytes 2-3 : secondary control channel A (4-bit ID + 12-bit number)
+//	byte 4    : system service class A
+//	bytes 5-6 : secondary control channel B (4-bit ID + 12-bit number)
+//	byte 7    : system service class B
+cA := binary.BigEndian.Uint16(p[2:4])
+cB := binary.BigEndian.Uint16(p[5:7]) // was p[4:6] — one byte early
+```
+
+Reading a byte early spliced service class A into the channel field and
+produced a **phantom secondary control channel** on every real broadcast. And
+the round-trip test was green the whole time, because
+`AssembleSecondaryControlChannelBroadcast` encoded the *same wrong layout* —
+parse(assemble(x)) == x held perfectly for a format that existed nowhere but
+this codebase. It is the purest small specimen of the
+[self-consistent-synthetic trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}):
+a test whose encoder and decoder share an assumption validates it against
+nothing. The fix — and the standing rule — is to pin parsers with **literal
+byte vectors cross-checked against an independent decoder** (here SDRTrunk's
+field offsets), the discipline
+[From Spec to Shipping Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+develops in full. `tsbk_test.go` now carries the mnemonic and layout pins
+that would have caught this on day one.
+
+### How the workhorse shaped the Go code
+
+- **Parse and validate are one call.** `ParseTSBK` returns the parsed block
+  *and* the CRC verdict together — and returns the partial parse on failure,
+  so diagnostics can log what almost arrived.
+- **The encoder exists for tests, and that cuts both ways.** `AssembleTSBK` /
+  `EncodeTSBKChannel` make synthetic streams easy — which is exactly why
+  layout facts need literal vectors from outside the codebase.
+- **Metrics ride along.** Every decode carries its Viterbi metric, so a
+  marginal channel is visible per block (`TSBKErrorRate`, issue #858's
+  frame-error instrument) instead of averaged into folklore.
+- **The vendor split is structural.** `IsVendorMFID` gates every vendor
+  parse, and vendor decoding lives in its own file — the namespace boundary
+  in the spec is a file boundary in the tree.
+
+## Where this goes next
+
+TSBKs are single blocks — 8 payload bytes, take it or leave it. Some systems
+put their richest data where a single block can't hold it: multi-block PDUs
+on the control channel, which GopherTrunk once logged as `non-control DUID
+duid=PDU` and threw away.
+[Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})
+is the story of learning to read them — and why one neighbour site out of
+twelve was ever visible before.
+
+## FAQ
+
+**How many TSBKs per second does a control channel send?**
+The channel runs at 9.6 kbps, and a 98-dibit block plus its share of FSW/NID
+overhead works out to a few dozen blocks per second — a busy site fills
+nearly all of them. That density is why decoding all three blocks per TSDU
+matters.
+
+**What does the Viterbi path metric actually tell me?**
+How far the received dibits sat from the nearest valid trellis path — 0
+means the channel was clean, small values mean corrected noise, large values
+mean the decoder guessed hard. GopherTrunk treats it as advisory (the CRC
+decides) but logs it, because a rising metric across blocks is the earliest
+sign of a degrading control channel.
+
+**Why did the wrong CRC variant ever work in tests?**
+Because the tests generated their own TSBKs with the same wrong variant —
+encode and check agreed with each other, disagreeing only with the air. Same
+shape as the SCCB bug: round-trips validate consistency, not correctness.
+Only a real capture (Mt Anakie's 195/197 failure rate) exposed it.
+
+**Is the P (protected) bit the same as an encrypted call?**
+No — P marks encrypted *signalling* in the TSBK itself, which is rare on
+public-safety systems. Whether a granted *call* is encrypted arrives in the
+grant's service options (and later in the voice frames' encryption sync,
+Part 9); GopherTrunk stamps `Encrypted` onto the `trunking.Grant` from the
+service options at grant time.
+
+**What happens to a grant whose channel ID has no band-plan entry yet?**
+It parks in `pendingGrants` and publishes a `stage="no-bandplan"` decode
+error so the gap is measurable. When the matching IDEN_UP arrives, the
+pending grant drains through the normal path. On a healthy system that wait
+is seconds; a *persistent* no-bandplan counter usually means the operator's
+seeded band plan (or the site's identifier set) needs Part 5's attention.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: Frame Sync, the NID & What 'Locked' Means]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})
+· Next →
+[Part 4: Multi-Block Trunking — The PDU That Isn't Noise]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})

--- a/docs/_posts/2026-09-05-p25-end-to-end-03-tsbk-workhorse.md
+++ b/docs/_posts/2026-09-05-p25-end-to-end-03-tsbk-workhorse.md
@@ -186,9 +186,9 @@ into four working families:
 | Unit business | 0x28 GRP_AFF_RSP, 0x2C U_REG_RSP, 0x18 STS_UPDT, 0x1F CALL_ALRT | registration, affiliation, paging |
 
 `Opcode.String()` renders the canonical TIA mnemonic so logs read in spec
-terms, falling back to `OSP(0xNN)` for opcodes the decoder doesn't name.
-That method carries a scope rule we'll return to below: it is only
-meaningful for **standard** (MFID 0x00) outbound opcodes.
+terms, falling back to `OSP(0xNN)` for unnamed opcodes — with a scope rule
+we'll return to below: it is only meaningful for **standard** (MFID 0x00)
+outbound opcodes.
 
 ## From opcode to `trunking.Grant`
 

--- a/docs/_posts/2026-09-06-from-spec-to-shipping-04-conformance-harness.md
+++ b/docs/_posts/2026-09-06-from-spec-to-shipping-04-conformance-harness.md
@@ -1,0 +1,337 @@
+---
+title: "From Spec to Shipping, Part 4: The Conformance Harness — Bit-Identical or Bust"
+description: "Building a conformance harness against the ETSI EN 300 395-2 reference codec: one 137-bit bitstream into both decoders, zero PCM mismatches allowed, the LP64 Word32 gotcha that makes the reference itself lie, and why conformance at two layers brackets everything in between."
+category: deep-dives
+keywords: etsi reference codec conformance, bit exact vocoder test, acelp reference decoder, tetra en 300 395-2, fixed point codec port, word32 lp64 typedef long, skip guarded test harness, validate whole decode chain, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, acelp, vocoder, conformance, testing, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 4
+---
+
+*Part 4 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+pinned parsers with literal byte vectors — discrete facts, one field at a
+time. But a vocoder is tens of thousands of saturating fixed-point
+operations whose correctness only shows in the aggregate, and for that the
+vector becomes a stream and the assertion becomes absolute: feed your
+decoder and the reference the same bitstream and demand **bit-identical
+output**. This part builds that harness around GopherTrunk's clean-room
+TETRA ACELP decoder — and meets the build gotcha that makes the reference
+itself produce garbage on a modern machine.*
+
+> **TL;DR:** `internal/voice/acelp/etsi_reference_test.go` is the
+> authoritative check on GopherTrunk's TETRA vocoder: the ETSI EN 300 395-2
+> reference tools (`scoder`/`sdecoder`) produce a serial bitstream (int16
+> LE, **138 words per frame** — 1 BFI flag + 137 coded speech bits) and a
+> reference PCM file (**240 samples per frame**); the harness feeds the
+> same bits to GopherTrunk's `Decoder.Decode` and requires **zero sample
+> mismatches** — fixed-point integer maths means a faithful port matches
+> exactly, so "close" is failure. Two traps: build the reference with
+> `Word32` as a 32-bit int (on LP64 the default `typedef long` is 64-bit
+> and **every saturating op returns garbage**), and remember conformance
+> only covers the layer you tested — the class-2 CRC bug that silently
+> dropped every on-air TCH/S burst lived *outside* the vocoder, which is
+> why a second pass (`TestTETRAMultiSlotReplay`, a real cs16 capture to
+> per-slot audio) brackets the chain from the other end.
+
+**Key takeaways**
+
+- **Fixed-point references permit an exact assertion — take it.** The
+  reference codec is integer arithmetic with defined saturation; a faithful
+  port matches sample-for-sample, so the pass criterion is 0 mismatches,
+  not a similarity score that would hide systematic drift.
+- **The reference can lie if you build it wrong.** ETSI's basic ops assume
+  a 32-bit `long`; compiled untouched on LP64, saturation never fires and
+  the "reference" output is garbage. Validate the oracle before validating
+  against it.
+- **Skip-guarded harnesses keep CI honest and results reproducible.** The
+  test skips unless env vars point at reference vectors — CI stays green
+  without copyrighted ETSI sources in the tree, and anyone can re-run the
+  exact conformance pass locally.
+- **Conformance at one layer proves that layer only.** The vocoder passed
+  while on-air voice decoded nothing — the bug was in the channel coding
+  above it. Bracket the chain: bit-exact at the bottom, capture-replay at
+  the top, and a defect must live between two pinned surfaces.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Bit-exact conformance | same 137-bit frames → GT and ETSI ref → 0 PCM mismatches | `internal/voice/acelp/etsi_reference_test.go` (`TestETSIReferenceConformance`) |
+| Reference tools | `scoder` / `sdecoder` from EN 300 395-2 | ETSI distribution (copyrighted, not committed) |
+| Serial format | int16 LE, 138 words/frame: BFI + 137 bits | test doc comment; matches `Bits2prm_Tetra` |
+| Output alignment | reference `Post_Process` = saturating ×2 | `postProcessX2` in the harness |
+| The build gotcha | `Word32` must be 32-bit; LP64 `long` breaks saturation | test comment; GT mirror in `acelp/ops.go` (`maxWord32`) |
+| Second-layer pass | real cs16 IQ → receiver → TCH/S → per-slot PCM | `cmd/gophertrunk/tetra_multislot_replay_test.go` (`TestTETRAMultiSlotReplay`) |
+| The layer in between | TCH/S channel decode, class-2 CRC | `internal/radio/tetra/tch.go` |
+
+## In this post
+
+- **Why bit-identical, not "sounds right"** — what an exact assertion buys.
+- **The harness, end to end** — reference tools, serial format, the
+  comparison loop.
+- **The Word32 gotcha** — when the oracle itself is broken.
+- **Skip-guarded but reproducible** — copyrighted vectors and honest CI.
+- **Bracketing: conformance at two layers** — and the CRC bug that proved
+  why one layer is not enough.
+
+## Why bit-identical, not "sounds right"
+
+A vocoder invites the worst validation standard in engineering: play the
+output and listen. Speech is intelligible through astonishing amounts of
+systematic error — a wrong gain table, a swapped codebook, crushed
+high-band energy — so "sounds okay" bounds almost nothing. GopherTrunk has
+a measured case on file: the AMBE+2 3600×2450 decode produced perfectly
+intelligible speech with 4–10× less energy above 1 kHz than mbelib's decode
+of the *same* frames — content intact, spectrum systematically wrong, and
+only octave-band measurement against a reference made the deficit visible
+(the [vocoders guide]({{ '/vocoders.html' | relative_url }}) documents it).
+
+EN 300 395-2 removes the excuse for that standard entirely, because the
+codec it defines is **fixed-point integer arithmetic** — every multiply,
+add and shift saturates to defined 16- and 32-bit bounds. There is no
+floating-point wiggle, no platform rounding: a faithful implementation
+produces the same int16 as the reference at every sample index, forever.
+So the harness demands exactly that:
+
+```go
+// internal/voice/acelp/etsi_reference_test.go (shape) — TestETSIReferenceConformance
+dec := NewDecoder()
+for f := 0; f < nFrames; f++ {
+    bfi := serial[base] != 0          // word 0: bad-frame indicator
+    /* … words 1..137 → bits … */
+    out := dec.Decode(bits, bfi)      // 240 samples
+    for i, s := range out {
+        got := postProcessX2(s)       // mirror the reference Post_Process
+        if got != ref[f*pcmPerFrame+i] {
+            mismatches++
+        }
+    }
+}
+if mismatches != 0 {
+    t.Errorf("ACELP decode diverges from the ETSI reference: %d/%d samples differ …")
+}
+```
+
+**Zero.** Not a correlation threshold, not an SNR floor. The moment the
+criterion is exact, every class of subtle bug — an off-by-one in a table, a
+saturation applied one op too late, an interpolation half-done — becomes a
+loud, countable failure with a first-bad-frame index to start debugging
+from. The harness logs `mismatches`, `maxAbsDiff` and `firstBadFrame` for
+exactly that reason: a conformance failure should arrive with its own
+triage data.
+
+One alignment detail earns its comment: the reference decoder's
+`Post_Process` applies a saturating ×2 to every output sample after
+`Decod_Tetra`. GopherTrunk omits that scaling in production, so the harness
+applies `postProcessX2` to GT's output before comparing — the *harness*
+absorbs representation differences, keeping the shipped decoder clean and
+the comparison exact.
+
+## The harness, end to end
+
+The moving parts, and the one contract binding them:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="The conformance harness: one serial bitstream of 138 int16 words per frame, produced by the ETSI scoder, feeds two decoders in parallel — the ETSI sdecoder reference and GopherTrunk's clean-room ACELP decoder. The reference emits 240 PCM samples per frame; GopherTrunk's output passes through a saturating times-two post-process, then both meet a comparator whose only passing verdict is zero mismatched samples.">
+  <rect x="230" y="10" width="220" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="340" y="24" text-anchor="middle" fill="currentColor" font-size="10">serial.bin — int16 LE, 138 words/frame</text>
+  <text x="340" y="38" text-anchor="middle" fill="var(--fg-muted)" font-size="10">word 0 = BFI · words 1..137 = coded bits</text>
+  <line x1="290" y1="44" x2="180" y2="78" stroke="currentColor"/><polygon points="184,72 174,80 186,84" fill="currentColor"/>
+  <line x1="390" y1="44" x2="500" y2="78" stroke="currentColor"/><polygon points="494,72 506,80 494,84" fill="currentColor"/>
+  <rect x="60" y="82" width="240" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="180" y="100" text-anchor="middle" fill="currentColor" font-size="10">ETSI sdecoder (reference C)</text>
+  <text x="180" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="10">Word32 MUST be 32-bit — LP64 breaks it</text>
+  <rect x="390" y="82" width="230" height="44" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="505" y="100" text-anchor="middle" fill="currentColor" font-size="10">GT clean-room decoder (Go)</text>
+  <text x="505" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="10">internal/voice/acelp — Decoder.Decode</text>
+  <line x1="180" y1="126" x2="180" y2="160" stroke="currentColor"/><polygon points="176,158 180,166 184,158" fill="currentColor"/>
+  <line x1="505" y1="126" x2="505" y2="140" stroke="currentColor"/><polygon points="501,138 505,146 509,138" fill="currentColor"/>
+  <rect x="430" y="146" width="150" height="22" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="505" y="161" text-anchor="middle" fill="var(--fg-muted)" font-size="10">postProcessX2 (saturating ×2)</text>
+  <line x1="505" y1="168" x2="505" y2="180" stroke="currentColor"/>
+  <line x1="180" y1="166" x2="180" y2="180" stroke="currentColor"/>
+  <rect x="150" y="180" width="380" height="34" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="340" y="194" text-anchor="middle" fill="var(--accent)" font-size="10">comparator: 240 int16 samples/frame, every frame</text>
+  <text x="340" y="208" text-anchor="middle" fill="var(--accent)" font-size="10" font-weight="bold">pass = 0 mismatches — bit-identical or bust</text>
+  <text x="340" y="232" text-anchor="middle" fill="var(--fg-muted)" font-size="10">logged on failure: mismatches, maxAbsDiff, firstBadFrame — a failure arrives with its own triage data</text>
+</svg>
+<figcaption>One bitstream, two decoders, one comparator — and the only passing verdict is zero, because fixed-point arithmetic leaves nothing to round.</figcaption>
+</figure>
+
+The serial format is the contract: int16 little-endian, 138 words per
+frame — word 0 the bad-frame indicator, words 1–137 the coded speech bits,
+exactly what the reference's `Bits2prm_Tetra` reads and what GT's
+`Decoder.Decode` consumes. Because the format is the reference's own, the
+same `serial.bin` drives both sides with no adapter that could smuggle in
+an assumption — [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+rule about generated fixtures, applied at stream scale. Feeding BFI frames
+through the same path also exercises the error-concealment machinery under
+the same exact criterion — muted and interpolated frames must match too.
+
+## The Word32 gotcha: validate the oracle
+
+The reference C code was written when `long` meant 32 bits. Its `Word32`
+is `typedef long`, and every saturating basic op — `L_add`, `L_sub`, the
+lot — detects overflow by wrapping behavior at the 32-bit boundary. Compile
+it unmodified on a 64-bit Linux host (LP64: `long` is 64-bit) and nothing
+overflows where the algorithm expects: **every saturating op returns
+garbage**, silently, while the tools run happily and produce plausible
+PCM. The harness's doc comment carries the fix because it cost real time:
+build with `Word32` as a 32-bit `int` — edit the typedef or build `-m32`.
+
+The general lesson outranks the specific one: **a reference implementation
+is itself a build artifact that can be wrong on your machine.** Before
+trusting an oracle, make it prove itself — the ETSI encoder emits its own
+locally-decoded synthesis (`synth_local.pcm`), so encoder and decoder can
+be cross-checked against each other before either judges your port. A
+conformance harness that skips this step can "fail" a correct decoder
+against a broken reference and send you debugging working code — or worse,
+"pass" a broken pair.
+
+GopherTrunk's own side of that arithmetic lives in
+`internal/voice/acelp/ops.go`: explicit `maxWord32`/`minWord32` saturation
+in Go, where int32 is int32 on every platform — one of the quiet arguments
+for the pure-Go port over binding the reference
+([Part 5]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})
+takes up the clean-room side of that decision).
+
+## Skip-guarded but reproducible
+
+The ETSI sources and vectors are copyrighted and not committed, so the
+test skips unless `GT_ETSI_SERIAL` and `GT_ETSI_REF` point at files
+produced by the reference tools. That single design choice buys three
+things at once:
+
+- **CI stays green and honest** — no fixture of dubious licensing in the
+  tree, no silently-degraded approximation of the check.
+- **Anyone can reproduce the authoritative result** — the doc comment
+  gives the exact `scoder`/`sdecoder` invocations; the claim "bit-exact
+  against the reference" is a command away from re-verification, not
+  folklore.
+- **The harness doubles as a field instrument** — the same env-var pattern
+  scales up to capture replays (`GT_TETRA_IQ`, `GT_TETRA_DMO_IQ`, …) that
+  operators run against their own recordings, a practice
+  [Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+  builds a whole workflow on.
+
+The one discipline a skip-guard demands: someone must actually run it.
+A skipped conformance test asserts nothing, so the result gets recorded
+where the next engineer will find it — in GopherTrunk's case, the
+project's institutional notes state the vocoder cleared two independent
+conformance passes, with the harness names attached
+([TETRA End to End Part 7]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }})
+walks through the runs).
+
+## Bracketing: conformance at two layers
+
+Here is the trap conformance sets for you: the vocoder passes bit-exact,
+so when on-air voice produces silence, the vocoder is *ruled out* — and
+the temptation is to conclude the whole voice path is fine. GopherTrunk
+lived the counterexample. With the ACELP decoder conformance-clean, real
+TETRA calls still yielded almost nothing, because the **class-2 CRC in the
+TCH/S channel decode** (`internal/radio/tetra/tch.go`, one layer *above*
+the vocoder) had been implemented as a generator-polynomial LFSR when the
+real check is a fixed parity-check matrix — the reference's `TAB_CRC`
+tables. Synthetic round-trips passed (both sides shared the wrong CRC —
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+villain again), while every on-air burst was silently dropped. The story
+is told in full in
+[TETRA End to End Part 5]({{ '/blog/deep-dives/tetra-end-to-end-05-tchs-traffic-channel/' | relative_url }}).
+
+The structural answer is a **second conformance pass at a different
+layer**:
+
+| | Bottom pass | Top pass |
+|---|---|---|
+| Harness | `TestETSIReferenceConformance` | `TestTETRAMultiSlotReplay` |
+| Input | reference `serial.bin` bitstream | real cs16 IQ capture (`GT_TETRA_IQ`) |
+| Oracle | ETSI reference decoder | the air: CC grant timeslots vs per-slot audio |
+| Assertion | 0 PCM mismatches | CRC-valid speech clustered on granted slots |
+
+The replay harness runs the receiver, the traffic extractor, the TCH/S
+channel decode and the vocoder end to end, printing a per-slot activity
+timeline to cross-check against the control channel's grants. With the
+bottom pinned bit-exact and the top pinned against real air, a defect has
+nowhere to live except *between* the two pinned surfaces — and the
+diagnosis rule falls out for free: **when "voice doesn't decode" but the
+vocoder unit tests pass, suspect the channel coding — CRC, interleave,
+reorder — and validate the whole chain, not parts**
+([Voice Coding Part 12]({{ '/blog/deep-dives/voice-coding-12-calibration-testing/' | relative_url }})
+applies the same bracketing to the MBE stack).
+
+### How that principle shaped the Go code
+
+- **The exactness lives in the assertion, not the prose.** `mismatches != 0`
+  fails the test; no tolerance parameter exists to loosen quietly.
+- **Representation differences are absorbed by the harness.**
+  `postProcessX2` mirrors the reference's output stage in the *test*, so
+  the shipped decoder carries no reference-shaped warts.
+- **Oracles are documented as build artifacts.** The Word32 note rides in
+  the test's doc comment — the next person to build the reference on LP64
+  hits the warning before the garbage.
+- **Every conformance claim names its harness.** "Bit-exact" appears in
+  the notes only alongside `TestETSIReferenceConformance` and
+  `TestTETRAMultiSlotReplay` — a claim without a re-runnable check is
+  treated as unverified, the standard
+  [/learn/testing/]({{ '/learn/testing/' | relative_url }}) builds toward.
+
+## Where this goes next
+
+This harness runs a copyrighted reference *as a binary oracle* while
+GopherTrunk ships a clean-room Go implementation — and that boundary is
+load-bearing, legally and technically.
+[Part 5]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})
+draws the line in practice: implementing from the spec, using other
+people's decoders as validation oracles rather than source to translate,
+and the licensing hygiene that keeps test-only dependencies out of the
+shipped binary.
+
+## FAQ
+
+**What if my target codec has no reference implementation?**
+Fall back one rung on Part 2's ladder: a proven decoder becomes a
+behavioral reference (GopherTrunk uses mbelib/DSD-FME this way for
+IMBE/AMBE, comparing octave-band energy rather than bits, since MBE
+synthesis is floating-point). The assertion weakens from bit-identical to
+measured-and-bounded — document that difference, because it changes what
+a "pass" proves.
+
+**Why not commit the reference vectors so CI runs the conformance test?**
+Licensing — the ETSI sources and their outputs are copyrighted. The
+skip-guard pattern is the honest compromise: CI runs everything it can
+own, and the authoritative pass is reproducible by anyone holding the
+reference, with the exact commands documented in the test.
+
+**Is bit-identical ever the wrong goal?**
+For floating-point algorithms, yes — platform rounding makes exactness
+brittle, and a bounded-error criterion is correct. But for fixed-point
+codecs, exact is *easier* to maintain than approximate: any nonzero
+mismatch count is a bug with a frame number attached, and there is no
+threshold to argue about when one appears.
+
+**How do I debug a conformance failure with thousands of mismatches?**
+Start at `firstBadFrame` — fixed-point decoders carry state, so the first
+divergence is the real defect and everything after may be cascade. Then
+bisect by stage: the reference tools print or can be made to print
+intermediate parameters (LSPs, gains, codebook indices), so you can find
+the first *parameter* that differs, not just the first sample.
+
+**Does passing conformance mean the vocoder work is done?**
+It means one layer is done. The class-2 CRC story is the standing proof
+that a conformance-clean vocoder can sit inside a voice path that decodes
+nothing — and the reverse trap, green synthetics above a broken layer, is
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})'s
+whole subject. Bracket with an end-to-end pass, then let real captures
+referee.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: Literal Vectors, Not Round-Trips]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+· Next →
+[Part 5: Clean-Room Rules — Reading Without Copying]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})

--- a/docs/_posts/2026-09-06-operator-cookbook-04-tetra-tmo.md
+++ b/docs/_posts/2026-09-06-operator-cookbook-04-tetra-tmo.md
@@ -1,0 +1,318 @@
+---
+title: "The Operator's Cookbook, Part 4: A TETRA TMO Rig"
+description: A complete GopherTrunk build for a TETRA trunked-mode network — one dongle camped on a 25 kHz control carrier, the CC equalizer that now ships enabled, MCC/MNC identity, four-slot same-carrier voice through the clean-room ACELP vocoder, and the sync-loss troubleshooting that came from real field logs.
+category: tutorials
+keywords: tetra scanner setup, tetra sdr decoder, tetra tmo trunked mode, tetra control channel lock, tetra acelp voice decode, tetra mcc mnc, pi/4 dqpsk sdr, tetra encrypted network metadata, gophertrunk cookbook
+tags: [operator-cookbook, tetra, tmo, dqpsk, acelp, config]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 4
+---
+
+*Part 4 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 3]({{ '/blog/tutorials/operator-cookbook-03-conventional-dmr-two-slots/' | relative_url }})
+squeezed two conversations out of one conventional DMR repeater. This part
+leaves the 4-level-FSK family entirely for TETRA — π/4-DQPSK, a downlink that
+never stops transmitting, and the protocol GopherTrunk has spent more
+hard-won engineering on than any other. The payoff for you: the recipe is
+*short*, because the difficult parts — the control-channel equalizer, the
+clean-room ACELP vocoder, the sync-loss watchdogs — now ship as defaults.*
+
+> **TL;DR:** `protocol: tetra` plus the cell's main-carrier frequency in
+> `control_channels` is a working TETRA TMO rig on one `role: control`
+> dongle: GopherTrunk channelizes the 25 kHz carrier to 144 kHz, runs the
+> **blind CMA equalizer that's now default on the CC path** (it lifted a
+> marginal real-world control channel from ~12% to ~100% CRC-clean BSCH),
+> decodes the cell identity, and registers **four same-carrier voice taps** —
+> one per TDMA slot — feeding the clean-room ACELP vocoder
+> (`vocoder=tetra-acelp`). Healthy looks like
+> `tetra cc locked freq=… mcc=… mnc=… la=…` and calls in the browser;
+> the classic failure signature (locked but silent, `bsch_ok` high with
+> `sch_pdus=0`) now self-heals via the payload watchdog.
+
+**Key takeaways**
+
+- **TETRA is a different physical layer, same recipe.** π/4-DQPSK at 18000
+  symbols/s in a 25 kHz channel — nothing like P25/DMR's FSK — but the config
+  shape you learned in Parts 1–3 carries over unchanged.
+- **The equalizer is on because real networks needed it.** Field captures
+  showed marginal control channels (~10 dB in-channel SNR) locking but
+  decoding ~22% of their sync bursts; the default-on CMA equalizer recovers
+  them. You configure nothing.
+- **One carrier can be the whole cell.** A single-carrier TETRA site keeps
+  voice on the control carrier's other TDMA slots, so the same-carrier taps
+  give you up to four concurrent calls with no voice radio.
+- **Encrypted networks still yield the map.** TEA-encrypted voice is not
+  decryptable, but the control channel is clear — talkgroups, identities and
+  activity all decode. Know what your local law permits before you camp one.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| System definition | trunked TETRA cell, camped CC | `protocol: tetra`, `control_channels` |
+| Cell identity | MCC / MNC / location area, decoded + displayed | `tetra cc locked` log line; Systems panel — [MNI]({{ '/reference/tetra-mobile-network-identity/' | relative_url }}) |
+| CC equalizer | blind CMA, default-on for the TETRA CC path | nothing to configure; [the equalizer story]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }}) |
+| Voice | four same-carrier slot taps → ACELP | automatic; [ACELP]({{ '/reference/acelp/' | relative_url }}), [clean-room vocoder]({{ '/blog/deep-dives/tetra-end-to-end-06-clean-room-acelp/' | relative_url }}) |
+| Decode health | per-interval counters at debug | `tetra: decode status` (`bsch_ok`, `sch_pdus`, `grants`); cadence via `tetra_status_interval_secs` |
+| Talkgroup names | GSSIs in the same CSV format | `talkgroup_file` |
+| Is TETRA for you? | region + hardware reality check | [TETRA scanner guide]({{ '/tetra-scanner/' | relative_url }}) |
+
+## In this post
+
+- **What you're building, and where it works** — region and legality, briefly.
+- **The shopping list** — Part 1's again, with one frequency-band caveat.
+- **The config** — two meaningful lines.
+- **First run — what healthy looks like** — lock, identity, slots, voice.
+- **When it doesn't work** — sync loss, carrier offset, encryption.
+- **Variations** — multi-carrier cells, status cadence, capture taps.
+
+## What you're building, and where it works
+
+TETRA is the trunked-radio standard of most of the world outside North
+America: public safety across Europe, plus transit, utilities, ports and
+airports on several continents. If you're in the US, your local
+public-safety system is not TETRA — but TETRA gear does show up in
+commercial and industrial use, and [Part 5]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }})'s
+direct-mode radios travel everywhere. One sentence on law, kept factual:
+countries differ sharply on whether receiving public-safety traffic is legal
+at all, and some prohibit even possession of a capable receiver — check your
+jurisdiction before you camp a government network. The
+[TETRA scanner guide]({{ '/tetra-scanner/' | relative_url }}) covers the
+landscape, including why almost no consumer hardware scanner decodes TETRA
+voice — which is precisely why this recipe exists.
+
+Technically, a TETRA cell's **main carrier** is this build's target: a
+25 kHz channel whose downlink transmits continuously, four TDMA slots per
+frame, control signalling on one and — on single-carrier sites — voice calls
+on the others. GopherTrunk channelizes it to 144 kHz (8 samples per symbol),
+demodulates the π/4-DQPSK, and decodes everything from the sync bursts up.
+The physics of that carrier fills its own series opener,
+[TETRA End to End Part 1]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }});
+the cookbook just points a dongle at it.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the TETRA TMO rig: antenna and RTL-SDR feed a downconverter to 144 kilohertz; a highlighted default-on CMA equalizer feeds the pi over four DQPSK receiver; the decoded dibit stream splits into the control-channel decoder reading BSCH and SCH signalling on slot one, and three same-carrier voice slot taps feeding the ACELP vocoder; outputs are the cell identity, recordings and the web console">
+  <rect x="8" y="104" width="60" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="38" y="124" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="68" y1="120" x2="92" y2="120" stroke="currentColor"/>
+  <rect x="92" y="104" width="70" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="127" y="124" text-anchor="middle" fill="currentColor" font-size="10">RTL-SDR</text>
+  <line x1="162" y1="120" x2="186" y2="120" stroke="currentColor"/>
+  <rect x="186" y="104" width="78" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="225" y="118" text-anchor="middle" fill="currentColor" font-size="10">DDC</text>
+  <text x="225" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="9">144 kHz</text>
+  <line x1="264" y1="120" x2="288" y2="120" stroke="currentColor"/>
+  <rect x="288" y="100" width="96" height="40" rx="4" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="336" y="116" text-anchor="middle" fill="var(--accent)" font-size="10">CMA equalizer</text>
+  <text x="336" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="9">default ON</text>
+  <line x1="384" y1="120" x2="408" y2="120" stroke="currentColor"/>
+  <rect x="408" y="100" width="100" height="40" rx="4" fill="none" stroke="currentColor"/>
+  <text x="458" y="116" text-anchor="middle" fill="currentColor" font-size="10">π/4-DQPSK RX</text>
+  <text x="458" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="9">18000 sym/s</text>
+  <line x1="508" y1="112" x2="546" y2="52" stroke="var(--accent)"/>
+  <line x1="508" y1="128" x2="546" y2="180" stroke="currentColor"/>
+  <rect x="546" y="30" width="124" height="44" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="608" y="47" text-anchor="middle" fill="var(--accent)" font-size="10">CC decode (slot 1)</text>
+  <text x="608" y="61" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BSCH → MCC/MNC · grants</text>
+  <rect x="546" y="158" width="124" height="58" rx="4" fill="none" stroke="currentColor"/>
+  <text x="608" y="175" text-anchor="middle" fill="currentColor" font-size="10">voice slot taps ×4</text>
+  <text x="608" y="189" text-anchor="middle" fill="var(--fg-muted)" font-size="9">TCH/S → ACELP</text>
+  <text x="608" y="203" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ WAV + web console</text>
+  <text x="230" y="60" fill="var(--fg-muted)" font-size="10">the downlink never stops: lock quality is</text>
+  <text x="230" y="74" fill="var(--fg-muted)" font-size="10">measurable every frame, so the decode-status</text>
+  <text x="230" y="88" fill="var(--fg-muted)" font-size="10">counters below are a continuous health meter</text>
+  <text x="340" y="240" text-anchor="middle" fill="var(--fg-muted)" font-size="10">a single-carrier cell keeps voice on the control carrier's own slots — one dongle carries all four</text>
+</svg>
+<figcaption>The TETRA chain: the equalizer sits ahead of the receiver by default — on a real marginal control channel it was the difference between ~12% and ~100% CRC-clean sync bursts.</figcaption>
+</figure>
+
+## The shopping list
+
+The [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})
+hardware transfers whole: one ~$35 RTL-SDR, an antenna, a computer. Two
+caveats. TETRA lives mostly at 380–430 MHz (public safety and commercial),
+so extend the kit whip accordingly, and expect ACELP + equalizer + four
+potential slot decodes to want more CPU than a P25 rig — any recent laptop
+is fine; the smallest Pis will feel it. If your target network sits at the
+weak end, the [Analog Edge]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})
+antenna and feedline parts are the upgrade path; the numbers below tell you
+whether you need them.
+
+## The config
+
+Every key verified against `config.example.yaml`:
+
+```yaml
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000001"
+      role: control
+      gain: "auto"
+
+trunking:
+  systems:
+    - name: "Harbour-TETRA"
+      protocol: tetra
+      control_channels:
+        - 419_512_500        # the cell's main carrier
+      talkgroup_file: "../config/talkgroups-tetra.csv"   # optional (GSSIs)
+```
+
+That's the whole rig. Things you might expect to configure and don't: the
+144 kHz channel rate (per-protocol, automatic), the equalizer (default-on for
+the TETRA CC path), the colour code for descrambling (recovered from the
+BSCH), and voice devices (four same-carrier slot taps are registered for
+every TETRA system automatically). The optional
+`tetra_status_interval_secs` sets how often the decode-status counters
+accumulate before logging — leave it defaulted until the troubleshooting
+table sends you there. Talkgroups in TETRA are GSSIs; the CSV format is the
+same `Decimal`/`Alpha Tag` shape as every other protocol's.
+
+## First run — what healthy looks like
+
+Start the daemon with `log.level: debug` for the first session — TETRA's
+continuous downlink makes the debug stream genuinely informative rather than
+spammy. The lock line carries the decoded network identity:
+
+```
+INF tetra cc locked freq=419512500 mcc=262 mnc=1023 la=2101 system=Harbour-TETRA
+```
+
+`mcc`/`mnc` are the [Mobile Network Identity]({{ '/reference/tetra-mobile-network-identity/' | relative_url }})
+— country code and network — and they appear in the web Systems panel too;
+check them against what you expect for the network, because a strong adjacent
+cell is a real possibility (see the table). Then the five-second heartbeat:
+
+```
+DBG tetra: decode status system=Harbour-TETRA locked=true carrier_off_hz=-412.3 baud=18000 sb_bursts=38 bsch_ok=37 bsch_fail=1 sysinfo=37 sch_pdus=214 sch_pdus_fail=6 grants=3 colour_code=27
+```
+
+Read it like a meter: `bsch_ok` near `sb_bursts` means sync is healthy;
+`sch_pdus` climbing means the signalling payload is decoding (this is the
+number that matters — more below); `grants` means traffic. When a call goes
+out, the composer announces the slot-tap chain and the recorder does its
+usual thing with a TETRA-specific vocoder name:
+
+```
+INF composer: tetra voice follow started — TCH/S decode + ACELP vocoder serial=cc:same-carrier:2 group=61432 timeslot=2 ...
+INF recorder: call started ... tg=61432 ... vocoder=tetra-acelp
+```
+
+The voice you hear came through a clean-room ACELP implementation validated
+bit-identical against the ETSI EN 300 395-2 reference codec — the
+[conformance story]({{ '/blog/deep-dives/tetra-end-to-end-07-etsi-conformance/' | relative_url }})
+is worth reading once, because it's why "TETRA voice sounds wrong" almost
+never means the vocoder.
+
+## When it doesn't work
+
+TETRA's troubleshooting rows are unusually well-grounded: most came from
+multi-hour operator field logs, diagnosed in the
+[sync-loss deep dive]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }}).
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No lock at all | wrong frequency, or the carrier isn't TETRA | `gophertrunk hunt -candidates` identifies it; TETRA carriers are 25 kHz and continuously keyed — easy to spot on the Spectrum panel |
+| Locks, drops, `tetra: dsp resync (signal-time decode drought…)`, re-hunts | weak signal — the marginal regime. Field captures split cleanly: ~18 dB in-channel SNR decodes ~100% of BSCH, ~10 dB locks but decodes ~22% and storms resyncs | The equalizer already mitigates this; the rest is RF — antenna, feedline, siting. Raising software knobs will not help; raising the signal will |
+| `bsch_ok` healthy, `sch_pdus=0`, no traffic ever | the "locked but deaf" signature — historically the AFC latching a wrong ±4.5 kHz alias bucket | Self-healing now: the payload watchdog forces a resync after 12 s of lock without payload and escalates to a re-hunt. If you still see it persist, that's a capture worth reporting |
+| `ccdecoder: control carrier offset far from configured frequency` (issue #815) | you've locked an adjacent cell's stronger carrier, or the tuner is badly mistuned | Check the reported MCC/MNC/LA against your target; set the device `ppm`. The WARN requires the offset to persist 10 s, so it isn't estimator jitter |
+| MCC/MNC in the lock line looks absurd | one corrupted sync burst can't rewrite identity — changes need two consecutive agreeing decodes — so a stable absurd value means you're genuinely on a different network | Believe the decoder; re-check which carrier you camped |
+| Calls appear, recordings are silent or missing, talkgroups decode fine | the network encrypts voice (TEA air-interface encryption) | Nothing to fix: GopherTrunk decodes all clear signalling — talkgroups, identities, activity — but does not decrypt TETRA. Per-system `encrypted_calls: mode: metadata` keeps voice taps free |
+| Garbled voice on an otherwise-strong signal | multipath/ISI on the traffic slots | The voice path runs its own equalizer; if it persists, capture IQ — the [soft-decision + equalizer work]({{ '/blog/deep-dives/tetra-end-to-end-09-equalizer-voice-path/' | relative_url }}) roughly doubled yield on exactly such captures |
+
+The second row carries this series' standing RF sermon. The equalizer, the
+soft-decision decoding, the watchdogs — all of them widen the marginal band,
+none of them repeal it. **The decoder can only be as good as the samples**,
+and the 10-vs-18 dB split above is what that abstraction costs in concrete
+numbers on a real network.
+
+### How this recipe shapes operator practice
+
+- **`sch_pdus` is the truth; `bsch_ok` is just the handshake.** Sync bursts
+  survive conditions that kill payload. A rig is healthy when payload
+  counters climb, not when lock flags are green.
+- **Identity is a checksum for your config.** MCC/MNC/LA in the lock line
+  either match your intended network or you're camped somewhere else — check
+  it on day one, before you name a single talkgroup.
+- **Defaults encode field experience.** Every default this recipe leans on —
+  equalizer, watchdogs, confirmation thresholds — exists because an operator's
+  log demanded it. Overriding them is for A/B tests, not setup.
+
+## Variations
+
+- **Multi-carrier cells.** Bigger sites put voice on secondary carriers the
+  same-carrier taps can't reach. Add a second dongle as `role: voice` and
+  off-carrier grants bind it automatically — the same spill-over pattern as
+  Parts 1–2.
+- **Status cadence.** `tetra_status_interval_secs: 30` calms the debug
+  heartbeat for long soak sessions; the counters accumulate over the window
+  either way.
+- **Capture-on-failure.** `baseband.auto_record` with `on_cc_sync_loss: true`
+  and `tap: ddc` writes a small 144 kHz IQ capture at the exact moment a
+  locked CC loses sync — the feature the sync-loss investigation was solved
+  with, and the single best thing you can attach to a TETRA bug report.
+- **Pre-stripped fixtures.** The `tetra_channel` / `tetra_channel_coding` /
+  `tetra_colour_code` opt-out keys exist for feeding pre-decoded capture
+  files, not live air — leave them alone on a real rig.
+
+## Where this goes next
+
+TMO assumed infrastructure: a base station, a cell, a downlink that never
+stops. [Part 5]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }})
+scans TETRA radios talking **directly to each other** — Direct Mode, where
+there is no control channel, no talkgroup in the grant, and a colour-code
+recovery problem interesting enough that the rig solves it statistically.
+It's the newest and most honestly-caveated recipe in the series.
+
+## FAQ
+
+**Can an RTL-SDR really decode TETRA voice?**
+Yes — a 25 kHz π/4-DQPSK carrier is comfortably within an RTL-SDR's
+bandwidth and dynamic range, and GopherTrunk's TETRA path (144 kHz channel
+rate, CMA equalizer, soft-decision channel decoding, clean-room ACELP) was
+developed and validated on exactly such captures. Voice quality tracks
+signal quality; the equalizer buys real margin but not miracles.
+
+**What do MCC and MNC mean in the TETRA lock line?**
+Mobile Country Code and Mobile Network Code — together the Mobile Network
+Identity that names the network, like a cellular PLMN. GopherTrunk decodes
+them from the broadcast sync channel and shows them in the log and the
+Systems panel; they're your first check that you locked the network you
+intended.
+
+**Can GopherTrunk decode encrypted TETRA networks?**
+It decodes everything that's clear — and on TEA-encrypted networks that's
+the entire control channel: talkgroups, subscriber activity, cell topology.
+Voice on such networks is not recoverable, and GopherTrunk performs no
+key recovery. The `encrypted_calls` per-system policy stops encrypted calls
+from tying up voice taps.
+
+**Why does GopherTrunk process TETRA at 144 kHz when the channel is 25 kHz?**
+144 kHz is a processing rate — 8 samples per symbol at 18000 symbols/s —
+not a bandwidth. Every protocol gets channelized to its own designed rate
+(the C4FM family gets 48 kHz); the receiver's filters and timing loops are
+sized from that constant, which is what makes the decode rate-invariant to
+whatever your dongle captured at.
+
+**Do I need a separate voice SDR for TETRA?**
+Not for a single-carrier cell: voice occupies the control carrier's other
+TDMA slots, and GopherTrunk registers four same-carrier slot taps per TETRA
+system automatically. Only multi-carrier sites — where grants point at
+secondary carriers — need a `role: voice` dongle for the overflow.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: One Repeater, Two Conversations — Conventional DMR]({{ '/blog/tutorials/operator-cookbook-03-conventional-dmr-two-slots/' | relative_url }})
+· Next →
+[Part 5: TETRA Direct Mode — Scanning DMO]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }})

--- a/docs/_posts/2026-09-06-p25-end-to-end-04-mbt-ambt.md
+++ b/docs/_posts/2026-09-06-p25-end-to-end-04-mbt-ambt.md
@@ -1,0 +1,313 @@
+---
+title: "P25 End to End, Part 4: Multi-Block Trunking — The PDU That Isn't Noise"
+description: Why a PDU on a P25 control channel is Multi-Block Trunking, not garbage — the AMBT header and data blocks with their two different CRCs, the neighbour sites and WACN that only arrive this way, and why a "MBT data CRC failed" line next to a clean decode is two frames, not a contradiction.
+category: deep-dives
+keywords: p25 multi-block trunking, ambt decode, p25 pdu control channel, p25 network status broadcast wacn, adjacent site status broadcast, p25 crc-32 pdu, op25 process_pdu, p25 neighbor sites missing, gophertrunk p25
+tags: [p25-end-to-end, p25, mbt, ambt, trunking, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 4
+---
+
+*Part 4 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice.
+[Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
+opened the TSBK, the single-block message that runs a trunked system. This
+part is about the messages that don't fit in a single block — and about a
+decoder that spent months logging its richest incoming data as noise. If your
+P25 site table shows one neighbour where another tool shows twelve, or a
+blank WACN on a system that certainly has one, this is almost certainly the
+layer you're missing.*
+
+> **TL;DR:** A PDU (DUID 0xC) on a P25 control channel is usually
+> **Multi-Block Trunking** — and GopherTrunk used to log every one as
+> `non-control DUID duid=PDU` and drop it. The cost, straight from the
+> operator report that exposed it: SDRTrunk listed **12 neighbour sites with
+> uplinks in 15 s** while GT showed **one** and "No Network Status Broadcast
+> yet". `mbt.go` now decodes the Alternate MBT (format 0x17, SAP 61): blocks
+> reuse the **TSBK 98-dibit trellis** exactly; the 12-octet header ends in
+> the same **augmented CRC-CCITT16** as a TSBK trailer, the concatenated data
+> blocks in a **CRC-32** — both validated against OP25's `process_PDU`. A
+> `p25: MBT data CRC failed` line whose identity fields match a decoded
+> broadcast is **two different frames** (the header carries its own CRC), and
+> an AMBT's explicit uplink channel resolves as plain base + spacing with
+> **no transmit offset**. An MBT decodes everything — but never locks the
+> channel.
+
+**Key takeaways**
+
+- **"Non-control DUID" was hiding the network map.** Many systems — notably
+  Motorola — broadcast Network Status (the sole WACN carrier), RFSS Status
+  and most of their neighbour list *only* in AMBT form. Dropping DUID 0xC
+  didn't lose exotic data; it lost the system's self-description.
+- **MBT blocks are TSBK blocks.** Same 196-bit, 1/2-rate trellis, same
+  interleave, same 98-dibit geometry — `DecodeMBTBlockChannel` reuses the
+  Part 3 pipeline wholesale. Only the CRC conventions differ.
+- **A failed-CRC line beside a clean decode is not a contradiction.** Every
+  identity field on the failure line comes from the *header* block, which
+  carries its own CCITT-16 and decoded clean; only a data block failed its
+  CRC-32. The broadcast repeats, so a clean copy usually logs nearby.
+- **Explicit uplink channels already encode the uplink.** An AMBT that names
+  an uplink (id, number) pair resolves via plain base + number·spacing — the
+  band plan's transmit offset must NOT be applied on top.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Header parse + CRC-16 | format/SAP/MFID/blocks/opcode, augmented CCITT | `internal/radio/p25/phase1/mbt.go` (`ParseMBTHeader`) |
+| Trunking-control gate | SAP 61, formats 0x17 (AMBT) / 0x15 | `mbt.go` (`MBTSAPTrunkingControl`, `IsTrunkingControl`) |
+| Block channel decode | reuses TSBK deinterleave + Viterbi | `mbt.go` (`DecodeMBTBlockChannel`) |
+| Data CRC-32 | poly 0x04C11DB7 over the block train | `mbt.go` (`ValidateMBTData`, `mbtCRC32`) |
+| AMBT broadcasts | Network/RFSS/Adjacent Status with uplinks | `mbt.go` (`ParseMBTNetworkStatusBroadcast` et al.) |
+| Dispatch + labelling | decode, census, never mislabel | `control.go` (`dispatchMBT`, `ambtOpcodeLabel`) |
+| Neighbour merge | TSBK + AMBT halves of one site | `network.go` (`NetworkModel.upsertNeighbor`) |
+
+## In this post
+
+- **The frame that got thrown away** — the operator's twelve-to-one gap.
+- **Anatomy of an MBT** — header, data blocks, and the reused trellis.
+- **Two CRCs, two verdicts** — and the log line that looks like a paradox.
+- **What only the AMBT carries** — WACN, uplinks, and the neighbour merge.
+- **The uplink rule** — base + spacing, no transmit offset.
+
+## The frame that got thrown away
+
+Part 2 established the lock rule: only a TSDU proves a control channel, and
+every other DUID gets a `non-control DUID` debug line. For voice DUIDs that
+line is correct and boring. For DUID 0xC it was a quiet catastrophe: on the
+reporting operator's system, the frames being logged as
+`non-control DUID duid=PDU` spam *were* the network data — SDRTrunk sitting
+on the same signal listed 12 neighbour sites with uplink frequencies inside
+15 seconds, while GopherTrunk showed one neighbour and "No Network Status
+Broadcast yet", with no WACN at all.
+
+The explanation is a spec corner with real-world teeth. P25 defines the PDU
+for packet data, but it also defines a **trunking-control SAP (61)** under
+which a PDU carries trunking signalling that needs more room than one TSBK's
+eight payload bytes: Multi-Block Trunking. In its Alternate form (AMBT,
+format 0x17), it is how many systems — notably Motorola — transmit their
+*richest* broadcasts: the Network Status Broadcast that is the sole carrier
+of the WACN, and Adjacent Status Broadcasts with explicit downlink *and*
+uplink channels. A decoder that drops DUID 0xC never surfaces most neighbour
+sites, and on some systems never learns the WACN. The site-topology
+machinery that consumes all this is
+[Trunking Engine Part 10]({{ '/blog/deep-dives/trunking-engine-10-sites-topology-roaming/' | relative_url }})'s
+story, and Part 10 of this series returns to it; here we decode the frames.
+
+## Anatomy of an MBT
+
+An MBT rides the same physical layer as everything else in this series: each
+block is 196 bits, 1/2-rate trellis coded and interleaved **exactly like a
+TSBK**, so `DecodeMBTBlockChannel` simply reuses Part 3's deinterleave →
+Viterbi → repack pipeline. What differs is the content: first a 12-octet PDU
+header, then `BlocksToFollow` 12-octet data blocks.
+
+```go
+// internal/radio/p25/phase1/mbt.go (shape) — ParseMBTHeader
+//	octet 0     : bits 4..0 = format (0x17 AMBT / 0x15 unconfirmed)
+//	octet 1     : bits 5..0 = SAP (61 = trunking control)
+//	octet 2     : MFID
+//	octets 3-5  : AMBT: message-specific (LRA / System ID)
+//	octet 6     : bits 6..0 = blocks to follow
+//	octet 7     : bits 5..0 = opcode (AMBT only)
+//	octets 10-11: header CRC (CCITT-16)
+h.Format = info[0] & 0x1F
+h.SAP = info[1] & 0x3F
+h.MFID = info[2]
+h.BlocksToFollow = info[6] & 0x7F
+h.Opcode = Opcode(info[7] & 0x3F)
+if framing.CRCCCITTAugmented(info) != 0 {
+    return h, ErrMBTHeaderCRC
+}
+```
+
+The layouts were cross-checked against **two independent decoders** — OP25's
+`process_PDU` for the header extraction and both CRC algorithms, SDRTrunk's
+`PDUHeader`/`AMBTC*` classes for per-field bit offsets — precisely so this
+would not be another working model of the kind
+[Part 2 of From Spec to Shipping]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})
+warns about. The AMBT carries its opcode in header octet 7 and message
+fields split between header and first data block; the Unconfirmed form
+(0x15) buries opcode and fields in the data blocks with different layouts,
+and GopherTrunk deliberately **censuses it without decoding it** — counting
+occurrences until a capture justifies a parser is the #764/#771 discipline,
+the same instinct behind
+[census everything]({{ '/blog/solution-postmortem/from-the-issue-tracker-21-census-everything/' | relative_url }}).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="Structure of a P25 Alternate Multi-Block Trunking message: a 12-octet header block with format, SAP, MFID, blocks-to-follow and opcode fields ending in its own CCITT-16 CRC, followed by one or two 12-octet data blocks whose concatenation ends in a CRC-32; every block rides the same 98-dibit TSBK trellis coding">
+  <text x="20" y="26" fill="currentColor" font-size="11" font-weight="bold">one AMBT = header block + BlocksToFollow data blocks</text>
+  <!-- header block -->
+  <rect x="20" y="44" width="260" height="70" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="150" y="62" text-anchor="middle" fill="var(--accent)" font-size="10">HEADER — 12 octets</text>
+  <text x="150" y="78" text-anchor="middle" fill="currentColor" font-size="9">format 0x17 · SAP 61 · MFID · blocks · opcode</text>
+  <rect x="196" y="88" width="76" height="18" rx="3" fill="none" stroke="var(--accent)"/>
+  <text x="234" y="101" text-anchor="middle" fill="var(--accent)" font-size="9">CRC-CCITT16</text>
+  <text x="106" y="101" fill="var(--fg-muted)" font-size="9">System ID / LRA / msg fields</text>
+  <!-- data blocks -->
+  <rect x="300" y="44" width="170" height="70" rx="6" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="385" y="62" text-anchor="middle" fill="currentColor" font-size="10">DATA BLOCK 0 — 12 octets</text>
+  <text x="385" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">WACN · downlink ch · uplink ch …</text>
+  <rect x="490" y="44" width="170" height="70" rx="6" fill="none" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="575" y="62" text-anchor="middle" fill="currentColor" font-size="10">DATA BLOCK 1 (optional)</text>
+  <rect x="584" y="88" width="68" height="18" rx="3" fill="none" stroke="currentColor"/>
+  <text x="618" y="101" text-anchor="middle" fill="currentColor" font-size="9">CRC-32</text>
+  <line x1="304" y1="97" x2="582" y2="97" stroke="var(--fg-muted)" stroke-dasharray="2 3"/>
+  <text x="420" y="92" fill="var(--fg-muted)" font-size="9">CRC-32 spans ALL data octets</text>
+  <!-- trellis note -->
+  <line x1="20" y1="132" x2="660" y2="132" stroke="var(--fg-muted)"/>
+  <text x="340" y="150" text-anchor="middle" fill="currentColor" font-size="10">every block: 98 channel dibits through the SAME 1/2-rate trellis + interleave as a TSBK (Part 3)</text>
+  <text x="340" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="10">header CRC clean + data CRC failed ⇒ the log line's opcode/blocks/nac are REAL (they're the header's) —</text>
+  <text x="340" y="192" text-anchor="middle" fill="var(--fg-muted)" font-size="10">only a data block is corrupt, and the repeating broadcast usually logs a clean copy nearby</text>
+  <text x="340" y="216" text-anchor="middle" fill="var(--accent)" font-size="10">decodes fully — but never locks the channel: only a TSDU proves a control channel (Part 2)</text>
+</svg>
+<figcaption>An AMBT: one self-checked header block plus a CRC-32-terminated data train, all riding the TSBK trellis — two CRCs with separate verdicts, which is why one message can half-fail honestly.</figcaption>
+</figure>
+
+## Two CRCs, two verdicts
+
+The header block ends in the same augmented CRC-CCITT16 a TSBK trailer uses;
+the concatenated data blocks end in a **CRC-32** — polynomial 0x04C11DB7,
+init 0, final XOR 0xFFFFFFFF, MSB-first over all data octets except the last
+four (`mbtCRC32`, translated from OP25's `p25craft.py` derivation and
+validated against `process_PDU`). Two codes, two independently checkable
+units — and one log line that has repeatedly been misread as a parser bug:
+
+```
+p25: MBT data CRC failed opcode=NET_STS_BCST blocks=2 metric=… nac=…
+     cause="corrupt data block (header decoded clean; identity fields above are the header's)"
+```
+
+Seeing that line with identity fields matching a *successfully decoded*
+broadcast moments earlier looks like one frame both failing and passing.
+It is **two different PDU frames**. Everything the failure line prints —
+opcode, block count, NAC — comes from the header block, which carries its own
+CCITT-16 and decoded clean; only a data block failed its CRC-32, from
+ordinary residual RF errors. Broadcasts repeat many times a minute, so a
+clean copy of the same message usually logs nearby. The line now carries the
+worst data-block Viterbi metric and that explanatory `cause` precisely so
+nobody chases a phantom parser bug from the pairing again — the CRC span was
+re-verified byte-for-byte against OP25 before that conclusion was allowed to
+stand.
+
+The dispatch behind it (`dispatchMBT`) counts everything: `MBTDecoded`,
+`MBTHeaderFailed`, `MBTDataCRCFailed`, and per-broadcast counters
+(`NetStatusSeen`, `RFSSStatusSeen`, `AdjacentSeen`) that make "this system
+only sends its WACN in AMBT form" a measurable statement instead of a hunch.
+Unhandled AMBT opcodes log through `ambtOpcodeLabel` — numerically, per
+Part 3's naming rule, because an AMBT opcode GopherTrunk doesn't decode must
+never borrow a TSBK mnemonic.
+
+## What only the AMBT carries
+
+Three broadcasts get full AMBT parsers, each keyed to what the TSBK form
+lacks:
+
+| Broadcast | AMBT opcode | What the AMBT form adds |
+|---|---|---|
+| Network Status | 0x3B | **WACN** + explicit downlink *and* uplink control channels |
+| RFSS Status | 0x3A | site identity with explicit uplink |
+| Adjacent Status | 0x3C | neighbour's explicit uplink channel — often the *only* form sent |
+
+The neighbour table merge is where the two worlds meet.
+`NetworkModel.upsertNeighbor` keys on (RFSS, Site) and treats the TSBK and
+AMBT forms as **complementary halves of one site**: the TSBK form carries
+CFVA flags and service class, the AMBT form the explicit uplink — so a merge
+keeps whichever half the new observation lacks instead of clobbering it with
+zeros. That design fell out of the field data: systems that broadcast most
+of their neighbour list only in AMBT form, and the rest only as TSBKs, are
+both real.
+
+## The uplink rule
+
+An explicit uplink channel pair resolves with deliberate simplicity:
+
+```go
+// internal/trunking/network_report.go (shape)
+// An explicit uplink (the P25 AMBT adjacent-status form) wins; a
+// pair-only explicit uplink resolves via plain base + number*spacing
+// (no transmit offset — the uplink channel number already encodes the
+// uplink frequency).
+if hz := b.BaseHz + uint64(n.UplinkChannelNumber)*uint64(b.SpacingHz); /* … */
+```
+
+The temptation is to treat every uplink as downlink + `TxOffsetHz`, because
+that is how a *derived* uplink works when only the downlink channel is known.
+But an explicit uplink channel number already encodes the uplink frequency
+through the band plan's base + spacing arithmetic — applying the transmit
+offset on top would shift it a second time. Two resolution paths, chosen by
+what the broadcast actually said: derived (downlink + offset) when the
+uplink is absent, plain arithmetic when it's explicit. Part 5 unpacks the
+identifier tables this arithmetic runs on — and what breaks when they're
+wrong.
+
+### How the thrown-away frame shaped the Go code
+
+- **Decode ≠ lock.** `parseFrame` routes DUID 0xC through the full MBT
+  pipeline but never sets the locked flag — only a TSDU proves a control
+  channel, so richer decoding never weakened Part 2's rule.
+- **Reuse the proven coding layer.** MBT blocks ride the TSBK trellis and
+  interleaver unchanged; the new code is parsing and CRC conventions only,
+  which kept the blast radius of a new frame type small.
+- **Census before decode.** The Unconfirmed MBT is counted, not parsed —
+  no spec-guessing without a capture to verify against.
+- **Log lines carry their own epistemology.** The failure line says *which
+  block* its fields came from, so the two-frames reading is in the log
+  itself rather than in tribal memory.
+
+## Where this goes next
+
+Every grant in Part 3 and every AMBT channel here leaned on the same quiet
+machinery: the identifier tables that turn a 4-bit ID plus 12-bit channel
+number into hertz.
+[Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})
+gives the band plan its own episode — IDEN_UP in its three flavours, the
+base + spacing arithmetic, transmit offsets, and the failure mode where every
+voice grant tunes to nothing.
+
+## FAQ
+
+**Is every PDU on a control channel Multi-Block Trunking?**
+No — that's why the header gate exists. `IsTrunkingControl` requires SAP 61
+(trunking control) and a known format (0x17 AMBT or 0x15 unconfirmed);
+anything else is genuine packet data (SNDCP, IP) and takes the data path.
+"Usually MBT" is the right prior on a control channel, but the SAP decides.
+
+**Why doesn't an MBT lock the channel?**
+Lock is a claim that *this frequency is a control channel*, and Part 2's
+rule keys that claim to a validated TSDU. MBTs also appear in contexts a
+scanner shouldn't camp on, and the TSDU test is cheap and constantly
+refreshed — so MBT decoding feeds the network model without touching the
+lock state machine.
+
+**My site table shows one neighbour but the system has many. Is that this
+bug?**
+On current GopherTrunk, no — the AMBT path has decoded Adjacent Status
+broadcasts since `mbt.go` landed. Check the decode-status counters:
+`AdjacentSeen` climbing with `MBTDecoded` means the frames are arriving;
+a neighbour list that still looks thin then usually reflects what the site
+actually broadcasts, which Part 10's topology tooling can show you directly.
+
+**What does `p25: unhandled AMBT opcode opcode=AMBT(0x05)` mean?**
+The header decoded cleanly (SAP 61, valid CRC) but its opcode isn't one of
+the three broadcasts GopherTrunk parses, so it was counted and skipped. The
+numeric label is deliberate — per the naming rule, an undecoded AMBT opcode
+never borrows a TSBK mnemonic that doesn't apply to it.
+
+**What is a WACN and why does it only arrive this way on some systems?**
+The Wide Area Communications Network ID — the top of P25's identity
+hierarchy (WACN → System → RFSS → Site), and the key that makes a system
+globally unambiguous. The TSBK Network Status Broadcast carries it too, but
+some systems transmit that broadcast only in AMBT form — which is exactly
+why dropping DUID 0xC left the WACN blank. Part 10 climbs the full
+hierarchy.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: TSBKs — The Control Channel's Workhorse]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
+· Next →
+[Part 5: Channel Identifiers & Band Plans — From Channel Number to Hertz]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})

--- a/docs/_posts/2026-09-07-from-spec-to-shipping-05-clean-room-rules.md
+++ b/docs/_posts/2026-09-07-from-spec-to-shipping-05-clean-room-rules.md
@@ -1,0 +1,348 @@
+---
+title: "From Spec to Shipping, Part 5: Clean-Room Rules — Reading Without Copying"
+description: "How a pure-Go, Apache-2.0 decoder uses GPL decoders as validation oracles without copying them: where the line sits between wire-format facts and copyrightable expression, the vocoder patent aisle, and the licensing hygiene that CI enforces on every build."
+category: deep-dives
+keywords: clean room implementation sdr decoder, gpl code as validation oracle, wire format facts copyright, mbelib isc license attribution, ambe patent status, etsi reference codec licensing, third party licenses go binary, apache 2.0 pure go decoder, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, licensing, clean-room, vocoders, methodology, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 5
+---
+
+*Part 5 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})
+built the conformance harness: the ETSI reference codec and GopherTrunk's
+decoder fed the same 137-bit bitstream, bit-identical PCM or bust. That
+harness only works because the reference is allowed to be *run* — and this
+part is about the rule that makes everything else in the series legal to
+do: how to lean on other people's decoders as hard as we do, every day,
+without ever copying them into an Apache-2.0 binary.*
+
+> **TL;DR:** GopherTrunk is **pure Go under Apache-2.0** — while its most
+> valuable references (OP25, trunk-recorder, osmo-tetra-dmo, DSD-FME) are
+> GPL. The rule that reconciles them: **implement from the spec; use other
+> decoders as validation oracles** — run them, compare outputs, cite their
+> constants — never as source to translate. Wire-format *facts* (a sync
+> word, an interleave stride, a CRC register, a bit offset) cross that
+> wall freely with a citation; expression-for-expression translation does
+> not. The paperwork lives in `LICENSE`, `THIRD_PARTY_LICENSES.md` and a
+> `make licenses` CI job that fails the build on any non-permissive
+> dependency; the vocoders each carry an explicit provenance statement
+> (mbelib's ISC codebook tables attributed, the ACELP port's ETSI lineage
+> declared in `internal/voice/acelp/ops.go`) because patents and licenses
+> are separate questions with separate answers.
+
+**Key takeaways**
+
+- **An oracle is run, not read into your editor.** The highest-value use
+  of a GPL decoder is feeding it the same input as your code and
+  comparing outputs — DSD-FME decoding the same `.amb` frames, the ETSI
+  reference decoder producing the PCM your decoder must match
+  sample-for-sample. Nothing crosses the license wall but bytes.
+- **Facts are free; expression is not.** The SmartNet sync word `0xAC`,
+  the stride-19 interleave, the XOR masks — those are properties of the
+  radio waves, learned from OP25 and cited to it. The Go code around them
+  is written fresh, in this project's idioms, against this project's
+  interfaces.
+- **Patents are a separate ledger from licenses.** mbelib is permissively
+  licensed (ISC) and AMBE+2 is still patent-encumbered anyway; IMBE and
+  core ACELP patents have expired. A pure-Go rewrite changes the license
+  answer and does not move the patent answer one inch.
+- **Hygiene is a build gate, not a document.** `make licenses` inventories
+  every module the binary links; CI diffs the result and fails on a
+  non-permissive newcomer. A licensing policy that is not enforced by the
+  build is a policy that drifts.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Project license | Apache-2.0 for everything original | `LICENSE` |
+| Third-party inventory | direct deps table + in-tree attributions | `THIRD_PARTY_LICENSES.md` |
+| License CI gate | inventories transitive deps, fails on non-permissive | `make licenses`, the `licenses` job in `.github/workflows/ci.yml` |
+| mbelib table data | ISC-licensed quantiser codebooks, attributed | `internal/voice/ambe2/`, `internal/voice/imbe/` |
+| ACELP provenance | ETSI reference lineage declared at the package door | `internal/voice/acelp/ops.go` (package doc) |
+| Validation oracles | skip-guarded conformance vs reference binaries | `internal/voice/acelp/etsi_reference_test.go` |
+| Patent posture | IMBE/ACELP expired, AMBE+2 encumbered — stated plainly | `docs/vocoders.md` |
+
+## In this post
+
+- **Two rooms, one wall** — the working model: spec into the
+  implementation room, binaries into the validation room.
+- **Facts cross the wall; expression does not** — where the line actually
+  sits, with the SmartNet constants as the worked example.
+- **The vocoder aisle** — three codecs, three different provenance
+  stories, one honesty rule.
+- **Hygiene as a build gate** — `THIRD_PARTY_LICENSES.md`, `make
+  licenses`, and what deliberately never links into the binary.
+- **How that principle shaped the Go code** — the pattern in four bullets.
+
+## Two rooms, one wall
+
+Picture the project as two rooms. The **implementation room** contains
+the specs — ETSI EN 300 392-2, EN 300 395-2, the TIA-102 family from
+[Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})
+— plus this project's own Go code. The **validation room** contains
+everything else: OP25, trunk-recorder, osmo-tetra-dmo, DSD-FME, the
+compiled ETSI reference tools. The wall between them passes exactly two
+kinds of traffic: **outputs** (bytes to compare against) and **facts**
+(constants and layouts, with a citation).
+
+The validation room earns its keep constantly.
+[Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})'s
+conformance harness runs the ETSI `scoder`/`sdecoder` binaries and
+demands GopherTrunk's ACELP output match the reference decoder
+**sample-for-sample** — 0 mismatches over 96,000 samples. The AMBE+2
+band-energy investigation used DSD-FME's decode of the *same* `.amb`
+frames as ground truth to localize a high-band deficit to one parameter
+unpacker. The DMO scrambler seed was cross-checked byte-for-byte against
+osmo-tetra-dmo's `tetra_scramb_get_init`. In every case the reference ran
+as a black box and only its *output* crossed the wall — which is what
+makes a GPL reference safe to use this hard: running a GPL program
+imposes nothing on your code; translating its source into your tree
+makes your tree a derivative work.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Two rooms separated by a wall. The implementation room on the left receives the specs and contains the pure-Go Apache-2.0 code. The validation room on the right contains GPL and reference binaries: OP25, trunk-recorder, osmo-tetra-dmo, DSD-FME, and the ETSI reference codec. Two arrows cross the wall: outputs flowing left into a comparator, and cited facts such as sync words and CRC registers flowing left into constants. A crossed-out arrow labelled source translation shows what never crosses.">
+  <rect x="20" y="30" width="270" height="180" rx="8" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="155" y="52" text-anchor="middle" fill="var(--accent)" font-size="11" font-weight="bold">implementation room</text>
+  <text x="155" y="72" text-anchor="middle" fill="currentColor" font-size="10">specs: ETSI EN / TIA-102</text>
+  <text x="155" y="90" text-anchor="middle" fill="currentColor" font-size="10">pure-Go code, Apache-2.0</text>
+  <rect x="45" y="110" width="220" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="155" y="129" text-anchor="middle" fill="currentColor" font-size="10">cited constants (0xAC, stride 19, …)</text>
+  <rect x="45" y="150" width="220" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="155" y="169" text-anchor="middle" fill="currentColor" font-size="10">comparator: bit-exact / yield A/B</text>
+  <rect x="390" y="30" width="270" height="180" rx="8" fill="none" stroke="var(--fg-muted)" stroke-width="2"/>
+  <text x="525" y="52" text-anchor="middle" fill="var(--fg-muted)" font-size="11" font-weight="bold">validation room (run, not read)</text>
+  <text x="525" y="74" text-anchor="middle" fill="currentColor" font-size="10">OP25 · trunk-recorder (GPL)</text>
+  <text x="525" y="92" text-anchor="middle" fill="currentColor" font-size="10">osmo-tetra-dmo · DSD-FME</text>
+  <text x="525" y="110" text-anchor="middle" fill="currentColor" font-size="10">ETSI reference codec (ETSI terms)</text>
+  <line x1="330" y1="10" x2="330" y2="230" stroke="currentColor" stroke-width="2"/>
+  <line x1="390" y1="125" x2="290" y2="125" stroke="var(--accent)" stroke-width="2"/>
+  <polygon points="292,121 284,125 292,129" fill="var(--accent)"/>
+  <text x="340" y="118" text-anchor="middle" fill="var(--accent)" font-size="9">facts +</text>
+  <text x="340" y="140" text-anchor="middle" fill="var(--accent)" font-size="9">outputs</text>
+  <line x1="390" y1="185" x2="290" y2="185" stroke="var(--fg-muted)" stroke-dasharray="5 4"/>
+  <line x1="322" y1="173" x2="342" y2="197" stroke="var(--fg-muted)" stroke-width="2"/>
+  <line x1="342" y1="173" x2="322" y2="197" stroke="var(--fg-muted)" stroke-width="2"/>
+  <text x="340" y="212" text-anchor="middle" fill="var(--fg-muted)" font-size="9">source translation: never</text>
+</svg>
+<figcaption>The wall passes outputs and cited facts in one direction only — source code never crosses it, which is what lets an Apache-2.0 binary lean on GPL oracles daily.</figcaption>
+</figure>
+
+## Facts cross the wall; expression does not
+
+The line the wall enforces is the one copyright itself draws: facts and
+methods of operation are not copyrightable; a particular *expression* of
+them is. A wire format is a fact about the world — the radio waves carry
+the sync word `0xAC` whether or not anyone wrote a decoder. So when the
+SmartNet framing was rebuilt from proven decoders
+([Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})'s
+case study, [#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)),
+what crossed the wall from OP25's `rx_smartnet.cc` was a set of facts,
+landed as cited constants:
+
+```go
+// internal/radio/motorola/frame.go (shape)
+const (
+    // OutboundSyncHex is the 8-bit outbound sync word 10101100.
+    OutboundSyncHex uint32 = 0xAC
+
+    // idXORMask / cmdXORMask un-invert the address and command
+    // fields (the wire carries the data bits inverted).
+    // From rx_smartnet.h: ID_XOR 0x33C7, CMD_XOR 0x32A.
+    idXORMask  uint16 = ^uint16(0x33C7)        // 0xCC38
+    cmdXORMask uint16 = ^uint16(0x32A) & 0x3FF // 0x0D5
+
+    // CRC-10 registers (rx_smartnet.cc crc_check).
+    crcInit uint16 = 0x0393
+    crcOp   uint16 = 0x036E
+    crcPoly uint16 = 0x0225
+)
+```
+
+Every number names its source, and the tests that pin them
+(`TestOutboundSyncBitsMatchReference`, `TestXORMasksMatchReference`)
+cite the same OP25 literals —
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+discipline applied at the license boundary. What did *not* cross the
+wall is everything around those numbers: the buffering, the framer state
+machine's shape, the error handling, the interfaces — all written fresh
+in Go against GopherTrunk's own `BitSink`/`events.Bus` contracts, in a
+codebase that shares no line with the C++ it validated against.
+
+The distinction changes how you work. A translator rewrites someone
+else's function statement by statement — inheriting its structure, its
+bugs, and its license. A clean-room implementer extracts the *claims*
+the code makes about the wire ("payload position `k + l*19`
+deinterleaves to `k*4 + l`"), writes them down as testable facts, and
+implements them however the target codebase wants. More work up front,
+repaid immediately: you cannot extract a claim you don't understand, so
+every fact that crosses the wall arrives *understood* — exactly the
+property the
+[self-consistent-trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
+series villain preys on the absence of.
+
+## The vocoder aisle: licenses, patents, and provenance
+
+Nowhere do these questions get sharper than vocoders, and GopherTrunk's
+three tell three different stories — each documented where a reader will
+trip over it, in `docs/vocoders.md` and the packages themselves.
+
+| Codec | License story | Patent story |
+|---|---|---|
+| IMBE (P25 Phase 1) | pure Go, mbelib's ISC table data attributed | core patents (early-90s filings) **expired** |
+| AMBE+2 (DMR, P25 P2, NXDN) | pure Go, same ISC attribution | **still encumbered** — DVSI's, deployer's risk |
+| TETRA ACELP | port of the spec's own reference, ETSI terms declared | core algebraic-CELP patents **expired** |
+
+**The mbelib case** is the narrowest possible borrowing. The AMBE+2 and
+IMBE decoders (`internal/voice/ambe2/`, `internal/voice/imbe/`) use
+quantisation codebook tables originally extracted from mbelib — pure
+spec-fixed data, released under ISC, which requires attribution and gets
+it in `THIRD_PARTY_LICENSES.md`. The synthesis pipelines around those
+tables were re-implemented from scratch, and the attribution note says
+exactly that — an attribution that overclaims is as misleading as one
+that's missing. The patent line is stated with equal bluntness:
+**re-implementing AMBE+2 in pure Go does not change the patent posture** —
+the patents cover the algorithm, not the language. The code ships; the
+legal evaluation belongs to the deployer.
+
+**The ACELP case** is the opposite shape: here the *spec itself ships
+the code*. EN 300 395-2's normative artifact is fixed-point ANSI C, and
+implementing the standard means reproducing that arithmetic bit-exactly —
+which is why the package doc opens with a provenance block instead of
+burying it:
+
+```go
+// internal/voice/acelp/ops.go (shape) — package doc
+// PROVENANCE / LICENSING: this port derives from the ETSI reference
+// codec (fixed-point ANSI C), obtained via
+// github.com/curlyboi/libtetradec. The ETSI reference implementation
+// is copyrighted by ETSI and distributed under ETSI's terms; the
+// codec is also historically patent-encumbered (algebraic CELP,
+// though the core patents are largely expired). […] This is why the
+// decoder lives in its own package behind an explicit vocoder
+// registration.
+package acelp
+```
+
+The decoder was ported from the algorithmic description and the ITU-T
+fixed-point operator definitions, with the fixed quantiser tables —
+numeric constants, again — sourced from the reference. The gate that
+makes the port trustworthy is
+[Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})'s
+bit-exact conformance run, and the gate that keeps it honest is
+structural: the decoder registers behind an explicit `tetra-acelp`
+vocoder name so a build can omit it, and the ETSI sources and test
+vectors are **not committed** — the skip-guarded harness points at files
+the operator builds themselves. Different provenance, same principle:
+say exactly where every byte came from, in the file where the bytes live.
+
+## Hygiene as a build gate
+
+A licensing posture that lives only in a Markdown file decays. So the
+inventory is mechanical: `THIRD_PARTY_LICENSES.md` hand-curates the
+direct dependency table (thirteen modules, all MIT / BSD / Apache-2.0
+families), and `make licenses` generates the full transitive inventory
+into a committed CSV. The CI `licenses` job re-runs the target, diffs
+against the committed copy, and **fails the build** if a newly-introduced
+dependency carries a non-permissive license — a PR that adds a
+dependency must regenerate both files, in the open, in the diff.
+
+Three boundaries are worth naming because each is easy to get wrong:
+
+**Test-only references never link.** The ETSI tools, DSD-FME, the
+operator-capture harnesses — all reachable only from skip-guarded tests
+behind environment variables (`GT_ETSI_SERIAL`, `GT_TETRA_DMO_IQ`, …).
+Nothing in `go.mod` pulls a reference implementation.
+
+**Bundled is not linked.** The Windows installer ships Zadig — GPL-3.0 —
+as an unmodified upstream executable launched from a Start Menu shortcut,
+never linked into the daemon. `THIRD_PARTY_LICENSES.md` spells out the
+distinction: "we distribute a GPL binary" and "our binary is GPL-derived"
+are different sentences with different consequences.
+
+**Specs get archived with their terms.** The reference PDFs under
+`docs/specs/` ride under the standards bodies' own distribution terms,
+noted per-document — the input side of the implementation room gets the
+same paper trail as the output side. (For the general landscape behind
+these choices — copyleft versus permissive, derivative works, attribution
+clauses — see the
+[software licensing learn module]({{ '/learn/software-licensing/' | relative_url }}).)
+
+### How that principle shaped the Go code
+
+- **Provenance is a package-doc concern.** `acelp`'s license block sits
+  at the top of `ops.go`; `motorola/frame.go`'s header names OP25 and
+  says outright that the constants are ported facts. The place you read
+  the code is the place you learn where it came from.
+- **The oracle interface is bytes.** Conformance harnesses consume files
+  the reference tools *produced* (`serial.bin`, `ref_out.pcm`) — never
+  the reference's internals — so the comparison stays legal and stays
+  honest at once.
+- **Registration boundaries mirror legal boundaries.** Each vocoder is a
+  separately-registered package, so posture decisions ("omit this codec
+  in that jurisdiction") map to a build decision, not a refactor.
+- **The inventory is diffable.** Hand-curated table for humans, generated
+  CSV for machines, CI to keep them synchronized — the same
+  literal-vector instinct as [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }}),
+  pointed at the dependency graph.
+
+## Where this goes next
+
+Clean-room discipline assumes your references agree with each other. They
+don't, always — and when two implementations you trust give two different
+answers for the same burst geometry, no amount of reading settles it.
+[Part 6]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})
+is about the referee that outranks every implementation: a measurement on
+a real capture, designed so the right answer wins by a wide margin — and
+so the machinery *refuses to answer* when it doesn't.
+
+## FAQ
+
+**Can I legally use a GPL decoder to test my permissively-licensed one?**
+Yes — running a GPL program and comparing its output against yours
+imposes no license obligation on your code; the GPL governs copying and
+derivation of the *source*, not use of the program. The discipline is
+keeping the boundary clean and auditable: outputs and cited facts cross,
+source structure does not.
+
+**Are protocol constants like sync words and CRC polynomials
+copyrightable?**
+Constants that describe a wire format are facts about an external system,
+and facts are not copyrightable — a sync word learned from OP25 is the
+same sync word the radio transmits. What copyright protects is creative
+expression: the surrounding code's structure and phrasing. GopherTrunk
+cites the source of every borrowed constant anyway, both as courtesy and
+as engineering provenance.
+
+**Why is the ACELP decoder a port of the reference when everything else
+is implemented from prose?**
+Because for ACELP the reference *is* the spec: EN 300 395-2's normative
+definition of the codec is fixed-point C whose exact saturation behaviour
+the standard requires, and ETSI distributes it to be implemented from.
+The obligations that path carries — ETSI's terms, the provenance
+statement, the not-committed vectors — are documented at the package door.
+
+**Does rewriting a patented codec in another language avoid the patent?**
+No. Patents cover the algorithm, not its expression, so a pure-Go AMBE+2
+decoder sits in exactly the same patent posture as mbelib's C —
+`docs/vocoders.md` says so in as many words. The rewrite changes the
+*copyright* story (no borrowed expression) and the engineering story
+(testable, idiomatic, memory-safe), not the patent one.
+
+**What stops a contributor from accidentally adding a GPL dependency?**
+The build. `make licenses` inventories every module the binary links, CI
+diffs the generated inventory against the committed copy, and a
+non-permissive newcomer fails the job — so the question surfaces in the
+PR that introduces it, when it costs a conversation instead of a rewrite.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: The Conformance Harness — Bit-Identical or Bust]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})
+· Next →
+[Part 6: When References Disagree, the Capture Referees]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})

--- a/docs/_posts/2026-09-07-from-spec-to-shipping-05-clean-room-rules.md
+++ b/docs/_posts/2026-09-07-from-spec-to-shipping-05-clean-room-rules.md
@@ -82,10 +82,10 @@ without ever copying them into an Apache-2.0 binary.*
 
 ## Two rooms, one wall
 
-Picture the project as two rooms. The **implementation room** contains
-the specs — ETSI EN 300 392-2, EN 300 395-2, the TIA-102 family from
+Picture the project as two rooms. The **implementation room** holds the
+specs — ETSI EN 300 392-2, EN 300 395-2, the TIA-102 family from
 [Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})
-— plus this project's own Go code. The **validation room** contains
+— plus this project's own Go code. The **validation room** holds
 everything else: OP25, trunk-recorder, osmo-tetra-dmo, DSD-FME, the
 compiled ETSI reference tools. The wall between them passes exactly two
 kinds of traffic: **outputs** (bytes to compare against) and **facts**
@@ -188,9 +188,9 @@ series villain preys on the absence of.
 
 ## The vocoder aisle: licenses, patents, and provenance
 
-Nowhere do these questions get sharper than vocoders, and GopherTrunk's
-three tell three different stories — each documented where a reader will
-trip over it, in `docs/vocoders.md` and the packages themselves.
+Nowhere do these questions get sharper than vocoders. GopherTrunk's
+three tell three different stories, each documented in
+`docs/vocoders.md` and the packages themselves.
 
 | Codec | License story | Patent story |
 |---|---|---|
@@ -213,8 +213,7 @@ legal evaluation belongs to the deployer.
 **The ACELP case** is the opposite shape: here the *spec itself ships
 the code*. EN 300 395-2's normative artifact is fixed-point ANSI C, and
 implementing the standard means reproducing that arithmetic bit-exactly —
-which is why the package doc opens with a provenance block instead of
-burying it:
+so the package doc opens with a provenance block instead of burying it:
 
 ```go
 // internal/voice/acelp/ops.go (shape) — package doc
@@ -232,14 +231,13 @@ package acelp
 The decoder was ported from the algorithmic description and the ITU-T
 fixed-point operator definitions, with the fixed quantiser tables —
 numeric constants, again — sourced from the reference. The gate that
-makes the port trustworthy is
-[Part 4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})'s
-bit-exact conformance run, and the gate that keeps it honest is
-structural: the decoder registers behind an explicit `tetra-acelp`
-vocoder name so a build can omit it, and the ETSI sources and test
-vectors are **not committed** — the skip-guarded harness points at files
-the operator builds themselves. Different provenance, same principle:
-say exactly where every byte came from, in the file where the bytes live.
+makes the port trustworthy is Part 4's bit-exact conformance run, and
+the gate that keeps it honest is structural: the decoder registers
+behind an explicit `tetra-acelp` vocoder name so a build can omit it,
+and the ETSI sources and vectors are **not committed** — the
+skip-guarded harness points at files the operator builds themselves.
+Different provenance, same principle: say exactly where every byte came
+from, in the file where the bytes live.
 
 ## Hygiene as a build gate
 
@@ -248,9 +246,9 @@ inventory is mechanical: `THIRD_PARTY_LICENSES.md` hand-curates the
 direct dependency table (thirteen modules, all MIT / BSD / Apache-2.0
 families), and `make licenses` generates the full transitive inventory
 into a committed CSV. The CI `licenses` job re-runs the target, diffs
-against the committed copy, and **fails the build** if a newly-introduced
-dependency carries a non-permissive license — a PR that adds a
-dependency must regenerate both files, in the open, in the diff.
+against the committed copy, and **fails the build** on any
+non-permissive newcomer — a PR that adds a dependency must regenerate
+both files, in the open, in the diff.
 
 Three boundaries are worth naming because each is easy to get wrong:
 
@@ -293,9 +291,9 @@ clauses — see the
 
 ## Where this goes next
 
-Clean-room discipline assumes your references agree with each other. They
-don't, always — and when two implementations you trust give two different
-answers for the same burst geometry, no amount of reading settles it.
+Clean-room discipline assumes your references agree. They don't, always —
+and when two implementations you trust give different answers for the
+same burst geometry, no amount of reading settles it.
 [Part 6]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})
 is about the referee that outranks every implementation: a measurement on
 a real capture, designed so the right answer wins by a wide margin — and
@@ -314,10 +312,10 @@ source structure does not.
 copyrightable?**
 Constants that describe a wire format are facts about an external system,
 and facts are not copyrightable — a sync word learned from OP25 is the
-same sync word the radio transmits. What copyright protects is creative
+same sync word the radio transmits. Copyright protects creative
 expression: the surrounding code's structure and phrasing. GopherTrunk
-cites the source of every borrowed constant anyway, both as courtesy and
-as engineering provenance.
+cites the source of every borrowed constant anyway, as courtesy and as
+engineering provenance.
 
 **Why is the ACELP decoder a port of the reference when everything else
 is implemented from prose?**
@@ -336,9 +334,9 @@ decoder sits in exactly the same patent posture as mbelib's C —
 
 **What stops a contributor from accidentally adding a GPL dependency?**
 The build. `make licenses` inventories every module the binary links, CI
-diffs the generated inventory against the committed copy, and a
-non-permissive newcomer fails the job — so the question surfaces in the
-PR that introduces it, when it costs a conversation instead of a rewrite.
+diffs the result against the committed copy, and a non-permissive
+newcomer fails the job — the question surfaces in the introducing PR,
+when it costs a conversation instead of a rewrite.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-07-operator-cookbook-05-tetra-dmo.md
+++ b/docs/_posts/2026-09-07-operator-cookbook-05-tetra-dmo.md
@@ -1,0 +1,338 @@
+---
+title: "The Operator's Cookbook, Part 5: TETRA Direct Mode — Scanning DMO"
+description: A complete GopherTrunk recipe for TETRA DMO — radio-to-radio direct mode with no infrastructure. One dongle camped on a simplex frequency, the tetra-dmo protocol, colour-code auto-recovery, the tetra_mcc/tetra_mnc keys an MNI≠0 network requires, and an honest account of what is still on-air-gated.
+category: tutorials
+keywords: tetra dmo scanner, tetra direct mode decoder, decode tetra dmo sdr, tetra dmo colour code, tetra mcc mnc config, tetra dmo 430 mhz, tetra walkie talkie decode, sdr tetra decoder, gophertrunk cookbook
+tags: [operator-cookbook, tetra, dmo, direct-mode, config, sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 5
+---
+
+*Part 5 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 4]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})
+built a TETRA TMO rig camped on a trunked network's continuous control channel.
+This part points the same hardware at the opposite animal:
+**Direct Mode Operation** — TETRA radios talking straight to each other, no
+base station, no control channel, nothing on the air between transmissions.
+It's GopherTrunk's newest decode path, it needs the least hardware of any
+recipe here, and it carries the series' most honest caveat list.*
+
+> **TL;DR:** One dongle camped on one simplex UHF frequency decodes
+> [TETRA DMO]({{ '/reference/tetra-dmo/' | relative_url }}) end to end:
+> `protocol: tetra-dmo` in the system block, the DMO frequency in
+> `control_channels`, and **no voice SDR at all** — DMO voice rides the same
+> carrier the pipeline decodes, so a single same-carrier tap feeds the ACELP
+> vocoder. The traffic descrambler's colour code is **auto-recovered off the
+> air** (~20 traffic bursts), but on a network with a non-zero MNI you must
+> set `tetra_mcc` / `tetra_mnc` or every colour candidate sits at the chance
+> floor. Watch for `tetra dmo cc locked`, then
+> `tetra dmo grant (traffic detected)`. Recordings file under **talkgroup 0**
+> — DMO grants carry none. Full on-air verification is still open in
+> [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003).
+
+**Key takeaways**
+
+- **This is the one-SDR, zero-infrastructure recipe.** No control channel, no
+  grants from a network, no voice pool — the pipeline locks the sync bursts,
+  detects traffic on a slot grid, and decodes voice off the very same carrier.
+- **The colour code is the whole ballgame.** TETRA scrambles traffic with a
+  30-bit [extended colour code]({{ '/reference/tetra-extended-colour-code/' | relative_url }});
+  GopherTrunk recovers the 6-bit colour by brute force, but the MNI half
+  (MCC/MNC) is **not on the air** — on an MNI≠0 network it must come from
+  your config.
+- **`dnb_qualified` means traffic; `dnb_total` is a noise meter.** The raw
+  burst correlator false-fires ~18 times a second on an idle channel by
+  design math. A large gap between the two counters is normal, not a fault.
+- **Green synthetic ≠ on-air correct.** The DMO path has already produced —
+  and retracted — one wrong verdict ("it's encrypted"; it was a descramble
+  skip). The remaining gate is operator captures, and this post tells you how
+  to contribute one.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Protocol selector | direct-mode pipeline, 144 kHz channel rate | `trunking.systems[].protocol: tetra-dmo` (also accepts `dmo`) |
+| The frequency | simplex channel to camp on | `control_channels: [438_900_000]` |
+| Network identity | MNI folded into every colour candidate | `tetra_mcc`, `tetra_mnc` ([MNI]({{ '/reference/tetra-mobile-network-identity/' | relative_url }})) |
+| Manual colour override | skip auto-recovery entirely | `tetra_colour_code` (leave 0 to auto-recover) |
+| Voice decode | same-carrier tap → TCH/S → ACELP | automatic — no `role: voice` device needed |
+| Where TETRA even is | region/legality background | [TETRA scanner guide]({{ '/tetra-scanner/' | relative_url }}) |
+| The full story | how this path was built, bug by bug | [TETRA End to End 11–13]({{ '/blog/deep-dives/tetra-end-to-end-11-dmo-direct-mode/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — a camped ear on a radio-to-radio channel.
+- **The shopping list** — Part 4's hardware, unchanged.
+- **The config** — three blocks, one protocol string, two identity keys.
+- **First run — what healthy looks like** — camping, lock, grant, colour, voice.
+- **When it doesn't work** — symptom → cause → fix, with the MNI trap up top.
+- **Variations & the open gate** — wideband hosting, and how to close #1003.
+
+## What you're building
+
+Everything in Parts 1–4 decoded *infrastructure*: a tower transmitting
+continuously, voice channels handed out by grants. DMO has none of that.
+Two TETRA handhelds on a construction site or an event crew — one radio keys
+up, transmits directly on a simplex frequency, and stops. Between
+transmissions the channel is **pure noise floor**.
+
+That changes the decoder's whole posture. So GopherTrunk **camps**: the hunt
+supervisor parks on the frequency without demanding a lock, the pipeline
+holds its lock stickily across silence, and traffic detection is deliberately
+skeptical — a transmission is declared only when bursts line up on the
+255-symbol TETRA slot grid, because the raw correlator alone false-fires on
+noise ~18 times per second. The
+[three]({{ '/blog/deep-dives/tetra-end-to-end-11-dmo-direct-mode/' | relative_url }})
+[DMO]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+[deep dives]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})
+tell that story properly; this recipe cooks with the result.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the TETRA DMO rig: two handhelds share one simplex carrier; one SDR feeds a 144 kilohertz down-converter, the DMO pipeline locks sync bursts and grid-qualifies traffic into a grant, and a same-carrier voice tap recovers the colour code and decodes ACELP voice into recordings filed under talkgroup zero">
+  <rect x="8" y="30" width="54" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="35" y="49" text-anchor="middle" fill="currentColor" font-size="10">radio A</text>
+  <rect x="8" y="76" width="54" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="35" y="95" text-anchor="middle" fill="currentColor" font-size="10">radio B</text>
+  <line x1="62" y1="45" x2="100" y2="64" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <line x1="62" y1="91" x2="100" y2="72" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="82" y="120" fill="var(--fg-muted)" font-size="9">one simplex carrier,</text>
+  <text x="82" y="132" fill="var(--fg-muted)" font-size="9">silent between PTTs</text>
+  <rect x="104" y="52" width="74" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="141" y="72" text-anchor="middle" fill="currentColor" font-size="10">SDR dongle</text>
+  <line x1="178" y1="68" x2="212" y2="68" stroke="currentColor"/>
+  <rect x="212" y="14" width="230" height="216" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="327" y="30" text-anchor="middle" fill="var(--fg-muted)" font-size="10">GopherTrunk (protocol: tetra-dmo)</text>
+  <rect x="226" y="42" width="202" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="327" y="61" text-anchor="middle" fill="currentColor" font-size="10">DDC → 144 kHz channel stream</text>
+  <rect x="226" y="86" width="202" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="327" y="100" text-anchor="middle" fill="var(--accent)" font-size="10">DSB sync decode → sticky lock</text>
+  <text x="327" y="113" text-anchor="middle" fill="var(--fg-muted)" font-size="9">SCH/S + SYNC PDU, frame counter</text>
+  <rect x="226" y="134" width="202" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="327" y="148" text-anchor="middle" fill="var(--accent)" font-size="10">DNB slot-grid vote → grant</text>
+  <text x="327" y="161" text-anchor="middle" fill="var(--fg-muted)" font-size="9">dnb_qualified, not dnb_total</text>
+  <rect x="226" y="182" width="202" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="327" y="196" text-anchor="middle" fill="currentColor" font-size="10">same-carrier voice tap</text>
+  <text x="327" y="209" text-anchor="middle" fill="var(--fg-muted)" font-size="9">colour recovery → TCH/S → ACELP</text>
+  <line x1="327" y1="72" x2="327" y2="86" stroke="currentColor"/>
+  <line x1="327" y1="120" x2="327" y2="134" stroke="currentColor"/>
+  <line x1="327" y1="168" x2="327" y2="182" stroke="currentColor"/>
+  <line x1="428" y1="199" x2="480" y2="199" stroke="currentColor"/>
+  <rect x="480" y="150" width="190" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="575" y="164" text-anchor="middle" fill="var(--accent)" font-size="10">web console: Active / History</text>
+  <text x="575" y="177" text-anchor="middle" fill="var(--fg-muted)" font-size="9">calls appear under group 0</text>
+  <rect x="480" y="196" width="190" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="575" y="210" text-anchor="middle" fill="currentColor" font-size="10">recordings/&lt;system&gt;/0/*.wav</text>
+  <text x="575" y="223" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DMO grants carry no talkgroup</text>
+  <line x1="442" y1="160" x2="480" y2="162" stroke="var(--accent)"/>
+</svg>
+<figcaption>One dongle, one carrier, no infrastructure: the DMO pipeline locks the sync bursts, votes traffic onto the slot grid, and decodes voice from the same tap — recordings land under talkgroup 0 because direct mode never announces one.</figcaption>
+</figure>
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| RTL-SDR Blog V3/V4 (or your Part 4 dongle) | ~$35 | a [TCXO]({{ '/reference/tcxo/' | relative_url }}) matters more here — DMO channels are 25 kHz and often up at 430–470 MHz |
+| UHF-capable antenna | $0–$30 | the kit whip extended for 70 cm works; a tuned [whip]({{ '/reference/whip-antenna/' | relative_url }}) buys margin |
+| Computer | $0 | anything that ran Parts 1–4 |
+
+Nothing new — the cheapest recipe in the series. You also need one fact you
+can't buy: the **DMO frequency** your target radios use. There's no control
+channel to hunt, so it comes from a codeplug, a licence record, or a
+band-scope sweep (the captures this path was built on live at 438.9 MHz).
+
+## The config
+
+```yaml
+log:
+  level: info        # set debug to see the DMO decode-status counters
+
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000001"        # from `gophertrunk sdr list`
+      role: control
+      gain: "auto"
+
+trunking:
+  systems:
+    - name: "Site-DMO"
+      protocol: tetra-dmo       # "dmo" is accepted too
+      control_channels:
+        - 438_900_000           # the simplex DMO frequency
+      tetra_mcc: 250            # your network's MCC — see below
+      tetra_mnc: 1              # your network's MNC — see below
+```
+
+Three things to understand before running it.
+
+**There is no voice device — on purpose.** DMO voice is transmitted *on the
+carrier you're already decoding* (there is no separate traffic channel), so
+GopherTrunk allocates a same-carrier tap automatically and the composer runs
+its DMO voice chain on it. Adding a voice SDR here does nothing.
+
+**`tetra_mcc` / `tetra_mnc` are load-bearing on real networks.** TETRA seeds
+its traffic scrambler with the full 30-bit extended colour code —
+MCC + MNC + 6-bit colour. The DMO sync burst is *always* colour-0 scrambled
+and carries MNI 0 on the air, so the network's real
+[MNI]({{ '/reference/tetra-mobile-network-identity/' | relative_url }}) is
+not recoverable by listening — it has to come from you. Learned the hard
+way: a reporter's Motorola MTP8500Ex radios ran MCC 250 / MNC 1, the colour
+search assumed MNI 0, and all 64 candidates sat at the chance floor while
+signalling decoded perfectly. True out-of-the-box MNI-0 direct mode keeps
+the zero defaults; anything with a codeplug, get its MCC/MNC.
+
+**Leave `tetra_colour_code` alone.** The 6-bit DM colour is recovered
+automatically by decoding traffic under all 64 candidates and requiring a
+dominant winner — on a real capture the correct colour won ~35 CRC-valid
+frames against a runner-up of ≤3. Set the key only to skip the ~20-burst
+recovery delay on a colour you already know.
+
+## First run — what healthy looks like
+
+```sh
+gophertrunk run -config config.yaml
+```
+
+A silent DMO channel is the *normal* startup state, and the log says so
+explicitly instead of alarming:
+
+```
+INF cchunt: camped on conventional channel — idle, waiting for traffic system=Site-DMO
+```
+
+That line fires once (issue #1036 made it transition-only, so a quiet night
+doesn't spam the log). Now wait for someone to key up. The first PTT produces
+a burst of activity in order:
+
+```
+INF tetra dmo cc locked freq=438900000 system=Site-DMO
+INF tetra dmo grant (traffic detected) freq=438900000 colour=0 system=Site-DMO
+INF composer: tetra DMO voice follow started — DNB TCH/S decode + ACELP vocoder serial=cc:same-carrier:1 colour_hint=0 rate_hz=18000
+INF composer: tetra DMO colour code recovered serial=cc:same-carrier:1 colour=3 attempt=1
+INF recorder: call started device=cc:same-carrier:1 wav=../recordings/Site-DMO/0/... tg=0 provoice=false vocoder=tetra-acelp
+```
+
+Read the timing honestly: the grant lands **about half a second into the
+transmission** (the slot-grid latch plus four qualified bursts), and colour
+recovery needs roughly **20 traffic bursts** — but the voice chain buffers
+everything from the grant onward and decodes it retroactively once the
+colour is known, so leading speech isn't lost. The call ends on
+`voice_hangtime_ms` after the last decoded voice — DMO carries no release
+message GopherTrunk decodes, so a timeout-flavoured ending is normal.
+
+Note the `tg=0`: **every DMO recording files under talkgroup 0**. A DMO
+grant carries no talkgroup, so History and the `recordings/Site-DMO/0/`
+folder collect everything under group zero. Name it in a talkgroup file if
+the raw `0` bothers you.
+
+With `log.level: debug`, a periodic status line shows the pipeline's
+internals:
+
+```
+DBG tetra dmo: decode status system=Site-DMO locked=true carrier_off_hz=-412.5 dsb_total=54 dsb_schs_crc=46 dnb_total=4541 dnb_qualified=837 tch_crc=203 distinct_fn=17 colour=3 colour_known=true grant_active=true
+```
+
+The counter pair to internalize: **`dnb_qualified` is traffic,
+`dnb_total` is a noise meter.** The raw correlator is loose enough that
+noise trips it ~18 times a second on a dead-silent channel — arithmetic, not
+a bug; only bursts landing on the learned slot grid qualify. Thousands of
+`dnb_total` next to hundreds of `dnb_qualified` is a healthy channel. An
+early version that trusted raw detections granted 230 ms of noise on an
+empty channel — which is exactly why the qualified counter exists.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Locks, `dsb_schs_crc` climbs, but `tch_crc` stays near zero and `colour_known=false` forever | **wrong MNI** — the colour search can never reach the real scrambler seed | Set `tetra_mcc`/`tetra_mnc` from the codeplug. This signature (several colours rising modestly, none dominant) cost weeks before the MNI-0 blind spot was found — [the descramble saga]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }}) has the story |
+| `colour_known=false` on short PTTs only | recovery needs ~20 qualified bursts; a 2-second PTT ends first | Nothing is wrong — the next longer transmission recovers it, and recovery re-arms per transmission |
+| `dnb_total` climbing constantly, no grants, no lock | noise doing what noise does | Expected on an idle channel. If radios ARE transmitting and there's no `tetra dmo cc locked`, treat it as RF: gain, antenna, exact frequency |
+| Decodes, but audio garbled or thin | marginal signal — handhelds at range are a weak-signal regime | The blind equalizer is already on. Better antenna first ([The Analog Edge]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }})), then contribute a capture (below) |
+| "It must be encrypted" | maybe — but this path was burned by that verdict once | GopherTrunk once called a clear TEA0 capture "encrypted"; the real bug was a skipped colour-0 descramble. Confirm from the codeplug before concluding encryption — a chance-floor decode on a known-clear channel is a defect worth reporting |
+| Calls end at odd times / `reason=timeout` | DMO decodes no release PDU | Normal — hangtime is the only end signal; tune `voice_hangtime_ms` |
+
+## Variations & the open gate
+
+- **Host it on a wideband dongle.** A `role: wideband` device can carry the
+  DMO channel as a `channels:` entry pointing at the `tetra-dmo` system,
+  alongside other protocols' taps — same pipeline, shared hardware
+  (see [Part 7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})).
+- **Pin the colour.** On your own known radios, set `tetra_colour_code` and
+  skip recovery — first-PTT decode with no 20-burst warm-up.
+- **Capture for posterity (and for #1003).** The honest part: the
+  full-daemon DMO path is offline-verified, **not yet on-air-verified** —
+  and per
+  [the self-consistent-trap discipline]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}),
+  a green synthetic is not a verified decode. What closes
+  [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003): run
+  `protocol: tetra-dmo` against live radios of **known** colour and MNI,
+  with someone actually *talking* (a silent keyed carrier is a poor test
+  vector), and report whether an intelligible recording lands. A raw IQ
+  capture of the session (`gophertrunk capture`, MCC/MNC noted) makes any
+  failure reproducible.
+
+### How this recipe shapes operator practice
+
+- **Silence is a state, not an error.** `camped … waiting for traffic` is the
+  healthy idle line; don't chase it.
+- **Trust the qualified counter.** A DMO question that starts from
+  `dnb_total` starts from a noise meter.
+- **Identity comes from config, not the air.** The MNI cannot be sniffed —
+  write it down whenever you get codeplug access.
+
+## Where this goes next
+
+Direct mode is the simplest *digital* recipe; [Part
+6]({{ '/blog/tutorials/operator-cookbook-06-analog-fm-tone-out/' | relative_url }})
+goes simpler still — plain analog FM. Fire dispatch, marine VHF, GMRS: a
+conventional scan list with real squelch, CTCSS/DCS tone gating, and two-tone
+fire paging that fires an alert the moment your station's tones hit the air.
+
+## FAQ
+
+**What is TETRA DMO and can an SDR decode it?**
+Direct Mode Operation is TETRA's radio-to-radio mode — handhelds on a
+simplex channel with no network. GopherTrunk decodes it with one cheap SDR:
+sync, traffic detection, colour recovery and clear-voice ACELP. Encrypted
+DMO (TEA ciphers) yields metadata only.
+
+**Why do my DMO recordings all show talkgroup 0?**
+Because a DMO transmission genuinely announces none to a listener at this
+layer — the grant GopherTrunk publishes carries `GroupID 0` by design, and
+recordings file under `<system>/0/`. It's a property of what's decodable,
+not a config mistake.
+
+**What are tetra_mcc and tetra_mnc for in GopherTrunk?**
+They supply the network's Mobile Network Identity, which TETRA folds into
+the voice-traffic scrambler seed but never transmits in DMO sync bursts.
+With the wrong MNI, voice sits at the chance floor while signalling decodes
+fine — the diagnostic tell.
+
+**How fast does GopherTrunk catch a DMO transmission?**
+Roughly half a second after PTT: the pipeline requires a sync lock plus four
+slot-grid-qualified traffic bursts before declaring a call, so channel noise
+can't open recordings on a silent frequency. Buffering means speech from
+before the grant still gets decoded.
+
+**Is DMO decoding in GopherTrunk finished?**
+The decoders are conformance-tested and capture-verified offline; the
+full-daemon on-air loop is the last open gate (#1003). Run it and report what
+you see — especially a known-clear channel that *doesn't* decode.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: A TETRA TMO Rig]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})
+· Next →
+[Part 6: Analog FM & Tone-Out Paging]({{ '/blog/tutorials/operator-cookbook-06-analog-fm-tone-out/' | relative_url }})

--- a/docs/_posts/2026-09-07-operator-cookbook-05-tetra-dmo.md
+++ b/docs/_posts/2026-09-07-operator-cookbook-05-tetra-dmo.md
@@ -29,9 +29,9 @@ recipe here, and it carries the series' most honest caveat list.*
 > air** (~20 traffic bursts), but on a network with a non-zero MNI you must
 > set `tetra_mcc` / `tetra_mnc` or every colour candidate sits at the chance
 > floor. Watch for `tetra dmo cc locked`, then
-> `tetra dmo grant (traffic detected)`. Recordings file under **talkgroup 0**
-> — DMO grants carry none. Full on-air verification is still open in
-> [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003).
+> `tetra dmo grant (traffic detected)`. Recordings file under
+> **talkgroup 0** — DMO grants carry none. On-air verification is still
+> open in [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003).
 
 **Key takeaways**
 
@@ -75,10 +75,10 @@ recipe here, and it carries the series' most honest caveat list.*
 ## What you're building
 
 Everything in Parts 1–4 decoded *infrastructure*: a tower transmitting
-continuously, voice channels handed out by grants. DMO has none of that.
-Two TETRA handhelds on a construction site or an event crew — one radio keys
-up, transmits directly on a simplex frequency, and stops. Between
-transmissions the channel is **pure noise floor**.
+continuously, voice handed out by grants. DMO has none of that. Two TETRA
+handhelds on a construction site — one keys up, transmits directly on a
+simplex frequency, and stops. Between transmissions the channel is **pure
+noise floor**.
 
 That changes the decoder's whole posture. So GopherTrunk **camps**: the hunt
 supervisor parks on the frequency without demanding a lock, the pipeline

--- a/docs/_posts/2026-09-07-p25-end-to-end-05-channels-band-plans.md
+++ b/docs/_posts/2026-09-07-p25-end-to-end-05-channels-band-plans.md
@@ -1,6 +1,6 @@
 ---
 title: "P25 End to End, Part 5: Channel Identifiers & Band Plans — From Channel Number to Hertz"
-description: How a P25 grant's 16-bit channel field becomes a frequency — the IDEN_UP band-plan broadcasts in their 0x3D, 0x34 and 0x33 dialects, the base-plus-spacing arithmetic GopherTrunk runs in BandPlan.Frequency, and what happens when a grant arrives before the table that decodes it.
+description: How a P25 grant's 16-bit channel field becomes a frequency — the IDEN_UP band-plan broadcasts in their 0x3D, 0x34 and 0x33 dialects, the base-plus-spacing arithmetic in BandPlan.Frequency, and what happens when a grant arrives before the table that decodes it.
 category: deep-dives
 keywords: p25 iden_up, p25 band plan, p25 channel identifier, p25 channel number to frequency, iden_up_tdma 0x33, p25 grant frequency calculation, p25 tx offset uplink, trunking band plan decoding, gophertrunk p25
 tags: [p25-end-to-end, p25, band-plan, trunking, control-channel, go]
@@ -10,30 +10,29 @@ series: "P25 End to End"
 series_part: 5
 ---
 
-*Part 5 of **P25 End to End**, a 14-part deep dive that follows North America's
-dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
-recorded, named, multi-site voice.
+*Part 5 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
 [Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})
 decoded Multi-Block Trunking and recovered the site broadcasts some
 systems only send in AMBT form. But every grant and neighbor announcement
 names its frequency the same indirect way: a 4-bit channel identifier plus
-a 12-bit channel number. This part is the dictionary that turns those
-sixteen bits into hertz — the IDEN_UP broadcasts, the arithmetic, and the
-failure modes when the dictionary is late, missing, or wrong.*
+a 12-bit channel number. This part is the dictionary turning those sixteen
+bits into hertz — the IDEN_UP broadcasts, the arithmetic, and the failure
+modes when the dictionary is late, missing, or wrong.*
 
-> **TL;DR:** P25 never broadcasts frequencies with grants. A voice grant
-> carries a 16-bit channel field — **4-bit channel ID + 12-bit channel
-> number** — and the site separately, periodically broadcasts **IDEN_UP**
-> messages defining each ID slot's base frequency, spacing and transmit
-> offset. GopherTrunk accumulates them in `phase1.BandPlan`
+> **TL;DR:** P25 never broadcasts frequencies with grants. A grant carries
+> a 16-bit channel field — **4-bit channel ID + 12-bit channel number** —
+> and the site separately broadcasts **IDEN_UP** messages defining each ID
+> slot's base frequency, spacing and transmit offset. GopherTrunk
+> accumulates them in `phase1.BandPlan`
 > (`internal/radio/p25/phase1/identifier.go`) and resolves
-> `freq = BaseHz + ChannelNumber × SpacingHz`. Three on-air dialects (opcodes
-> **0x3D**, **0x34** VHF/UHF, **0x33** TDMA) parse into one struct; base
-> frequencies scale ×5 Hz, spacing ×125 Hz. A grant arriving before its
-> IDEN_UP is queued for 5 s (`pendingGrants`) and surfaced as a
-> `decode.error` with `stage="no-bandplan"` — and an explicit uplink channel
-> from Part 4's AMBT broadcasts resolves as plain base+spacing with **no**
-> tx offset.
+> `freq = BaseHz + ChannelNumber × SpacingHz`. Three on-air dialects
+> (opcodes **0x3D**, **0x34** VHF/UHF, **0x33** TDMA) parse into one
+> struct; bases scale ×5 Hz, spacing ×125 Hz. A grant arriving before its
+> IDEN_UP is queued 5 s (`pendingGrants`) and surfaced as a `decode.error`
+> with `stage="no-bandplan"` — and an explicit uplink channel from Part 4's
+> AMBT broadcasts resolves as plain base+spacing with **no** tx offset.
 
 **Key takeaways**
 
@@ -48,13 +47,12 @@ failure modes when the dictionary is late, missing, or wrong.*
   is fiction.
 - **An explicit uplink channel number already encodes the uplink
   frequency.** When an AMBT neighbor broadcast names an uplink channel,
-  GopherTrunk resolves it base+spacing with no transmit offset applied —
-  matching SDRTrunk, and the opposite of what the offset field's existence
-  tempts you to do.
+  GopherTrunk resolves it base+spacing with no transmit offset — matching
+  SDRTrunk, and the opposite of what the offset field tempts you to do.
 - **The channel ID carries more than arithmetic.** A slot advertised via
   opcode 0x33 is flagged `AccessTDMA`, and that one bit routes the grant
-  into the Phase 2 voice chain — the wiring hybrid Phase 1 CC / Phase 2
-  voice systems (issue #376) silently lacked.
+  into the Phase 2 voice chain — wiring hybrid Phase 1 CC / Phase 2 voice
+  systems (issue #376) silently lacked.
 
 ## Cheat sheet
 
@@ -70,17 +68,18 @@ failure modes when the dictionary is late, missing, or wrong.*
 
 ## In this post
 
-- **Frequencies are never broadcast with grants** — the 4+12-bit indirection and why it exists.
-- **Three dialects, one struct** — 0x3D vs 0x34 vs 0x33, and where they disagree.
-- **The arithmetic, worked** — from bitfield to megahertz in one figure.
-- **When the table is late, missing, or wrong** — pending grants, `no-bandplan`, and tuning to nothing.
-- **Uplinks, offsets, and the AMBT rule** — the Part 4 callback, resolved in code.
+- **Frequencies are never broadcast with grants** — the 4+12-bit indirection.
+- **Three dialects, one struct** — 0x3D vs 0x34 vs 0x33, where they disagree.
+- **The arithmetic, worked** — bitfield to megahertz in one figure.
+- **When the table is late, missing, or wrong** — pending grants, `no-bandplan`, tuning to nothing.
+- **Uplinks, offsets, and the AMBT rule** — the Part 4 callback, in code.
 
 ## Frequencies are never broadcast with grants
 
-Here is the whole payload of a Group Voice Channel Grant (TSBK opcode 0x00),
-the message [Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
-decoded a few hundred times a minute:
+Here is the whole payload of a Group Voice Channel Grant (TSBK opcode
+0x00), the message
+[Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
+decoded hundreds of times a minute:
 
 ```go
 // internal/radio/p25/phase1/opcodes.go (shape) — ParseGroupVoiceChannelGrant
@@ -96,9 +95,9 @@ func ParseGroupVoiceChannelGrant(p [8]byte) GroupVoiceChannelGrant {
 }
 ```
 
-Sixteen bits of channel, and not one of them is a frequency. The reason is
-economy: a TSBK payload is eight bytes, a frequency takes four, and a site
-grants calls constantly while its frequency plan changes never. So P25
+Sixteen bits of channel, none of them a frequency. The reason is economy:
+a TSBK payload is eight bytes, a frequency takes four, and a site grants
+calls constantly while its frequency plan changes never. So P25
 factors the plan out — the site periodically broadcasts up to sixteen
 **channel identifier** definitions, each pairing a 4-bit ID with a base
 frequency, spacing, nominal bandwidth and transmit offset, and every grant,
@@ -106,16 +105,16 @@ neighbor announcement and secondary-CC broadcast thereafter spends only 16
 bits per channel reference. The same `ID<<12 | number` packing appears in
 every channel-bearing TSBK in `opcodes.go` and in Part 4's AMBT forms alike.
 
-The cost of the economy is state: a receiver tuning in mid-stream knows the
-grants before it knows the dictionary — a structural race GopherTrunk built
-real machinery for, below.
+The cost of the economy is state: a receiver tuning in mid-stream knows
+the grants before the dictionary — a race GopherTrunk built real machinery
+for, below.
 
 ## Three dialects, one struct
 
-The dictionary entries arrive as **IDEN_UP** TSBKs, and there are three
-on-air variants. All three parse into one `IdentifierUpdate` struct, because
-downstream code only ever wants base, spacing, and offset — but the byte-0
-low nibble and the offset field mean different things in each:
+The dictionary entries arrive as **IDEN_UP** TSBKs, in three on-air
+variants. All three parse into one `IdentifierUpdate` struct — downstream
+code only wants base, spacing, and offset — but the byte-0 low nibble and
+the offset field mean different things in each:
 
 | | 0x3D `IDEN_UP` | 0x34 `IDEN_UP_VUHF` | 0x33 `IDEN_UP_TDMA` |
 |---|---|---|---|
@@ -124,11 +123,11 @@ low nibble and the offset field mean different things in each:
 | Tx offset | 9-bit two's complement × **250 kHz** | sign + 13-bit magnitude × **SpacingHz** | sign + 13-bit magnitude × **SpacingHz** |
 | Extra semantics | — | — | marks the slot `AccessTDMA` |
 
-Two fields are identical everywhere, and their scaling is worth memorising
-because it explains every suspicious number in a band-plan log: the 32-bit
-base frequency is in units of **5 Hz** (`BaseHz = freq32 × 5`), and the
-10-bit channel step is in units of **125 Hz** (`SpacingHz = step × 125`).
-The standard form's parser is compact enough to quote whole:
+Two fields are identical everywhere, and their scaling explains every
+suspicious number in a band-plan log: the 32-bit base frequency is in
+units of **5 Hz** (`BaseHz = freq32 × 5`), the 10-bit channel step in
+units of **125 Hz** (`SpacingHz = step × 125`). The standard form's parser
+is compact enough to quote:
 
 ```go
 // internal/radio/p25/phase1/identifier.go (shape) — ParseIdentifierUpdate
@@ -170,7 +169,7 @@ picks up the other side of that routing decision.
 
 ## The arithmetic, worked
 
-Resolution itself is one line plus guard rails:
+Resolution is one line plus guard rails:
 
 ```go
 // internal/radio/p25/phase1/identifier.go (shape) — BandPlan.Frequency
@@ -188,7 +187,7 @@ func (b *BandPlan) Frequency(channelID uint8, channelNumber uint16) (uint32, err
 ```
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="A worked example of P25 channel resolution: a 16-bit channel field splits into a 4-bit identifier and a 12-bit channel number; the identifier selects one of sixteen band-plan slots carrying base frequency and spacing from an IDEN_UP broadcast; the arithmetic base plus number times spacing yields 853.88125 megahertz">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="A 16-bit channel field splits into a 4-bit identifier selecting a band-plan slot and a 12-bit channel number; base plus number times spacing yields 853.88125 megahertz, and a missing slot queues the grant instead">
   <!-- channel field -->
   <rect x="30" y="28" width="60" height="30" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <rect x="90" y="28" width="180" height="30" fill="none" stroke="currentColor" stroke-width="2"/>
@@ -202,7 +201,7 @@ func (b *BandPlan) Frequency(channelID uint8, channelNumber uint16) (uint32, err
   <text x="340" y="40" fill="var(--fg-muted)" font-size="10">band plan (from IDEN_UP broadcasts)</text>
   <text x="340" y="58" fill="currentColor" font-size="10">id 0: base 851.00625 MHz · spacing 6.25 kHz</text>
   <text x="340" y="76" fill="var(--accent)" font-size="10" font-weight="bold">id 1: base 851.00625 MHz · spacing 6.25 kHz</text>
-  <text x="340" y="94" fill="var(--fg-muted)" font-size="10">id 2..15: (unknown until broadcast)</text>
+  <text x="340" y="94" fill="var(--fg-muted)" font-size="10">id 2..15: unknown until broadcast</text>
   <path d="M 92 60 C 140 110 260 90 334 74" fill="none" stroke="var(--accent)" stroke-dasharray="4 3"/>
   <polygon points="334,74 322,72 328,82" fill="var(--accent)"/>
   <!-- arithmetic -->
@@ -215,19 +214,17 @@ func (b *BandPlan) Frequency(channelID uint8, channelNumber uint16) (uint32, err
   <!-- failure branch -->
   <line x1="30" y1="182" x2="650" y2="182" stroke="var(--fg-muted)" stroke-dasharray="2 4"/>
   <text x="30" y="202" fill="currentColor" font-size="10" font-weight="bold">no IDEN_UP for that ID yet?</text>
-  <text x="230" y="202" fill="var(--fg-muted)" font-size="10">→ queue the grant 5 s (pendingGrants) + publish decode.error stage="no-bandplan"</text>
-  <text x="230" y="218" fill="var(--fg-muted)" font-size="10">→ drained the moment BandPlan.Apply lands the matching slot</text>
+  <text x="230" y="202" fill="var(--fg-muted)" font-size="10">→ queue 5 s (pendingGrants) + publish decode.error stage="no-bandplan"</text>
+  <text x="230" y="218" fill="var(--fg-muted)" font-size="10">→ drained when BandPlan.Apply lands the slot</text>
 </svg>
 <figcaption>Sixteen bits of grant become a frequency only through the band-plan table the site broadcasts separately — and GopherTrunk queues the grant when the table hasn't arrived yet.</figcaption>
 </figure>
 
 Run the example backwards to see the scaling: base 851.00625 MHz is
-`freq32 = 170201250` in 5 Hz units, spacing 6.25 kHz is `step = 50` in
-125 Hz units. Those constants also explain the classic symptom of a
-corrupted IDEN_UP — a base off by a factor of five lands the tuner in a
-different band entirely. The overflow guard exists for the same reason: a
-malformed broadcast must produce an error, never a silently wrapped
-frequency that looks plausible.
+`freq32 = 170201250` in 5 Hz units; spacing 6.25 kHz is `step = 50` in
+125 Hz units. The overflow guard exists in the same spirit: a malformed
+broadcast must produce an error, never a silently wrapped frequency that
+looks plausible.
 
 ## When the table is late, missing, or wrong
 
@@ -263,8 +260,8 @@ advertised.
 
 ## Uplinks, offsets, and the AMBT rule
 
-Every IDEN_UP carries a transmit offset — uplink = downlink + offset — and
-for a receive-only scanner it is mostly documentation. But
+Every IDEN_UP carries a transmit offset — uplink = downlink + offset —
+mostly documentation for a receive-only scanner. But
 [Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})'s
 AMBT broadcasts reintroduce it with a trap: the Adjacent Status and RFSS
 Status AMBT forms carry **explicit uplink channels** — a second
@@ -311,22 +308,22 @@ because nothing tunes to it.
 
 ## Where this goes next
 
-Everything so far assumed the FM discriminator from Part 1 — the C4FM
-physics nearly every P25 site transmits.
+Everything so far assumed Part 1's FM discriminator — the C4FM physics
+nearly every P25 site transmits.
 [Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})
 walks the twin path: the linear CQPSK/LSM demodulator for the minority of
-sites where the discriminator produces near-random dibits, the
-fractionally-spaced equalizer that path carries, and the hard-won rule that
-"simulcast" does not mean what the project's own docs once said it meant.
+sites where the discriminator produces near-random dibits, the equalizer
+that path carries, and the hard-won rule that "simulcast" does not mean
+what the project's own docs once said.
 
 ## FAQ
 
 **Why doesn't P25 just broadcast the frequency in the grant?**
-Payload economy on a channel granting calls many times per second: a 16-bit
-index costs a quarter of a 32-bit frequency and the plan it indexes almost
-never changes. The trade is that every receiver becomes stateful — it must
-hold the site's IDEN_UP table before any grant is actionable, which is why
-GopherTrunk queues grants that arrive first.
+Payload economy on a channel granting calls many times per second: a
+16-bit index is half a 32-bit frequency and the plan it indexes almost
+never changes. The trade is that every receiver becomes stateful — no
+grant is actionable before the site's IDEN_UP table arrives, which is why
+GopherTrunk queues the ones that beat it.
 
 **How long does it take to learn a site's band plan?**
 Sites repeat IDEN_UP continuously alongside their status broadcasts — the
@@ -336,17 +333,16 @@ broadcast gap, short enough that a stale grant isn't resolved pointlessly
 late.
 
 **What does `decode.error stage="no-bandplan"` mean in my metrics?**
-A voice grant referenced a channel ID for which no IDEN_UP has been seen
-yet. Occasional counts right after lock are the normal race; a steady rate
-means the site uses an ID it rarely (or never) defines on this control
-channel, or your capture is dropping the TSBKs that define it.
+A voice grant referenced a channel ID with no IDEN_UP seen yet. Occasional
+counts right after lock are the normal race; a steady rate means the site
+uses an ID it rarely defines on this control channel, or your capture is
+dropping the TSBKs that define it.
 
 **Can I hardcode my system's band plan instead of learning it?**
 The wideband path can pre-seed the table from configured `P25BandPlan`
-entries at startup, which helps replay and very short captures. But the
-on-air broadcasts still apply and win — a site's own IDEN_UP is the ground
-truth, and rebanding history is the argument against trusting a static
-table alone.
+entries, which helps replay and very short captures. But the on-air
+broadcasts still apply and win — a site's own IDEN_UP is the ground truth,
+and rebanding history is the argument against static tables.
 
 **Does the tx offset matter for a receive-only scanner?**
 For tuning, no — GopherTrunk only tunes downlinks. It matters for the

--- a/docs/_posts/2026-09-07-p25-end-to-end-05-channels-band-plans.md
+++ b/docs/_posts/2026-09-07-p25-end-to-end-05-channels-band-plans.md
@@ -1,0 +1,362 @@
+---
+title: "P25 End to End, Part 5: Channel Identifiers & Band Plans — From Channel Number to Hertz"
+description: How a P25 grant's 16-bit channel field becomes a frequency — the IDEN_UP band-plan broadcasts in their 0x3D, 0x34 and 0x33 dialects, the base-plus-spacing arithmetic GopherTrunk runs in BandPlan.Frequency, and what happens when a grant arrives before the table that decodes it.
+category: deep-dives
+keywords: p25 iden_up, p25 band plan, p25 channel identifier, p25 channel number to frequency, iden_up_tdma 0x33, p25 grant frequency calculation, p25 tx offset uplink, trunking band plan decoding, gophertrunk p25
+tags: [p25-end-to-end, p25, band-plan, trunking, control-channel, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 5
+---
+
+*Part 5 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice.
+[Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})
+decoded Multi-Block Trunking and recovered the site broadcasts some
+systems only send in AMBT form. But every grant and neighbor announcement
+names its frequency the same indirect way: a 4-bit channel identifier plus
+a 12-bit channel number. This part is the dictionary that turns those
+sixteen bits into hertz — the IDEN_UP broadcasts, the arithmetic, and the
+failure modes when the dictionary is late, missing, or wrong.*
+
+> **TL;DR:** P25 never broadcasts frequencies with grants. A voice grant
+> carries a 16-bit channel field — **4-bit channel ID + 12-bit channel
+> number** — and the site separately, periodically broadcasts **IDEN_UP**
+> messages defining each ID slot's base frequency, spacing and transmit
+> offset. GopherTrunk accumulates them in `phase1.BandPlan`
+> (`internal/radio/p25/phase1/identifier.go`) and resolves
+> `freq = BaseHz + ChannelNumber × SpacingHz`. Three on-air dialects (opcodes
+> **0x3D**, **0x34** VHF/UHF, **0x33** TDMA) parse into one struct; base
+> frequencies scale ×5 Hz, spacing ×125 Hz. A grant arriving before its
+> IDEN_UP is queued for 5 s (`pendingGrants`) and surfaced as a
+> `decode.error` with `stage="no-bandplan"` — and an explicit uplink channel
+> from Part 4's AMBT broadcasts resolves as plain base+spacing with **no**
+> tx offset.
+
+**Key takeaways**
+
+- **A grant is not tunable by itself.** Its 16 bits index a table the site
+  broadcasts separately, on its own schedule. Every P25 receiver is
+  therefore stateful: no IDEN_UP yet, no frequency — which is why
+  GopherTrunk queues early grants instead of dropping them.
+- **Three IDEN_UP dialects, and their offset fields disagree.** Opcode
+  0x3D scales its 9-bit signed offset by a fixed 250 kHz; 0x34 and 0x33
+  carry a sign bit plus a 13-bit magnitude scaled by the *channel
+  spacing*. Parse one with the other's rules and every uplink you compute
+  is fiction.
+- **An explicit uplink channel number already encodes the uplink
+  frequency.** When an AMBT neighbor broadcast names an uplink channel,
+  GopherTrunk resolves it base+spacing with no transmit offset applied —
+  matching SDRTrunk, and the opposite of what the offset field's existence
+  tempts you to do.
+- **The channel ID carries more than arithmetic.** A slot advertised via
+  opcode 0x33 is flagged `AccessTDMA`, and that one bit routes the grant
+  into the Phase 2 voice chain — the wiring hybrid Phase 1 CC / Phase 2
+  voice systems (issue #376) silently lacked.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Standard IDEN_UP (0x3D) | 700/800/900 form: 9-bit BW, 9-bit offset ×250 kHz | `internal/radio/p25/phase1/identifier.go` (`ParseIdentifierUpdate`) |
+| VHF/UHF IDEN_UP (0x34) | 4-bit BW code, sign+13-bit offset ×spacing | `ParseIdentifierUpdateVUHF` |
+| TDMA IDEN_UP (0x33) | channel-type nibble, flags the slot `AccessTDMA` | `ParseIdentifierUpdateTDMA` |
+| The table | 16 slots of (base, spacing, offset), one per channel ID | `identifier.go` (`BandPlan.Apply` / `Frequency`) |
+| Grant resolution | (ID, number) → Hz, or `stage="no-bandplan"` error | `control.go` (`publishVoiceGrant`) |
+| Early-grant queue | 5 s TTL, 4-deep ring per channel ID, drained on Apply | `pending_grants.go` (`pendingGrants`) |
+| Phase 2 routing | `IsTDMA(id)` flips the grant to `"p25-phase2"` | `identifier.go` + `control.go` |
+
+## In this post
+
+- **Frequencies are never broadcast with grants** — the 4+12-bit indirection and why it exists.
+- **Three dialects, one struct** — 0x3D vs 0x34 vs 0x33, and where they disagree.
+- **The arithmetic, worked** — from bitfield to megahertz in one figure.
+- **When the table is late, missing, or wrong** — pending grants, `no-bandplan`, and tuning to nothing.
+- **Uplinks, offsets, and the AMBT rule** — the Part 4 callback, resolved in code.
+
+## Frequencies are never broadcast with grants
+
+Here is the whole payload of a Group Voice Channel Grant (TSBK opcode 0x00),
+the message [Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
+decoded a few hundred times a minute:
+
+```go
+// internal/radio/p25/phase1/opcodes.go (shape) — ParseGroupVoiceChannelGrant
+func ParseGroupVoiceChannelGrant(p [8]byte) GroupVoiceChannelGrant {
+    chanField := binary.BigEndian.Uint16(p[1:3])
+    return GroupVoiceChannelGrant{
+        ServiceOptions: p[0],
+        ChannelID:      uint8(chanField >> 12),  // 4 bits: which band plan
+        ChannelNumber:  chanField & 0x0FFF,      // 12 bits: which channel in it
+        GroupAddress:   binary.BigEndian.Uint16(p[3:5]),
+        SourceID:       uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+    }
+}
+```
+
+Sixteen bits of channel, and not one of them is a frequency. The reason is
+economy: a TSBK payload is eight bytes, a frequency takes four, and a site
+grants calls constantly while its frequency plan changes never. So P25
+factors the plan out — the site periodically broadcasts up to sixteen
+**channel identifier** definitions, each pairing a 4-bit ID with a base
+frequency, spacing, nominal bandwidth and transmit offset, and every grant,
+neighbor announcement and secondary-CC broadcast thereafter spends only 16
+bits per channel reference. The same `ID<<12 | number` packing appears in
+every channel-bearing TSBK in `opcodes.go` and in Part 4's AMBT forms alike.
+
+The cost of the economy is state: a receiver tuning in mid-stream knows the
+grants before it knows the dictionary — a structural race GopherTrunk built
+real machinery for, below.
+
+## Three dialects, one struct
+
+The dictionary entries arrive as **IDEN_UP** TSBKs, and there are three
+on-air variants. All three parse into one `IdentifierUpdate` struct, because
+downstream code only ever wants base, spacing, and offset — but the byte-0
+low nibble and the offset field mean different things in each:
+
+| | 0x3D `IDEN_UP` | 0x34 `IDEN_UP_VUHF` | 0x33 `IDEN_UP_TDMA` |
+|---|---|---|---|
+| Typical bands | 700/800/900 MHz | VHF / UHF | Phase 2 TDMA channels |
+| Byte-0 low nibble | top of a 9-bit BW field (×125 Hz) | 4-bit BW lookup code | 4-bit channel-type code (slots + access mode) |
+| Tx offset | 9-bit two's complement × **250 kHz** | sign + 13-bit magnitude × **SpacingHz** | sign + 13-bit magnitude × **SpacingHz** |
+| Extra semantics | — | — | marks the slot `AccessTDMA` |
+
+Two fields are identical everywhere, and their scaling is worth memorising
+because it explains every suspicious number in a band-plan log: the 32-bit
+base frequency is in units of **5 Hz** (`BaseHz = freq32 × 5`), and the
+10-bit channel step is in units of **125 Hz** (`SpacingHz = step × 125`).
+The standard form's parser is compact enough to quote whole:
+
+```go
+// internal/radio/p25/phase1/identifier.go (shape) — ParseIdentifierUpdate
+// Bit layout, MSB first: [ ChanID(4) | BW(9) | OFF(9) | STEP(10) | FREQ(32) ]
+func ParseIdentifierUpdate(p [8]byte) IdentifierUpdate {
+    chanID := p[0] >> 4
+    /* … extract bw, offRaw, step, freq5Hz from the packed bytes … */
+    off := int16(offRaw)
+    if off&0x100 != 0 {
+        off -= 0x200 // sign-extend the 9-bit two's-complement offset
+    }
+    return IdentifierUpdate{
+        ChannelID:   chanID,
+        BandwidthHz: uint32(bw) * 125,
+        SpacingHz:   uint32(step) * 125,
+        TxOffsetHz:  int64(off) * 250_000, // 0x3D only: fixed 250 kHz units
+        BaseHz:      uint64(freq5Hz) * 5,
+    }
+}
+```
+
+The VUHF and TDMA parsers were cross-checked against two independent
+decoders — OP25's `trunking.py` and SDRTrunk's `FrequencyBandUpdateVUHF` /
+`FrequencyBandUpdateTDMA` — rather than against GopherTrunk's own
+assemblers. Deliberate policy: Part 3's SCCB bug read a channel one byte
+early and its round-trip test passed *because the assembler encoded the
+same wrong layout*. A parser pinned only by its own inverse is pinned to
+nothing.
+
+One more thing rides on the 0x33 form. Its channel-type nibble says the
+granted channels are Phase 2 H-DQPSK TDMA carriers, so the parser stamps
+`AccessTDMA: true` on the slot. When a grant later resolves through that
+ID, `BandPlan.IsTDMA` flips the published protocol to `"p25-phase2"` so
+the composer runs the Phase 2 voice chain — wiring that was missing on
+hybrid Phase 1-CC / Phase 2-voice systems until issue #376, where every
+grant landed in the Phase 1 chain and the Phase 2 MAC dispatch was dead
+code. [Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})
+picks up the other side of that routing decision.
+
+## The arithmetic, worked
+
+Resolution itself is one line plus guard rails:
+
+```go
+// internal/radio/p25/phase1/identifier.go (shape) — BandPlan.Frequency
+func (b *BandPlan) Frequency(channelID uint8, channelNumber uint16) (uint32, error) {
+    if int(channelID) >= len(b.slots) || !b.known[channelID] {
+        return 0, fmt.Errorf("%w: id=%d", ErrUnknownChannelID, channelID)
+    }
+    u := b.slots[channelID]
+    hz := u.BaseHz + uint64(channelNumber)*uint64(u.SpacingHz)
+    if hz > 0xFFFFFFFF { // malformed IDEN_UP must not silently wrap
+        return 0, fmt.Errorf("p25/phase1: resolved frequency %d Hz overflows uint32", hz)
+    }
+    return uint32(hz), nil
+}
+```
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="A worked example of P25 channel resolution: a 16-bit channel field splits into a 4-bit identifier and a 12-bit channel number; the identifier selects one of sixteen band-plan slots carrying base frequency and spacing from an IDEN_UP broadcast; the arithmetic base plus number times spacing yields 853.88125 megahertz">
+  <!-- channel field -->
+  <rect x="30" y="28" width="60" height="30" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="90" y="28" width="180" height="30" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="60" y="47" text-anchor="middle" fill="var(--accent)" font-size="11">ID = 1</text>
+  <text x="180" y="47" text-anchor="middle" fill="currentColor" font-size="11">number = 460</text>
+  <text x="150" y="18" text-anchor="middle" fill="var(--fg-muted)" font-size="10">grant channel field (16 bits): 0x11CC</text>
+  <text x="60" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="9">4 bits</text>
+  <text x="180" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="9">12 bits</text>
+  <!-- band plan table -->
+  <rect x="330" y="24" width="320" height="76" fill="none" stroke="var(--fg-muted)"/>
+  <text x="340" y="40" fill="var(--fg-muted)" font-size="10">band plan (from IDEN_UP broadcasts)</text>
+  <text x="340" y="58" fill="currentColor" font-size="10">id 0: base 851.00625 MHz · spacing 6.25 kHz</text>
+  <text x="340" y="76" fill="var(--accent)" font-size="10" font-weight="bold">id 1: base 851.00625 MHz · spacing 6.25 kHz</text>
+  <text x="340" y="94" fill="var(--fg-muted)" font-size="10">id 2..15: (unknown until broadcast)</text>
+  <path d="M 92 60 C 140 110 260 90 334 74" fill="none" stroke="var(--accent)" stroke-dasharray="4 3"/>
+  <polygon points="334,74 322,72 328,82" fill="var(--accent)"/>
+  <!-- arithmetic -->
+  <text x="60" y="140" fill="currentColor" font-size="11">851.00625 MHz</text>
+  <text x="168" y="140" fill="var(--fg-muted)" font-size="11">+</text>
+  <text x="185" y="140" fill="currentColor" font-size="11">460 × 6.25 kHz</text>
+  <text x="300" y="140" fill="var(--fg-muted)" font-size="11">=</text>
+  <text x="320" y="140" fill="var(--accent)" font-size="12" font-weight="bold">853.88125 MHz</text>
+  <text x="60" y="162" fill="var(--fg-muted)" font-size="10">BaseHz (freq32 × 5 Hz)   number × SpacingHz (step × 125 Hz)</text>
+  <!-- failure branch -->
+  <line x1="30" y1="182" x2="650" y2="182" stroke="var(--fg-muted)" stroke-dasharray="2 4"/>
+  <text x="30" y="202" fill="currentColor" font-size="10" font-weight="bold">no IDEN_UP for that ID yet?</text>
+  <text x="230" y="202" fill="var(--fg-muted)" font-size="10">→ queue the grant 5 s (pendingGrants) + publish decode.error stage="no-bandplan"</text>
+  <text x="230" y="218" fill="var(--fg-muted)" font-size="10">→ drained the moment BandPlan.Apply lands the matching slot</text>
+</svg>
+<figcaption>Sixteen bits of grant become a frequency only through the band-plan table the site broadcasts separately — and GopherTrunk queues the grant when the table hasn't arrived yet.</figcaption>
+</figure>
+
+Run the example backwards to see the scaling: base 851.00625 MHz is
+`freq32 = 170201250` in 5 Hz units, spacing 6.25 kHz is `step = 50` in
+125 Hz units. Those constants also explain the classic symptom of a
+corrupted IDEN_UP — a base off by a factor of five lands the tuner in a
+different band entirely. The overflow guard exists for the same reason: a
+malformed broadcast must produce an error, never a silently wrapped
+frequency that looks plausible.
+
+## When the table is late, missing, or wrong
+
+The race is real and routine: tune to a busy control channel and the first
+grant usually beats the first IDEN_UP. GopherTrunk's answer has two halves.
+First, visibility: `publishVoiceGrant` can't act on a grant whose channel
+ID has no slot, so it publishes a `decode.error` with
+`stage="no-bandplan"` — a counter operators can watch, not a silent drop.
+Second, patience: the grant enters `pendingGrants`
+(`internal/radio/p25/phase1/pending_grants.go`), a bounded ring of four
+entries per channel ID, drained the moment `BandPlan.Apply` lands the
+matching slot, with a **5-second TTL** — a voice grant addresses a live
+window measured in seconds, so resolving one later buys nothing, and the
+bound caps memory against a site that never defines some ID. This is the
+difference between "missed the first half-second of the first call after
+tune-in" and "missed the call."
+
+*Wrong* is worse than *missing*, because wrong resolves. A stale or
+corrupted band plan tunes every voice grant to a confidently computed
+frequency where nothing is transmitting — recordings of hiss, or none at
+all, while the control channel decodes perfectly. The 800 MHz **rebanding**
+era made this a live concern: NPSPAC-region systems moved their voice
+channels years ago, so any receiver carrying a hardcoded 800 MHz table
+decodes grants against history. GopherTrunk's position is structural: there
+is no built-in table. The band plan is *always* learned from the site's own
+broadcasts (the wideband path can pre-seed it from a config snapshot), so a
+rebanded, splintered, or just-plain-odd system is decoded on its own
+declared arithmetic. The learned plan is also exported —
+`BandPlan.Snapshot` feeds the discovery and
+[hunting]({{ '/blog/deep-dives/the-hunt-07-locking-a-p25-system/' | relative_url }})
+layers so a discovered system is documented with the plan it actually
+advertised.
+
+## Uplinks, offsets, and the AMBT rule
+
+Every IDEN_UP carries a transmit offset — uplink = downlink + offset — and
+for a receive-only scanner it is mostly documentation. But
+[Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})'s
+AMBT broadcasts reintroduce it with a trap: the Adjacent Status and RFSS
+Status AMBT forms carry **explicit uplink channels** — a second
+(ID, number) pair naming the neighbor's uplink directly. The tempting bug
+is to resolve that pair and then also apply the offset. The rule
+GopherTrunk encodes, matching SDRTrunk, is that an explicit uplink channel
+number *already encodes the uplink frequency*:
+
+```go
+// internal/radio/p25/phase1/control.go (shape) — topology snapshot
+if n.UplinkID != 0 || n.UplinkNumber != 0 {
+    // An explicit uplink channel number already encodes the uplink
+    // frequency in plain base+spacing terms — no transmit offset is
+    // applied (matches SDRTrunk's AMBT downlink/uplink resolution).
+    if hz, err := c.bandPlan.Frequency(n.UplinkID, n.UplinkNumber); err == nil {
+        ref.UplinkHz = hz
+    }
+}
+```
+
+Same arithmetic, same table, no offset. The offset exists so a *derived*
+uplink can be computed when only the downlink is named; an explicit uplink
+channel is not derived. Getting this wrong doesn't break receive — it
+corrupts the exported site topology
+[Part 10]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})
+builds roaming on: exactly the kind of error that survives for months
+because nothing tunes to it.
+
+### How the indirection shaped the Go code
+
+- **The table is a type, not a map in a handler.** `BandPlan` owns the
+  sixteen slots and the arithmetic; the control channel and the
+  [trunking engine]({{ '/blog/deep-dives/trunking-engine-03-grants/' | relative_url }})
+  only ever see a resolved `trunking.Grant.FrequencyHz` or an error.
+- **Three parsers, one output shape.** The dialects differ exactly where
+  confusing them is expensive, so each opcode gets its own parser and its
+  own literal-vector tests — all converging on `IdentifierUpdate`.
+- **Absence is an event.** `ErrUnknownChannelID` becomes a published
+  `stage="no-bandplan"` decode error — a gap you can graph gets fixed; a
+  gap that logs at debug does not.
+- **Grants wait, bounded.** `pendingGrants` turns the broadcast race into
+  a short TTL'd queue instead of dropping the first call after tune-in or
+  growing memory on a broken site.
+
+## Where this goes next
+
+Everything so far assumed the FM discriminator from Part 1 — the C4FM
+physics nearly every P25 site transmits.
+[Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})
+walks the twin path: the linear CQPSK/LSM demodulator for the minority of
+sites where the discriminator produces near-random dibits, the
+fractionally-spaced equalizer that path carries, and the hard-won rule that
+"simulcast" does not mean what the project's own docs once said it meant.
+
+## FAQ
+
+**Why doesn't P25 just broadcast the frequency in the grant?**
+Payload economy on a channel granting calls many times per second: a 16-bit
+index costs a quarter of a 32-bit frequency and the plan it indexes almost
+never changes. The trade is that every receiver becomes stateful — it must
+hold the site's IDEN_UP table before any grant is actionable, which is why
+GopherTrunk queues grants that arrive first.
+
+**How long does it take to learn a site's band plan?**
+Sites repeat IDEN_UP continuously alongside their status broadcasts — the
+slots that matter usually land within seconds of locking. The 5-second
+pending-grant TTL is sized to that cadence: long enough to bridge a normal
+broadcast gap, short enough that a stale grant isn't resolved pointlessly
+late.
+
+**What does `decode.error stage="no-bandplan"` mean in my metrics?**
+A voice grant referenced a channel ID for which no IDEN_UP has been seen
+yet. Occasional counts right after lock are the normal race; a steady rate
+means the site uses an ID it rarely (or never) defines on this control
+channel, or your capture is dropping the TSBKs that define it.
+
+**Can I hardcode my system's band plan instead of learning it?**
+The wideband path can pre-seed the table from configured `P25BandPlan`
+entries at startup, which helps replay and very short captures. But the
+on-air broadcasts still apply and win — a site's own IDEN_UP is the ground
+truth, and rebanding history is the argument against trusting a static
+table alone.
+
+**Does the tx offset matter for a receive-only scanner?**
+For tuning, no — GopherTrunk only tunes downlinks. It matters for the
+exported topology, and it matters that you *don't* apply it to an explicit
+AMBT uplink channel, which already encodes the uplink frequency in
+base+spacing terms.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: Multi-Block Trunking — The PDU That Isn't Noise]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})
+· Next →
+[Part 6: CQPSK & LSM — The Linear Twin Path]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})

--- a/docs/_posts/2026-09-07-p25-end-to-end-05-channels-band-plans.md
+++ b/docs/_posts/2026-09-07-p25-end-to-end-05-channels-band-plans.md
@@ -267,20 +267,12 @@ AMBT broadcasts reintroduce it with a trap: the Adjacent Status and RFSS
 Status AMBT forms carry **explicit uplink channels** — a second
 (ID, number) pair naming the neighbor's uplink directly. The tempting bug
 is to resolve that pair and then also apply the offset. The rule
-GopherTrunk encodes, matching SDRTrunk, is that an explicit uplink channel
-number *already encodes the uplink frequency*:
-
-```go
-// internal/radio/p25/phase1/control.go (shape) — topology snapshot
-if n.UplinkID != 0 || n.UplinkNumber != 0 {
-    // An explicit uplink channel number already encodes the uplink
-    // frequency in plain base+spacing terms — no transmit offset is
-    // applied (matches SDRTrunk's AMBT downlink/uplink resolution).
-    if hz, err := c.bandPlan.Frequency(n.UplinkID, n.UplinkNumber); err == nil {
-        ref.UplinkHz = hz
-    }
-}
-```
+GopherTrunk encodes, matching SDRTrunk's AMBT resolution, is that an
+explicit uplink channel number *already encodes the uplink frequency*:
+the topology snapshot in `control.go` runs the neighbor's
+`(UplinkID, UplinkNumber)` through the very same `bandPlan.Frequency`
+call as any downlink — plain base+spacing, with the comment "no transmit
+offset is applied" doing the standing-rule duty.
 
 Same arithmetic, same table, no offset. The offset exists so a *derived*
 uplink can be computed when only the downlink is named; an explicit uplink

--- a/docs/_posts/2026-09-08-from-spec-to-shipping-06-when-references-disagree.md
+++ b/docs/_posts/2026-09-08-from-spec-to-shipping-06-when-references-disagree.md
@@ -1,0 +1,346 @@
+---
+title: "From Spec to Shipping, Part 6: When References Disagree, the Capture Referees"
+description: "Two trusted decoders gave two different DMO burst geometries, and a single capture could not pin the colour-code bit offset at all. How GopherTrunk designs referee measurements where the right answer wins by a wide margin — and refuses to answer when it doesn't."
+category: deep-dives
+keywords: tetra dmo burst geometry, dnb block offsets, osmo-tetra-dmo comparison, dm colour code recovery, crc yield sweep, when reference implementations disagree, empirical protocol validation, dominance gate decoder, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, tetra, dmo, methodology, captures, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 6
+---
+
+*Part 6 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 5]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})
+drew the clean-room wall: implement from the spec, run other decoders as
+oracles, let facts cross with a citation. But an oracle is only useful
+while it's right — and this part is about the days it isn't. When two
+references you trust disagree, or when neither can answer at all,
+authority stops working and only one referee is left: a measurement on a
+real capture, designed so the correct answer cannot lose narrowly.*
+
+> **TL;DR:** GopherTrunk's TETRA DMO normal burst slices its blocks at
+> **−108/+11 dibits** around the training-sequence lead
+> (`dmDNBBKN1Start`/`dmDNBBKN2Start`, `internal/radio/tetra/dmo.go`) —
+> derived from EN 300 396-2 Tables 15/16 — while osmo-tetra-dmo carries
+> the TMO geometry, **−115/+19** (the very numbers in GT's own TMO
+> `traffic.go`). The tie-breaker was never authority: on a real 438.9 MHz
+> capture, TCH/S CRC yield shows a **sharp optimum** at −108/+11 and is
+> measurably worse at −115/+19. The DM colour-code bit offset could *not*
+> be pinned the same way (colour 3 lights only two LSBs — ambiguous), so
+> `RecoverDMColourCode` recovers it empirically instead — maximize
+> CRC-valid TCH/S over all 64 colours, behind a dominance gate
+> (best ≥ 6 and ≥ 3× the runner-up) that **refused** to pick on the one
+> capture where no colour dominated. That refusal was correct: the real
+> cause was a non-zero network MNI
+> ([#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003)).
+
+**Key takeaways**
+
+- **Authority doesn't referee; captures do.** Between a spec table you
+  derived and a proven implementation's different numbers, the decidable
+  question is which geometry decodes more CRC-valid speech from real air.
+- **Design the measurement so the right answer wins big.** CRC yield over
+  a parameter sweep gives the true value a structural advantage — the
+  correct colour descrambles class-2-protected speech while every wrong
+  one sits at a ~1/256 chance floor. Wide margins survive noise;
+  narrow ones are noise.
+- **Refusing to answer is an answer.** The dominance gate that "failed"
+  on the 15 Aug capture — several colours rising modestly, none 3× ahead —
+  was reporting a physically impossible pattern, and the impossibility
+  was the diagnostic clue.
+- **A single capture can under-determine a field.** Colour 3 exercises
+  two bits of a six-bit field; hardcoding an offset from it is the
+  self-consistent trap wearing a lab coat. When the data can't pin the
+  layout, recover the *value* empirically and leave the layout unpinned.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| DMO DNB geometry | BKN1 at L−108, BKN2 at L+11 (from EN 300 396-2 Tables 15/16) | `internal/radio/tetra/dmo.go` (`dmDNBBKN1Start`, `dmDNBBKN2Start`) |
+| TMO NDB geometry | BKN1 at L−115, BKN2 at L+19 — what osmo-tetra-dmo reuses for DMO | `internal/radio/tetra/traffic.go` (`ndbBKN1Start`) |
+| Colour recovery | picks the scramble seed maximizing CRC-valid TCH/S, 64 candidates | `internal/radio/tetra/dmo_decode.go` (`RecoverDMColourCode`) |
+| Confidence gate | best ≥ 6 CRC-valid AND ≥ 3× runner-up, else "not confident" | `dmo_decode.go` (`dmColourMinCRC`, `dmColourDominance`) |
+| Synthetic pin | colour-3 stream + noise distractors; all-noise must refuse | `dmo_decode_test.go` (`TestRecoverDMColourCode`) |
+| Field diagnostic | per-burst colour map when the model itself is in doubt | `cmd/gophertrunk/tetra_dmo_replay_test.go` (`TestTETRADMOColourScan`, `GT_TETRA_DMO_SCAN=1`) |
+
+## In this post
+
+- **The disagreement** — one burst, two geometries, both from sources we
+  trust.
+- **A referee with a sharp peak** — how CRC yield settled −108/+11.
+- **The offset no capture could pin** — the colour field and the trap of
+  hardcoding it.
+- **Recovering the value instead of the layout** — `RecoverDMColourCode`
+  and its dominance gate.
+- **When the gate says no** — the 15 Aug refusal, and why it was the
+  most informative output of the whole investigation.
+
+## The disagreement
+
+TETRA Direct Mode reuses the trunked-mode physical layer wholesale —
+same π/4-DQPSK, same 18000 sym/s, same 255-symbol timeslots, same
+training sequences — but its Direct Mode Normal Burst (DNB) lays its two
+216-bit payload blocks out differently around the training sequence.
+GopherTrunk derived the geometry from EN 300 396-2 Tables 15 and 16 by
+halving the on-air bit numbers into dibit offsets:
+
+```go
+// internal/radio/tetra/dmo.go (shape)
+// DNB (Table 15): BKN1 bits 15..230  → dibits 7..114 (108 dibits)
+//                 norm train 231..252 → dibits 115..125 (lead L=115)
+//                 BKN2 bits 253..468  → dibits 126..233 (108 dibits)
+const (
+    dmDNBBKN1Start = -108 // L-108 .. L
+    dmDNBBKN2Start = 11   // L+11  .. L+119
+)
+```
+
+osmo-tetra-dmo — a reference this project trusts enough to have
+cross-checked its scrambler seed byte-for-byte
+([Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }}))
+— slices the same burst at the TMO offsets: BKN1 at **L−115**, BKN2 at
+**L+19**. Those are not strange numbers; they're the *trunked-mode*
+normal-burst geometry, the exact constants in GopherTrunk's own
+`traffic.go` (`ndbBKN1Start = -115`). One reading says the spec tables
+give DMO its own layout; the other says DMO inherited TMO's. Both come
+from serious sources. Reading the PDF harder does not break the tie —
+[Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})
+already catalogued how easily two careful readers extract two different
+offset sets from the same table.
+
+## A referee with a sharp peak
+
+What breaks the tie is that the two geometries are not equally good at a
+job we can score. Slice a real DNB at the right offsets and the block
+boundaries line up with the channel coding: descramble, deinterleave,
+Viterbi, and the TCH/S class-2 CRC passes. Slice it seven dibits off and
+every codeword straddles a boundary — the CRC yield collapses toward the
+chance floor. So the referee is a sweep: decode the operator's real
+438.9 MHz DMO capture at candidate geometries and count CRC-valid
+speech frames.
+
+The result was not a nudge. **−108/+11 sits at a sharp optimum; the
+TMO-copied −115/+19 is measurably worse** — and sharpness is the point.
+A CRC is a ~1-in-256-per-frame accident under a wrong hypothesis, so a
+correct geometry doesn't beat a wrong one by a whisker; it towers over
+it. That structural advantage is what makes the measurement a referee
+rather than a coin flip, and it's the same yield-is-the-only-verdict
+rule the
+[Weak-Signal Engineering series]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }})
+learned from equalizers: a metric that can only be flattered by being
+*right* beats any amount of authority.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Two CRC-yield sweep curves side by side. Left: yield versus DNB block offset shows a single sharp peak at minus 108, towering over the chance floor, with the osmo geometry at minus 115 marked well below it — the referee can rule. Right: yield versus colour code on the 15 August capture shows several modest bumps of similar height above the floor with none three times the runner-up — the dominance gate refuses to pick.">
+  <line x1="45" y1="20" x2="45" y2="180" stroke="var(--fg-muted)"/>
+  <line x1="45" y1="180" x2="320" y2="180" stroke="var(--fg-muted)"/>
+  <text x="20" y="30" fill="var(--fg-muted)" font-size="9">CRC</text>
+  <text x="20" y="42" fill="var(--fg-muted)" font-size="9">yield</text>
+  <text x="182" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BKN1 offset (dibits)</text>
+  <polyline points="45,172 90,171 120,168 150,60 165,34 180,58 210,166 250,170 320,172" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <line x1="165" y1="34" x2="165" y2="180" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <text x="165" y="212" text-anchor="middle" fill="var(--accent)" font-size="10">−108: sharp optimum</text>
+  <circle cx="120" cy="168" r="4" fill="none" stroke="currentColor"/>
+  <text x="112" y="156" text-anchor="end" fill="currentColor" font-size="9">−115 (osmo)</text>
+  <text x="182" y="228" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">geometry: referee rules</text>
+  <line x1="395" y1="20" x2="395" y2="180" stroke="var(--fg-muted)"/>
+  <line x1="395" y1="180" x2="660" y2="180" stroke="var(--fg-muted)"/>
+  <text x="527" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="9">colour code 0..63</text>
+  <polyline points="395,172 420,170 440,120 455,171 480,150 500,172 525,140 545,171 575,158 600,172 630,169 660,172" fill="none" stroke="currentColor" stroke-width="2"/>
+  <line x1="395" y1="176" x2="660" y2="176" stroke="var(--fg-muted)" stroke-dasharray="2 4"/>
+  <text x="656" y="170" text-anchor="end" fill="var(--fg-muted)" font-size="9">chance floor</text>
+  <text x="440" y="108" text-anchor="middle" fill="currentColor" font-size="9">140</text>
+  <text x="525" y="128" text-anchor="middle" fill="currentColor" font-size="9">74</text>
+  <text x="575" y="147" text-anchor="middle" fill="currentColor" font-size="9">46</text>
+  <text x="527" y="228" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">colour, 15 Aug: gate refuses (140 &lt; 3×74)</text>
+</svg>
+<figcaption>The same referee, two verdicts: a sharp lone peak settles the geometry question, while several modest bumps — a pattern one radio with one scramble seed cannot produce — make refusal the only honest output.</figcaption>
+</figure>
+
+## The offset no capture could pin
+
+The next unknown looked identical and wasn't. A DMO receiver needs the
+DM **colour code** — the low six bits of the 30-bit scramble seed — to
+descramble traffic. The signalling can't simply hand it over: the DSB's
+SCH/S is *always* scrambled with colour 0 (like TMO's BSCH), so it
+decodes regardless of the traffic colour and reads colour 0 forever. The
+field genuinely lives in the DM-SYNC SYSINFO carried by the DSB's SCH/H
+(EN 300 396-3) — so why not pin its bit offset from the capture, the way
+the geometry was pinned?
+
+Because the capture couldn't. The operator's radios ran colour **3** —
+binary `000011` — which lights only the field's two least-significant
+bits. Any 6-bit window whose bottom two bits match is consistent with
+the data; an empirical scan across candidate offsets found **no unique
+window**. Hardcoding one anyway would have been the
+[self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
+in its most seductive form: the parser would decode *this* capture
+correctly, a round-trip test would enshrine the guess, and the first
+network running colour 40 would decode garbage with every test green.
+The reference stable was no help either — this is exactly the "know what
+a reference does NOT decide" rule from
+[Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }}):
+no independent decoder pinned that offset in a form we could
+cross-check against a second one.
+
+## Recovering the value instead of the layout
+
+So GopherTrunk declines to parse what it cannot pin, and recovers the
+value by measurement instead — the same referee, run at decode time:
+
+```go
+// internal/radio/tetra/dmo_decode.go (shape) — RecoverDMColourCode
+base := baseMNI &^ 0x3F
+var counts [64]int
+for c := 0; c < 64; c++ {
+    seed := base | uint32(c)
+    n := 0
+    for i := range bursts {
+        /* … skip non-DNBs … */
+        if len(DMBurstTCHSpeechSoft(b, seed)) == 2 ||
+            len(DMBurstTCHSpeech(b, seed)) == 2 {
+            n++
+        }
+    }
+    counts[c] = n
+}
+/* … best / runner-up … */
+confident = best >= dmColourMinCRC &&
+    best >= dmColourDominance*max(second, 1)
+```
+
+Try all 64 colours, count CRC-valid speech frames at each, and pick the
+winner — but only when the winner *deserves* it. The gate demands at
+least `dmColourMinCRC = 6` CRC-valid bursts **and** a
+`dmColourDominance = 3`× lead over the runner-up, thresholds set by the
+physics of the measurement: on the capture that proved the mechanism,
+the true colour scored **35 CRC-valid TCH/S bursts while every wrong
+colour managed ≤ 3** — 70 speech frames, 2.1 s of clear PCM, recovered
+with no manual override (the story
+[TETRA End to End Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+tells end to end). An encrypted call, an unreceivable capture, or plain
+noise clears neither bar, and the function says so instead of guessing.
+The synthetic pin, `TestRecoverDMColourCode`, checks both faces: a
+colour-3 stream with noise distractors must recover 3 confidently, and
+an **all-noise set must refuse** — the refusal path is a tested feature,
+not an error branch.
+
+Note what was and wasn't decided. The colour *value* is recovered per
+transmission; the SYSINFO field's *bit offset* stays unparsed until a
+capture with a colour like 42 (`101010`) can pin it uniquely. The
+unknown is quarantined exactly the way
+[Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})
+quarantined the unnamed comms-type enum: decoded around, logged,
+never load-bearing.
+
+## When the gate says no
+
+Then came the capture that tested the gate's nerve. The 15 Aug
+operator run — 25 s of clear, colour-0 PTT — decoded DSB signalling at
+~90%, yet the 64-colour sweep (`TestTETRADMOColourScan`, the
+`GT_TETRA_DMO_SCAN=1` diagnostic) produced the right-hand curve in the
+figure: **several colours rising modestly at once** — 140, 74, 46
+CRC-valid of 831 DNBs — none dominant. The gate refused: 140 < 3×74.
+The operator read it as "the colour guessing is broken."
+
+It was the opposite. One radio scrambling with one seed *cannot* produce
+three partial winners — a wrong model can. The refusal, plus the
+per-burst colour map the diagnostic preserved, is what eventually
+cracked the real cause: the radios ran a **non-zero network MNI**
+(MCC 250 / MNC 1), and TETRA seeds its scrambler from the full 30-bit
+extended colour code — so a search over bare colours 0..63 was
+searching a 64-seed slice of a space whose true seed it could never
+reach. Every candidate sat near the floor; partial keystream overlaps
+made a few rise together. The fix threads the configured MNI into the
+search (`baseMNI` in the excerpt above, from the `tetra_mcc`/`tetra_mnc`
+config keys), pinned failing-first by `TestRecoverDMColourCodeNonZeroMNI`
+scrambling with the independently-derived osmo seed formula.
+
+Had the gate picked the 140-yield colour — a "33% solution" — the
+decoder would have shipped a wrong descramble model that half-worked on
+one capture, and the MNI blind spot might still be undiagnosed. The
+capture referees, but only if the machinery is allowed to say *no
+contest*.
+
+### How that principle shaped the Go code
+
+- **Sweeps are decode-time citizens, not notebook scripts.**
+  `RecoverDMColourCode` ships in the production pipeline; the same
+  yield-maximization that settled the lab question runs on every
+  unconfigured DMO transmission.
+- **Every empirical pick carries a confidence bit.** The function returns
+  `confident`, and callers keep their configured default when it's false —
+  a chance-floor winner never silently becomes state.
+- **Diagnostics outlive the bug they were built for.**
+  `TestTETRADMOColourScan` asserts nothing; it prints the burst→colour
+  map so the *next* wrong model reveals its shape too — the instrument
+  mindset [Part 13]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})
+  makes systematic.
+- **Under-determined layouts stay unparsed.** No struct field exists for
+  the SYSINFO colour offset; the absence is deliberate and commented, so
+  nobody "helpfully" fills it in from one capture.
+
+## Where this goes next
+
+The colour saga's near-misses all share a shape: a test that would have
+agreed with the code because both encoded the same wrong assumption.
+[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+engineers that failure mode away — fixture transmitters that scramble
+like real radios, fake servers that enforce the real protocol's
+strictness, and control paths built from components the code under test
+doesn't share.
+
+## FAQ
+
+**What should I do when two reference implementations disagree about a
+wire format?**
+Stop reading and start scoring. Find a metric where the correct answer
+has a structural advantage — CRC yield is the usual one, because a wrong
+hypothesis sits at a chance floor — and run both candidates over a real
+capture. If the winner doesn't win by a wide margin, the capture is
+telling you your model has a deeper problem than the parameter you're
+sweeping.
+
+**Why is CRC yield a better referee than signal metrics like EVM or
+SNR?**
+Because it can't be flattered by anything except correctness. EVM
+improved 34%→8% on a GopherTrunk equalizer variant that decoded zero
+frames; a CRC passes only when descramble, deinterleave, FEC and layout
+are all simultaneously right, and a wrong hypothesis passes it ~1/256 of
+the time by luck. Sharp peaks in yield are evidence; smooth improvements
+in proxies are often self-deception.
+
+**How does GopherTrunk recover the TETRA DMO colour code without
+decoding it from signalling?**
+`RecoverDMColourCode` brute-forces all 64 colours (folded with the
+configured network MNI) and picks the one that maximizes CRC-valid
+TCH/S speech across the buffered bursts — accepting only a winner with
+≥ 6 CRC-valid bursts and a 3× lead over the runner-up. On the verifying
+capture the true colour scored 35 against ≤ 3 for every other candidate.
+
+**Isn't refusing to pick a colour just failing more politely?**
+No — it's preserving the information a forced pick destroys. The 15 Aug
+refusal encoded a physically impossible yield pattern, which pointed the
+investigation at the descramble *model* (the MNI blind spot) instead of
+at a plausible-but-wrong colour. A decoder that always answers converts
+model errors into silent misconfigurations.
+
+**Can one capture ever fully validate a parsed field?**
+Only if it exercises enough of the field's range to make the layout
+unique — colour 3 in a 6-bit field cannot. Until a discriminating
+capture exists, GopherTrunk's pattern is to recover the value
+empirically, log the raw bits for later confirmation, and keep the
+offset out of load-bearing code — the on-air gate
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+formalizes.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: Clean-Room Rules — Reading Without Copying]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})
+· Next →
+[Part 7: Tests That Can Disagree With You]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})

--- a/docs/_posts/2026-09-08-from-spec-to-shipping-06-when-references-disagree.md
+++ b/docs/_posts/2026-09-08-from-spec-to-shipping-06-when-references-disagree.md
@@ -1,6 +1,6 @@
 ---
 title: "From Spec to Shipping, Part 6: When References Disagree, the Capture Referees"
-description: "Two trusted decoders gave two different DMO burst geometries, and a single capture could not pin the colour-code bit offset at all. How GopherTrunk designs referee measurements where the right answer wins by a wide margin — and refuses to answer when it doesn't."
+description: Two trusted decoders gave two different DMO burst geometries, and a single capture could not pin the colour-code bit offset at all. How GopherTrunk designs referee measurements where the right answer wins by a wide margin — and refuses to answer when it doesn't.
 category: deep-dives
 keywords: tetra dmo burst geometry, dnb block offsets, osmo-tetra-dmo comparison, dm colour code recovery, crc yield sweep, when reference implementations disagree, empirical protocol validation, dominance gate decoder, gophertrunk from spec to shipping
 tags: [from-spec-to-shipping, tetra, dmo, methodology, captures, go]
@@ -200,6 +200,7 @@ for c := 0; c < 64; c++ {
     seed := base | uint32(c)
     n := 0
     for i := range bursts {
+        b := bursts[i]
         /* … skip non-DNBs … */
         if len(DMBurstTCHSpeechSoft(b, seed)) == 2 ||
             len(DMBurstTCHSpeech(b, seed)) == 2 {

--- a/docs/_posts/2026-09-08-operator-cookbook-06-analog-fm-tone-out.md
+++ b/docs/_posts/2026-09-08-operator-cookbook-06-analog-fm-tone-out.md
@@ -1,0 +1,345 @@
+---
+title: "The Operator's Cookbook, Part 6: Analog FM & Tone-Out Paging"
+description: A complete GopherTrunk recipe for conventional analog FM — a real scan list with squelch, CTCSS/DCS tone gating and per-channel hangtime, plus Quick Call II two-tone fire paging alerts, built on the scanner.conventional and tone_out config sections with every key verified.
+category: tutorials
+keywords: sdr analog fm scanner, fire dispatch scanner sdr, two tone paging decoder, quick call 2 tone out, ctcss squelch sdr scanner, conventional scan list config, marine vhf sdr monitor, rtl-sdr fire tones, gophertrunk cookbook
+tags: [operator-cookbook, analog-fm, tone-out, ctcss, scanning, config]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 6
+---
+
+*Part 6 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 5]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }})
+decoded TETRA radios talking directly to each other; this part drops the last
+digital layer entirely. Plenty of the traffic worth hearing — volunteer fire
+dispatch, marine VHF, GMRS repeaters, race crews — is still **plain analog
+FM**, and GopherTrunk scans it the way a hardware scanner does: a channel
+list, real squelch, sub-audible tone gating, and a two-tone detector that
+fires an alert the instant your station's pager tones hit the air. One
+honest reshaping up front: analog channels live in their own config section,
+not under `trunking.systems` — this recipe is built on what actually exists.*
+
+> **TL;DR:** Analog FM is a **scan list, not a trunked system**: channels go
+> under `scanner.conventional` (label, `frequency_hz`, `mode: fm|nfm`,
+> `squelch_dbfs`, `hangtime_ms`, per-channel CTCSS/DCS `tone:` gating), and
+> the scanner drives a dedicated **`role: voice`** SDR — the last voice
+> device in the pool. Each open-squelch dwell becomes a synthetic call
+> (`synthetic call started` in the log), recorded like any digital call. On
+> top of the decoded audio, `tone_out.profiles` runs a Goertzel two-tone
+> detector for Quick Call II fire paging and logs
+> `toneout: profile matched`. Pin a `talkgroup_id` per channel or your call
+> log's IDs shift when you reorder the list (#1105).
+
+**Key takeaways**
+
+- **Conventional analog is its own config section.** `scanner.conventional`
+  is a fixed-frequency scan list with per-channel squelch, priority and
+  hangtime — deliberately shaped like the scan list in a hardware scanner,
+  not like a trunked system.
+- **The scanner needs a voice SDR to own.** It takes the *last* `role: voice`
+  device in the pool; with none configured the daemon logs a WARN and skips
+  the scanner entirely — the most common "why is my scan list dead" cause.
+- **Tone gating is what makes shared frequencies usable.** With
+  [CTCSS]({{ '/reference/ctcss/' | relative_url }}) or
+  [DCS]({{ '/reference/dcs/' | relative_url }}) configured, the scanner
+  dwells only when carrier *and* the right tone are present, so a
+  co-channel system two counties over can't hold your scanner hostage.
+- **Tone-out listens to audio, not RF.** The two-tone detector runs on
+  decoded PCM from any voice device — so it catches pages on your analog
+  scan list *and* on digital talkgroups alike, scoped by profile.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The scan list | fixed analog channels, scanned in order | `scanner.conventional[]` |
+| Squelch | carrier gate in dBFS, per channel | `squelch_dbfs` ([squelch]({{ '/reference/squelch/' | relative_url }})) |
+| Tone gate | require CTCSS/DCS before dwelling | `tone: {mode, ctcss_hz, dcs_code}` |
+| Stable call-log IDs | pin the channel's talkgroup number | `talkgroup_id` (else synthetic, shifts on reorder — #1105) |
+| Fire paging alerts | Quick Call II two-tone sequential detect | `tone_out.profiles[]` |
+| Live audio | hear dwells on the host speakers | `audio.enabled: true` |
+| Where the frequencies are | US service-by-service listings | [scanner frequencies guide]({{ '/scanner-frequencies/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — a software scanner with a pager bolted on.
+- **The shopping list** — one dongle, one band-appropriate antenna.
+- **The config** — scan list + tone-out profiles, every key verified.
+- **First run — what healthy looks like** — dwells, synthetic calls, a matched page.
+- **When it doesn't work** — symptom → cause → fix.
+- **Variations** — priority channels, manual VFO, digital-side tone-out.
+
+## What you're building
+
+The finished rig scans a list of conventional analog channels — say a
+volunteer fire dispatch frequency, the county EMS channel, and
+[marine VHF 16]({{ '/reference/marine-vhf/' | relative_url }}) — the way a
+$150 hardware scanner does: tune, measure squelch, move on; when a carrier
+(and, if configured, its tone) appears, **dwell**, demodulate FM, and record
+until the carrier drops plus a hangtime. Every dwell becomes a call in the
+History panel with a WAV on disk, indistinguishable from the digital calls
+of Parts 1–5 except for its protocol tag (`fm-conv`).
+
+Under the hood this path is simpler than anything else in the series — FM
+discriminator to PCM, no vocoder — but it earned its own postmortem:
+the conventional channel used to be
+[its own voice channel]({{ '/blog/solution-postmortem/from-the-issue-tracker-16-conventional-fm-broker/' | relative_url }})
+in a way the IQ plumbing didn't expect, and the broker fix that came out of
+it is why live monitoring, recording and the tone-out detector can all listen
+to the same dwell today. The wider conventional/wideband architecture is
+[Protocol Decoders Part 9]({{ '/blog/deep-dives/protocol-decoders-09-conventional-wideband/' | relative_url }})'s
+territory.
+
+The second half of the build is **tone-out**: US fire/EMS dispatch still
+pages stations with Motorola Quick Call II — an A tone (~1 s) then a longer
+B tone, each a specific audio frequency. GopherTrunk runs a Goertzel
+detector across decoded voice PCM and fires a `KindToneAlert` event when a
+configured profile matches — surfaced in the web **Tones** panel and the
+log. (The encoder side of paging audio lives in
+[Voice Coding Part 11]({{ '/blog/deep-dives/voice-coding-11-recording-encoding/' | relative_url }}).)
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Signal chain of the analog FM and tone-out rig: an antenna feeds one voice-role SDR owned by the conventional scanner, whose loop tunes each listed channel, measures squelch and checks the CTCSS or DCS tone gate; an open gate starts a dwell that runs FM demodulation to PCM, feeding three consumers in parallel — the WAV recorder as a synthetic call, the Goertzel two-tone detector that raises tone alerts, and live audio in the web console">
+  <rect x="8" y="90" width="60" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="38" y="111" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="68" y1="107" x2="98" y2="107" stroke="currentColor"/>
+  <rect x="98" y="90" width="88" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="142" y="105" text-anchor="middle" fill="currentColor" font-size="10">SDR</text>
+  <text x="142" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="9">role: voice</text>
+  <line x1="186" y1="107" x2="216" y2="107" stroke="currentColor"/>
+  <rect x="216" y="16" width="212" height="208" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="322" y="32" text-anchor="middle" fill="var(--fg-muted)" font-size="10">scanner.conventional</text>
+  <rect x="230" y="44" width="184" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="322" y="58" text-anchor="middle" fill="currentColor" font-size="10">scan loop: tune next channel</text>
+  <text x="322" y="70" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ch1 → ch2 → ch3 → …</text>
+  <rect x="230" y="90" width="184" height="32" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="322" y="104" text-anchor="middle" fill="var(--accent)" font-size="10">squelch_dbfs + tone gate</text>
+  <text x="322" y="116" text-anchor="middle" fill="var(--fg-muted)" font-size="9">carrier AND CTCSS/DCS</text>
+  <rect x="230" y="136" width="184" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="322" y="150" text-anchor="middle" fill="currentColor" font-size="10">dwell: FM demod → PCM</text>
+  <text x="322" y="162" text-anchor="middle" fill="var(--fg-muted)" font-size="9">until carrier drops + hangtime_ms</text>
+  <line x1="322" y1="76" x2="322" y2="90" stroke="currentColor"/>
+  <line x1="322" y1="122" x2="322" y2="136" stroke="var(--accent)"/>
+  <line x1="414" y1="152" x2="452" y2="60" stroke="currentColor"/>
+  <line x1="414" y1="152" x2="452" y2="152" stroke="currentColor"/>
+  <line x1="414" y1="152" x2="452" y2="204" stroke="currentColor"/>
+  <rect x="452" y="42" width="218" height="34" rx="4" fill="none" stroke="currentColor"/>
+  <text x="561" y="56" text-anchor="middle" fill="currentColor" font-size="10">recorder: synthetic call → WAV</text>
+  <text x="561" y="69" text-anchor="middle" fill="var(--fg-muted)" font-size="9">History row, tg from talkgroup_id</text>
+  <rect x="452" y="134" width="218" height="34" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="561" y="148" text-anchor="middle" fill="var(--accent)" font-size="10">tone_out: Goertzel A/B match</text>
+  <text x="561" y="161" text-anchor="middle" fill="var(--fg-muted)" font-size="9">KindToneAlert → Tones panel</text>
+  <rect x="452" y="188" width="218" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="561" y="208" text-anchor="middle" fill="currentColor" font-size="10">live audio (web / speakers)</text>
+</svg>
+<figcaption>One voice SDR, three consumers of the same dwell: the recorder files it as a call, the Goertzel detector watches the audio for pager tones, and the web console streams it live.</figcaption>
+</figure>
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| RTL-SDR Blog V3/V4 | ~$35 | analog FM is the least demanding decode in this series |
+| VHF-capable antenna | $0–$30 | fire dispatch and marine live at 150–162 MHz — extend the kit whip fully, or a quarter-wave for the band |
+| Computer | $0 | anything; this path is the lightest on CPU too |
+
+Frequencies come free: the
+[scanner frequencies guide]({{ '/scanner-frequencies/' | relative_url }})
+lists US police/fire/EMS, marine, rail and GMRS allocations by service, and
+the [fire & EMS guide]({{ '/fire-ems-scanner/' | relative_url }}) covers
+which fire traffic tends to stay analog. Tone pairs for tone-out come from
+your agency's dispatch records or from listening to a few pages.
+
+## The config
+
+```yaml
+log:
+  level: info
+
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000001"      # from `gophertrunk sdr list`
+      role: voice             # the conventional scanner drives a Voice SDR
+      gain: "auto"
+
+scanner:
+  conventional:
+    - label: "County Fire Dispatch"
+      frequency_hz: 154_190_000
+      mode: fm
+      squelch_dbfs: -48
+      hangtime_ms: 1500
+      priority: 3
+      talkgroup_id: 2147500001    # pin it — see below
+      tone:
+        mode: ctcss
+        ctcss_hz: 110.9
+    - label: "Marine VHF 16"
+      frequency_hz: 156_800_000
+      mode: nfm
+      squelch_dbfs: -50
+      hangtime_ms: 1500
+      priority: 5
+      talkgroup_id: 2147500002
+
+audio:
+  enabled: true               # hear dwells on the host speakers
+
+tone_out:
+  profiles:
+    - name: "station-1-engine"
+      alpha_tag: "Station 1 Engine"
+      cooldown: "30s"
+      tones:
+        - frequency_hz: 1042.2
+          min_duration: "250ms"
+          max_duration: "1500ms"
+        - frequency_hz: 1297.4
+          min_duration: "2.5s"
+          max_duration: "5s"
+```
+
+Decisions worth understanding. **`role: voice` is mandatory** — the
+conventional scanner steals the *last* voice device in the pool; on a
+pure-analog rig like this one, that's your only dongle, which is fine.
+**`mode: nfm` vs `fm`** narrows the post-demod audio path for
+12.5 kHz-channelized services (most modern licensing); when audio sounds
+muffled or clipped, you've likely mismatched the channel's
+[deviation]({{ '/reference/fm-deviation/' | relative_url }}) class.
+**`squelch_dbfs`** is an absolute IQ-power gate — start around −48 and
+tune per channel while watching dwell behavior. **`talkgroup_id`** deserves
+its comment: an unset channel gets a positional synthetic ID
+(`0x80000000 | list index`) that **shifts when you reorder, insert or remove
+channels**, silently orphaning your call-log history and talkgroup-file rows
+— issue #1105's lesson. Pin explicit IDs from day one. And the **`tone:`**
+block makes the gate require carrier *and* tone: without it, any carrier
+above squelch holds the scanner, including a distant system sharing the
+frequency.
+
+The tone-out profile is Quick Call II shaped: tone A ~1 s, tone B ~3 s, with
+`tolerance_hz` (default 15), `magnitude_threshold` (default 0.05) and
+`max_gap` (default 200 ms) available when the defaults misbehave. A
+`cooldown` stops one long page from re-firing the alert. Profiles can also
+scope to one `system` / `group_id` — that's the digital-side variation below.
+
+## First run — what healthy looks like
+
+```sh
+gophertrunk run -config config.yaml
+```
+
+The scan loop starts silently — an idle list is just the tuner stepping
+channels a few times a second. The moment a carrier with the right tone
+appears, the dwell shows up as a synthetic call:
+
+```
+INF synthetic call started device=00000001 grant=...
+INF recorder: call started device=00000001 wav=../recordings/.../2147500001/... tg=2147500001 provoice=false
+INF recorder: call ended device=00000001 wav=... duration=8.32s reason=...
+INF synthetic call ended device=00000001 reason=...
+```
+
+Open the web console: the dwell plays live in **Active**, lands in
+**History** under the pinned talkgroup ID, and the channel's `label` is what
+you'll want in a talkgroup file so it reads as a name. When a page goes out
+and matches a profile:
+
+```
+INF toneout: profile matched profile=station-1-engine device=00000001 tones=[1042.2 1297.4]
+```
+
+— and the **Tones** panel logs the alert with its alpha tag. If the scanner
+has no device to run on, the daemon tells you at startup instead of failing
+quietly:
+
+```
+WRN daemon: scanner.conventional / manual_tune_enabled configured but no Voice SDRs in the pool; skipping
+```
+
+That WARN is the first thing to grep for when the scan list seems dead.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Scan list configured, nothing ever dwells, WARN above at startup | no `role: voice` device in the pool | Give the scanner a voice SDR. On a combined trunked+analog rig, add a *second* voice dongle — the scanner takes the last one |
+| Scanner parks forever on one channel | squelch open on noise or a constant carrier (data link, remote base) | Raise that channel's `squelch_dbfs`; better, add a `tone:` gate so only your agency's traffic opens it |
+| Dwells on someone else's traffic on a shared frequency | carrier squelch alone can't tell users apart | Configure the channel's [CTCSS]({{ '/reference/ctcss/' | relative_url }}) tone or [DCS]({{ '/reference/dcs/' | relative_url }}) code — the gate then needs carrier AND tone |
+| `conv: CTCSS detector failed to initialise; tone gate disabled — every signal passes the gate` | bad tone parameters for this channel/rate | Check `ctcss_hz` is a standard EIA tone (67.0–254.1) / `dcs_code` a 3-digit octal; the scanner fails open, so fix it or you're back to carrier squelch |
+| Audio muffled, or loud voices clip | deviation/bandwidth mismatch | Flip `mode:` between `fm` and `nfm` to match the service's channelization |
+| History IDs changed after editing the list | synthetic positional IDs shifted (#1105) | Pin `talkgroup_id` on every channel — one-time fix, durable forever |
+| Pages audible but no `toneout: profile matched` | tone frequencies off, or the B tone shorter than `min_duration` | Verify the pair against dispatch records; widen `tolerance_hz`, relax durations. The detector needs the whole A→B sequence within `max_gap` |
+| Alert fires twice per page | long pages re-trigger | Lengthen the profile's `cooldown` |
+
+One inherited lesson applies unchanged from the digital parts:
+[gain staging]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})
+still decides everything downstream. A squelch threshold tuned against a
+badly staged front end is a number about your gain knob, not about the
+channel.
+
+### How this recipe shapes operator practice
+
+- **Pin identity early.** `talkgroup_id` and `label` cost nothing on day one
+  and save your call history the first time you touch the list.
+- **Prefer tone gates to tight squelch.** A tone answers "is it *my*
+  agency?"; squelch only answers "is it loud?".
+- **Let the WARNs work.** This path fails loudly and open — the startup WARN
+  and the tone-gate-disabled WARNs are designed to be grepped, not ignored.
+
+## Where this goes next
+
+You now have five kinds of rig and only ever one system per box. [Part
+7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})
+scales *out*: several dongles, several trunked systems, one daemon — device
+serials and roles, sizing the shared voice pool against concurrent calls,
+and the priority/preemption rules that decide who gets a radio when calls
+outnumber tuners.
+
+## FAQ
+
+**Can GopherTrunk scan regular analog FM channels like a police scanner?**
+Yes — `scanner.conventional` is a real scan list: fixed frequencies, carrier
+squelch in dBFS, optional CTCSS/DCS gating, per-channel hangtime and
+priority, with each dwell recorded and logged as a call. It needs one
+`role: voice` SDR to drive.
+
+**How do I decode two-tone fire pager tones with an SDR?**
+Give GopherTrunk the A/B tone pair in a `tone_out.profiles` entry — the
+Goertzel detector watches decoded audio from your channels and fires an
+alert (log line, event, web Tones panel) when the sequence matches. Tone
+pairs come from your agency's dispatch documentation or from measuring a
+recorded page.
+
+**What's the difference between squelch_dbfs and a CTCSS tone gate?**
+`squelch_dbfs` opens on any carrier above a power threshold; a CTCSS/DCS
+gate additionally requires the sub-audible tone your agency transmits. On a
+shared or noisy frequency, tone gating is the difference between a usable
+scan list and a scanner held open by strangers.
+
+**Why do my conventional channels show weird talkgroup numbers?**
+Unpinned channels get a synthetic ID built from their list position
+(`0x80000000 | index`), which changes when the list changes. Set an explicit
+`talkgroup_id` per channel to keep History rows and talkgroup-file aliases
+stable — issue #1105 exists because reordering silently broke both.
+
+**Can tone-out watch digital talkgroups too?**
+Yes — the detector runs on decoded PCM from voice devices regardless of
+protocol, and a profile scoped with `system` and `group_id` will match pages
+that go out over a trunked talkgroup as readily as over analog dispatch.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: TETRA Direct Mode — Scanning DMO]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }})
+· Next →
+[Part 7: Many Systems, One Box — The SDR Pool]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})

--- a/docs/_posts/2026-09-08-operator-cookbook-06-analog-fm-tone-out.md
+++ b/docs/_posts/2026-09-08-operator-cookbook-06-analog-fm-tone-out.md
@@ -84,21 +84,21 @@ History panel with a WAV on disk, indistinguishable from the digital calls
 of Parts 1–5 except for its protocol tag (`fm-conv`).
 
 Under the hood this path is simpler than anything else in the series — FM
-discriminator to PCM, no vocoder — but it earned its own postmortem:
-the conventional channel used to be
+discriminator to PCM, no vocoder — but it earned its own postmortem: the
+conventional channel used to be
 [its own voice channel]({{ '/blog/solution-postmortem/from-the-issue-tracker-16-conventional-fm-broker/' | relative_url }})
-in a way the IQ plumbing didn't expect, and the broker fix that came out of
-it is why live monitoring, recording and the tone-out detector can all listen
-to the same dwell today. The wider conventional/wideband architecture is
+in a way the IQ plumbing didn't expect, and the broker fix from that story
+is why live monitoring, recording and the tone-out detector all listen to
+the same dwell today. The wider conventional architecture is
 [Protocol Decoders Part 9]({{ '/blog/deep-dives/protocol-decoders-09-conventional-wideband/' | relative_url }})'s
 territory.
 
 The second half of the build is **tone-out**: US fire/EMS dispatch still
 pages stations with Motorola Quick Call II — an A tone (~1 s) then a longer
-B tone, each a specific audio frequency. GopherTrunk runs a Goertzel
-detector across decoded voice PCM and fires a `KindToneAlert` event when a
-configured profile matches — surfaced in the web **Tones** panel and the
-log. (The encoder side of paging audio lives in
+B tone. GopherTrunk runs a Goertzel detector across decoded voice PCM and
+fires a `KindToneAlert` event when a profile matches — surfaced in the web
+**Tones** panel and the log. (The encoder side of this audio machinery
+lives in
 [Voice Coding Part 11]({{ '/blog/deep-dives/voice-coding-11-recording-encoding/' | relative_url }}).)
 
 <figure class="lab-figure">
@@ -226,11 +226,10 @@ block makes the gate require carrier *and* tone: without it, any carrier
 above squelch holds the scanner, including a distant system sharing the
 frequency.
 
-The tone-out profile is Quick Call II shaped: tone A ~1 s, tone B ~3 s, with
-`tolerance_hz` (default 15), `magnitude_threshold` (default 0.05) and
-`max_gap` (default 200 ms) available when the defaults misbehave. A
-`cooldown` stops one long page from re-firing the alert. Profiles can also
-scope to one `system` / `group_id` — that's the digital-side variation below.
+The tone-out profile is Quick Call II shaped: tone A ~1 s, tone B ~3 s,
+with `tolerance_hz` (default 15), `magnitude_threshold` (default 0.05) and
+`max_gap` (default 200 ms) available when the defaults misbehave, and a
+`cooldown` to stop one long page re-firing the alert.
 
 ## First run — what healthy looks like
 
@@ -249,10 +248,8 @@ INF recorder: call ended device=00000001 wav=... duration=8.32s reason=...
 INF synthetic call ended device=00000001 reason=...
 ```
 
-Open the web console: the dwell plays live in **Active**, lands in
-**History** under the pinned talkgroup ID, and the channel's `label` is what
-you'll want in a talkgroup file so it reads as a name. When a page goes out
-and matches a profile:
+Open the web console: the dwell plays live in **Active** and lands in
+**History** under the pinned talkgroup ID. When a page matches a profile:
 
 ```
 INF toneout: profile matched profile=station-1-engine device=00000001 tones=[1042.2 1297.4]
@@ -296,6 +293,21 @@ channel.
 - **Let the WARNs work.** This path fails loudly and open — the startup WARN
   and the tone-gate-disabled WARNs are designed to be grepped, not ignored.
 
+## Variations
+
+- **Manual VFO.** `scanner.manual_tune_enabled: true` builds the scanner
+  even with no channel list, so the TUI's `f` key (or
+  `POST /api/v1/scanner/manual_tune`) can tune anything ad hoc — a
+  software VFO on a spare voice dongle.
+- **Priority channels.** Per-channel `priority` is honored by the engine's
+  preemption against other calls — set your dispatch channel higher than
+  routine traffic (more in [Part 7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})).
+- **Digital-side tone-out.** Scope a profile with `system` and `group_id`
+  to catch pages that go out over a trunked talkgroup.
+- **Actual pagers.** For POCSAG/FLEX paging *protocols* (not voice tones),
+  the separate `paging:` section dedicates or shares an SDR per paging
+  frequency — same rig, different decoder.
+
 ## Where this goes next
 
 You now have five kinds of rig and only ever one system per box. [Part
@@ -333,9 +345,9 @@ Unpinned channels get a synthetic ID built from their list position
 stable — issue #1105 exists because reordering silently broke both.
 
 **Can tone-out watch digital talkgroups too?**
-Yes — the detector runs on decoded PCM from voice devices regardless of
-protocol, and a profile scoped with `system` and `group_id` will match pages
-that go out over a trunked talkgroup as readily as over analog dispatch.
+Yes — the detector runs on decoded PCM regardless of protocol, and a
+profile scoped with `system` and `group_id` matches pages sent over a
+trunked talkgroup as readily as over analog dispatch.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-08-p25-end-to-end-06-cqpsk-lsm.md
+++ b/docs/_posts/2026-09-08-p25-end-to-end-06-cqpsk-lsm.md
@@ -75,18 +75,18 @@ were once the bug.*
 ## Why a linear path exists
 
 "Compatible" is the load-bearing word in C4FM's name: the waveform family
-was designed so the same signal can be received either as four-level FM or
-as a phase modulation. Some operators — often, but not only, on simulcast
-systems — transmit **LSM (Linear Simulcast Modulation)**, a
-π/4-DQPSK-family linear waveform, because a linear signal survives
-multi-transmitter overlap better. When several towers transmit the same
-bits with small differential delays, the receiver hears the *sum* of
-delayed copies. For a linear modulation that sum is just a linear channel —
-inter-symbol interference an equalizer can invert
+was designed to be receivable either as four-level FM or as a phase
+modulation. Some operators — often, but not only, on simulcast systems —
+transmit **LSM (Linear Simulcast Modulation)**, a π/4-DQPSK-family linear
+waveform, because a linear signal survives multi-transmitter overlap
+better. When several towers transmit the same bits with small differential
+delays, the receiver hears the *sum* of delayed copies. For a linear
+modulation that sum is just a linear channel — inter-symbol interference an
+equalizer can invert
 ([the ISI story in general form]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})).
 For an FM discriminator the sum is a disaster: FM demodulation is
-nonlinear, so overlapping carriers produce phase-slope artifacts no
-downstream filter can cleanly remove.
+nonlinear, and overlapping carriers produce artifacts no downstream filter
+can cleanly remove.
 
 Push an actually-linear LSM signal through a quadrature FM discriminator
 and you get near-random dibits and a frame sync word that never matches —
@@ -135,17 +135,15 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 }
 ```
 
-Read the last loop first, because it is the twin-pair contract: after the
-remap, the CQPSK path's dibit values match what `SymbolToDibit` produces
-from C4FM, so everything from
+Read the last loop first — it is the twin-pair contract: after the remap,
+the CQPSK path's dibit values match what `SymbolToDibit` produces from
+C4FM, so everything from
 [Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})'s
-FSW detector to
-[Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})'s
-band plan is demod-agnostic. The AGC matters more than it looks: both the
-Gardner timing-error detector and the CMA weight update use un-normalised,
-amplitude-dependent error terms, so without it the path locked only in a
-narrow RTL-SDR gain window — a regression issue #275's reporters actually
-measured.
+FSW detector onward is demod-agnostic. The AGC matters more than it looks:
+the Gardner timing-error detector and the CMA weight update both use
+un-normalised, amplitude-dependent error terms, so without it the path
+locked only in a narrow RTL-SDR gain window — a regression issue #275's
+reporters actually measured.
 
 ## The equalizer C4FM never got
 

--- a/docs/_posts/2026-09-08-p25-end-to-end-06-cqpsk-lsm.md
+++ b/docs/_posts/2026-09-08-p25-end-to-end-06-cqpsk-lsm.md
@@ -15,8 +15,8 @@ America's dominant trunking protocol through GopherTrunk — from a raw C4FM
 carrier to recorded, named, multi-site voice.
 [Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})
 turned channel numbers into hertz; every layer so far rode Part 1's FM
-discriminator. This part is the first full twin pair of the series: the same
-Phase 1 protocol, transmitted as a **linear** modulation that a discriminator
+discriminator. This part is the series' first full twin pair: the same
+Phase 1 protocol, transmitted as a **linear** modulation a discriminator
 turns into near-random dibits. It is where the equalizer lives, where the
 carrier-recovery lessons were paid for, and where GopherTrunk's own docs
 were once the bug.*
@@ -28,25 +28,25 @@ were once the bug.*
 > Gardner T/2 timing → **`equalizer.FSE`, a fractionally-spaced blind CMA
 > equalizer** (the `fse` field) → Costas fine tracking → differential
 > decode → `lsmDibitRemap`, emitting dibits interchangeable with the C4FM
-> path. Getting it working took four acts on issue #492 (0/8 → 8/8 locks on
-> real captures). And the selection rule is empirical, not inferential:
-> **simulcast does not imply LSM** — forcing CQPSK on a C4FM simulcast site
-> kills the decode (issue #935).
+> path's. Getting it working took four acts on issue #492 (0/8 → 8/8 locks
+> on real captures). And the selection rule is empirical: **simulcast does
+> not imply LSM** — forcing CQPSK on a C4FM simulcast site kills the
+> decode (issue #935).
 
 **Key takeaways**
 
 - **Same dibits out, entirely different physics.** The CQPSK path ends in
   `lsmDibitRemap` so FSW detect, NID parse and the TSBK trellis never know
-  which demodulator ran — one control-channel state machine, two physical
-  layers, and a standing twin-drift risk.
+  which demodulator ran — one state machine, two physical layers, a
+  standing twin-drift risk.
 - **A linear channel is an invertible channel.** Simulcast multipath is a
   linear distortion of complex symbols, so an equalizer can undo it — the
-  structural reason this path carries a T/2 fractionally-spaced CMA
-  equalizer while the discriminator path has none.
+  structural reason this path carries a T/2 CMA equalizer while the
+  discriminator path has none.
 - **Differential decode removes phase, not rotation.** A residual carrier
-  offset spins the constellation a constant angle per symbol, and at 4800
-  baud it takes 3.75× less offset to break than TETRA's 18000 — why this
-  path needed a coarse seed, an NCO and a Costas loop.
+  offset spins the constellation a constant angle per symbol, and 4800
+  baud breaks at 3.75× less offset than TETRA's 18000 — why this path
+  needed a coarse seed, an NCO and a Costas loop.
 - **Choose `cqpsk` empirically, never by "the site is simulcast."** LSM is
   transmitter coordination, not a modulation; emission designators cover
   both; and a genuinely three-tower simulcast system decodes fine in C4FM
@@ -66,10 +66,10 @@ were once the bug.*
 
 ## In this post
 
-- **Why a linear path exists** — what simulcast does to a discriminator, and what LSM actually is.
-- **The chain in one pass** — from raw IQ to remapped dibits.
+- **Why a linear path exists** — what simulcast does to a discriminator.
+- **The chain in one pass** — raw IQ to remapped dibits.
 - **The equalizer C4FM never got** — the T/2 FSE and what it opens.
-- **The seed that lies on simulcast** — carrier recovery and its multipath gate.
+- **The seed that lies on simulcast** — carrier recovery and its gate.
 - **Two paths, one truth** — twin drift, and the myth the docs taught.
 
 ## Why a linear path exists
@@ -89,9 +89,8 @@ nonlinear, and overlapping carriers produce artifacts no downstream filter
 can cleanly remove.
 
 Push an actually-linear LSM signal through a quadrature FM discriminator
-and you get near-random dibits and a frame sync word that never matches —
-the issue #275 symptom that motivated this path. So the receiver carries a
-second demod mode:
+and you get near-random dibits and a frame sync word that never matches
+(the issue #275 symptom). So the receiver carries a second demod mode:
 
 | | `DemodC4FM` (default) | `DemodCQPSK` |
 |---|---|---|
@@ -102,14 +101,13 @@ second demod mode:
 | Decision | 4-level slicer | differential quadrant + remap |
 | Right for | the large majority of sites — including most simulcast | sites actually transmitting a linear waveform |
 
-The last row is the one the project got wrong for a long time, and we will
-come back to it.
+The last row is the one the project long got wrong; we return to it below.
 
 ## The chain in one pass
 
-`cqpskDemod` (`internal/radio/p25/phase1/receiver/cqpsk.go`) wraps the same
-`demod.PiOver4DQPSK` primitive TETRA uses — rotation π/4, the TIA-102.BAAA
-LSM constellation — and composes the rest around it:
+`cqpskDemod` (`cqpsk.go`) wraps the same `demod.PiOver4DQPSK` primitive
+TETRA uses — rotation π/4, the TIA-102.BAAA LSM constellation — and
+composes the rest around it:
 
 ```go
 // internal/radio/p25/phase1/receiver/cqpsk.go (shape) — process
@@ -147,68 +145,62 @@ reporters actually measured.
 
 ## The equalizer C4FM never got
 
-The `fse` field is the piece the series brief keeps pointing at, because it
-is the lever the default C4FM voice path lacks (that gap is
-[Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})'s
+The `fse` field is the lever the default C4FM voice path lacks (that gap
+is [Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})'s
 whole subject). Post-Gardner symbols are unit-modulus π/4-DQPSK points, so
 the **Constant Modulus Algorithm** applies — a blind equalizer needing no
 training sequence. Two design choices carry the weight:
 
 - **Fractionally spaced (T/2), not symbol spaced.** Gardner emits the
   on-time *and* half-symbol samples, and the equalizer runs two taps per
-  symbol (`cqpskFSESymbolSpan = 6` symbols). A T/2 equalizer synthesizes
-  the receive matched filter implicitly, so it opens both simulcast
-  multipath ISI **and** the C4FM-transmit-vs-RRC-receive pulse mismatch —
-  the latter is what left a real C4FM-shaped signal's constellation closed
-  through the linear path (issue #492). A symbol-spaced equalizer cannot
-  fix a pulse-shape mismatch; it only ever sees the symbols the wrong
-  filter already produced.
-- **Brisk step, leaky taps.** `cqpskFSEStep = 0.025` because real
-  control-channel captures are short — the blind equalizer must open the
-  constellation within a few hundred symbols of lead-in before the FSW
-  arrives — and `cqpskFSELeak = 5e-4` pulls the FSE's larger null space
-  toward identity so the taps don't wander on clean, ISI-free input.
+  symbol (`cqpskFSESymbolSpan = 6`). A T/2 equalizer synthesizes the
+  receive matched filter implicitly, so it opens both simulcast multipath
+  ISI **and** the C4FM-transmit-vs-RRC-receive pulse mismatch — what left
+  a real C4FM-shaped signal's constellation closed through the linear path
+  (issue #492). A symbol-spaced equalizer can't fix a pulse mismatch; it
+  only sees the symbols the wrong filter already produced.
+- **Brisk step, leaky taps.** `cqpskFSEStep = 0.025` because the blind
+  equalizer must open the constellation within a few hundred symbols of
+  lead-in before the FSW arrives; `cqpskFSELeak = 5e-4` pulls the FSE's
+  larger null space toward identity so the taps don't wander on clean,
+  ISI-free input.
 
 The safety analysis is the one the
 [TETRA equalizer work]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
 made a series-wide rule: a continuously-adapting filter ahead of a
-differential decoder is only safe if its phase is constrained, and here the
+differential decoder is only safe with its phase constrained — here the
 Costas loop *after* the FSE pins the constellation to the decision grid
-symbol by symbol, so the differential product sees a stable frame. The
-receiver also retains `cmaErr` — the equalizer's `|y|²−R²` convergence
-proxy — for the replay diagnostics, because "is the equalizer converged" is
-a question you want answerable from a log, not a debugger.
+symbol by symbol. The receiver also retains `cmaErr`, the equalizer's
+`|y|²−R²` convergence proxy, for replay diagnostics: "is the equalizer
+converged" should be answerable from a log, not a debugger.
 
 ## The seed that lies on simulcast
 
 The differential decode removes a constant carrier *phase* but not a
 constant per-symbol *rotation*: a residual offset Δf turns every symbol by
-2π·Δf/4800, and the FSW never correlates. (TETRA gets away without any
-carrier recovery only because 18000 baud rotates 3.75× less per symbol —
-the comment in `cqpsk.go` says exactly this.) So the path seeds an NCO from
-a one-shot coarse estimate, then lets a 120 Hz Costas loop track the
-residual.
+2π·Δf/4800, and the FSW never correlates. (TETRA gets away without carrier
+recovery only because 18000 baud rotates 3.75× less per symbol.) So the
+path seeds an NCO from a one-shot coarse estimate, then lets a 120 Hz
+Costas loop track the residual.
 
 The war story is in the *gate* on that estimate. The bare lag-1 (Kay)
-autocorrelation estimator reads a simulcast channel's multipath as a
-spurious carrier offset — ~650–750 Hz on issue #492's captures — because a
-deep simulcast null shifts the spectral centroid, and an autocorrelation
-estimator cannot tell that bias from a real offset. Mis-tune the NCO by it
-and the Costas loop rails. `robustSeedHz` therefore sharpens the estimate
-with a multi-lag phase-ramp fit, then **checks its own answer**: de-rotate
-by the candidate, run the matched filter, and measure the coefficient of
-variation of the symbol modulus (`seedModulusCV`). A true carrier offset
-only *rotates* a constant-modulus constellation (low CV); multipath *blurs*
-the modulus (high CV, gated at `cqpskSeedMaxModulusCV = 0.24`). A rejected
-seed leaves the NCO identity and lets the loop acquire the necessarily
-in-range true offset on its own.
+autocorrelation estimator reads simulcast multipath as a spurious carrier
+offset — ~650–750 Hz on issue #492's captures — because a deep simulcast
+null shifts the spectral centroid, a bias no autocorrelation estimator can
+tell from a real offset. Mis-tune the NCO by it and the Costas loop rails.
+`robustSeedHz` therefore sharpens the estimate with a multi-lag phase-ramp
+fit, then **checks its own answer**: de-rotate by the candidate, matched
+filter, and measure the coefficient of variation of the symbol modulus
+(`seedModulusCV`). A true offset only *rotates* a constant-modulus
+constellation (low CV); multipath *blurs* the modulus (high CV, gated at
+`cqpskSeedMaxModulusCV = 0.24`). A rejected seed leaves the NCO identity
+and lets the loop acquire the necessarily in-range true offset itself.
 
 Issue #492 took four acts to reach that design — no carrier recovery at
 all, then the poisoned seed, then the FSE, then a brute-force BCH hot path
-that only appeared once locking finally worked — and the score went **0/8 →
-3/8 → 8/8 locks** on the reporter's real captures. The full postmortem,
-including the diagnostic line that was reading the *wrong demodulator's*
-state, is
+that only surfaced once locking worked — and the score went **0/8 → 3/8 →
+8/8 locks** on the reporter's real captures. The full postmortem, including
+the diagnostic line reading the *wrong demodulator's* state, is
 [From the Issue Tracker Part 6]({{ '/blog/solution-postmortem/from-the-issue-tracker-06-cqpsk-four-acts/' | relative_url }}).
 
 <figure class="lab-figure">
@@ -230,7 +222,7 @@ state, is
   <path d="M 480 82 C 500 46 540 90 560 54 M 480 54 C 500 92 540 44 560 82" fill="none" stroke="currentColor"/>
   <text x="576" y="62" fill="currentColor" font-size="10">closed eye —</text>
   <text x="576" y="76" fill="currentColor" font-size="10">nonlinear mix,</text>
-  <text x="576" y="90" fill="currentColor" font-size="10">nothing inverts it</text>
+  <text x="576" y="90" fill="currentColor" font-size="10">not invertible</text>
   <!-- linear branch -->
   <line x1="215" y1="132" x2="300" y2="180" stroke="var(--accent)"/>
   <rect x="302" y="165" width="128" height="30" fill="none" stroke="var(--accent)"/>
@@ -243,7 +235,7 @@ state, is
   <circle cx="598" cy="167" r="3" fill="var(--accent)"/><circle cx="562" cy="167" r="3" fill="var(--accent)"/>
   <circle cx="562" cy="193" r="3" fill="var(--accent)"/><circle cx="598" cy="193" r="3" fill="var(--accent)"/>
   <text x="548" y="226" fill="var(--accent)" font-size="10">ISI inverted — open again</text>
-  <text x="236" y="238" fill="var(--fg-muted)" font-size="10">same air, two demodulators: only the linear one gives an equalizer something invertible</text>
+  <text x="236" y="238" fill="var(--fg-muted)" font-size="10">same air, two demodulators — only the linear one is equalizable</text>
 </svg>
 <figcaption>Simulcast differential delay is fatal noise after an FM discriminator but an invertible linear channel on the CQPSK path — which is why the equalizer lives here.</figcaption>
 </figure>
@@ -253,33 +245,33 @@ state, is
 Twin paths drift, and this pair drifted twice in ways worth naming.
 
 First, **selection folklore**. GopherTrunk's docs, config comments and UI
-labels all once taught "simulcast ⇒ CQPSK." Issue #935 disproved it on air:
-a genuinely three-tower simulcast site decodes reliably in **C4FM** — in
-GopherTrunk and SDRTrunk alike — and forcing CQPSK kills it, because LSM is
+labels once taught "simulcast ⇒ CQPSK." Issue #935 disproved it on air: a
+genuinely three-tower simulcast site decodes reliably in **C4FM** — in
+GopherTrunk and SDRTrunk alike — and forcing CQPSK kills it. LSM is
 transmitter *coordination*, not a modulation, and licensing metadata (the
 site's `10K1D7W` emission designator covers both) can't decide either. The
-`DemodMode` doc comment in `modes.go` now carries the corrected rule in
-permanent form: **C4FM is the default; `cqpsk` is warranted only when a
-strong, clean signal will not lock in C4FM** — near-random dibits, no FSW.
-The full story of unwinding the project's own guidance is
+`DemodMode` doc in `modes.go` now carries the corrected rule permanently:
+**C4FM is the default; `cqpsk` is warranted only when a strong, clean
+signal will not lock in C4FM.** The full story of unwinding the project's
+own guidance is
 [From the Issue Tracker Part 7]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }}).
-(The reporter's actual problem was gain entered in the wrong units. The
+(The reporter's actual problem was gain entered in the wrong units; the
 myth just kept everyone looking elsewhere.)
 
-Second, **plumbing drift**. The demod mode is a per-system (and per-channel)
-string that has to survive three hand-offs: config → control-channel
-pipeline → grant → voice chain. The composer's
-`resolveP25Phase1DemodMode` (`internal/voice/composer/p25p1_voice.go`)
-parses the string off the grant, warn-logs unknown values, and falls back
-to C4FM — and the voice chain now prints
-`composer: p25p1 voice chain started demod_mode=…` precisely because a
-field log once showed the CC locked on cqpsk with no way to verify the
-voice chain wasn't silently still on c4fm (issue #356 follow-up). The
-wideband pipeline, meanwhile, stamped *no* mode onto its grants at all
-until #935 — CQPSK was decorative on that whole path. Same lesson as the
+Second, **plumbing drift**. The demod mode is a per-system (and
+per-channel) string that must survive three hand-offs: config → CC
+pipeline → grant → voice chain. The composer's `resolveP25Phase1DemodMode`
+(`internal/voice/composer/p25p1_voice.go`) parses it off the grant,
+warn-logs unknown values, falls back to C4FM — and the voice chain now
+prints `composer: p25p1 voice chain started demod_mode=…` precisely
+because a field log once showed the CC locked on cqpsk with no way to
+verify the voice chain wasn't silently still on c4fm (issue #356
+follow-up). The wideband pipeline, meanwhile, stamped *no* mode onto its
+grants at all until #935 — CQPSK was decorative on that whole path. Same
+lesson as the
 [Two Pipelines postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }}):
-when a property exists on one side of a twin pair, audit the other side for
-the entire class.
+when a property exists on one side of a twin pair, audit the other side
+for the entire class.
 
 ### How the linear-channel principle shaped the Go code
 
@@ -291,59 +283,57 @@ the entire class.
   estimate when de-rotation doesn't restore constant modulus; a wrong seed
   held back is recoverable, a wrong seed applied rails the loop.
 - **The twin contract is enforced at the boundary.** `lsmDibitRemap`
-  converts to canonical TIA-102 dibits inside the demod, so no downstream
-  code ever branches on which physics ran.
-- **Mode strings parse in one place.** `ParseDemodMode` accepts
-  `cqpsk`/`lsm`/`linear`, returns `ok=false` on typos so callers warn and
-  fall back — a config mistake degrades to the default, never to silence.
+  converts to canonical dibits inside the demod, so no downstream code
+  branches on which physics ran.
+- **Mode strings parse in one place.** `ParseDemodMode` returns `ok=false`
+  on typos so callers warn and fall back — a config mistake degrades to
+  the default, never to silence.
 
 ## Where this goes next
 
 CQPSK is Phase 1 wearing linear clothes; the next twin is a different
-protocol generation on the same control channel.
+protocol generation.
 [Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})
 takes on Phase 2 TDMA: H-DQPSK at 6000 symbols/s carrying two voice slots
-per 12.5 kHz carrier, the shared differential primitive it borrows from
-TETRA with a π/8 twist, and the FEC-knob hand-off that issue #882 proved
-can silently default to zero on one pipeline.
+per 12.5 kHz carrier, the differential primitive it shares with TETRA one
+π/8 apart, and the FEC-knob hand-off issue #882 proved can silently
+default to zero on one pipeline.
 
 ## FAQ
 
 **How do I know if my P25 site needs CQPSK mode?**
-Empirically, and only empirically: a strong, clean signal that will not
-lock in C4FM — near-random dibits, no frame sync — is the CQPSK signature.
-Do not infer it from "the site is simulcast" (most simulcast is C4FM) or
-from licensing data (emission designators cover both). See issue #935 and
-the `DemodMode` documentation.
+Empirically, only: a strong, clean signal that will not lock in C4FM —
+near-random dibits, no frame sync — is the CQPSK signature. Do not infer
+it from "the site is simulcast" (most simulcast is C4FM) or from licensing
+data (emission designators cover both). See issue #935.
 
 **Why does the CQPSK path need carrier recovery when TETRA's π/4-DQPSK
 doesn't?**
 Baud rate. A residual offset rotates the differential constellation by
 2π·Δf per symbol interval; at 4800 baud the same hertz of error costs
-3.75× more rotation than at TETRA's 18000. P25's linear path crosses the
+3.75× more rotation than at TETRA's 18000. The linear path crosses the
 quadrant boundary at offsets an ordinary tuner routinely has, so it seeds
 an NCO and tracks with a Costas loop.
 
 **What is the difference between LSM and CQPSK?**
-In this context, none that the receiver cares about: LSM is the
-TIA-102.BAAA linear simulcast waveform, CQPSK the modulation family it
-belongs to, and GopherTrunk accepts `cqpsk`, `lsm` and `linear` as aliases
-for the same `DemodCQPSK` path. The important distinction is
-LSM-the-waveform versus simulcast-the-deployment — only the former needs
-this demodulator.
+None the receiver cares about: LSM is the TIA-102.BAAA linear simulcast
+waveform, CQPSK the modulation family it belongs to, and GopherTrunk
+accepts `cqpsk`, `lsm` and `linear` as aliases for the same `DemodCQPSK`
+path. The distinction that matters is LSM-the-waveform versus
+simulcast-the-deployment — only the former needs this demodulator.
 
 **Can the CQPSK path decode a normal C4FM site?**
 Often, yes — "compatible" 4-level FM is receivable as a phase modulation,
 and the T/2 equalizer exists partly to absorb the C4FM-vs-RRC pulse
 mismatch. But it is the harder road: more stages, more acquisition time,
-and no benefit on a discriminator-friendly signal. That's why C4FM stays
-the default and CQPSK stays opt-in.
+no benefit on a discriminator-friendly signal. So C4FM stays the default
+and CQPSK stays opt-in.
 
 **Why is the equalizer only on this path and not on C4FM voice?**
-Because the discriminator output isn't a linear function of the channel —
-there is no clean convolution to invert after nonlinear FM demodulation.
-Equalizing P25 means either the linear path (here) or porting an
-equalizer *ahead* of the decision chain on C4FM — the open weak-signal work
+Because a discriminator's output isn't a linear function of the channel —
+after nonlinear FM demodulation there is no clean convolution to invert.
+Equalizing P25 means either the linear path (here) or porting an equalizer
+*ahead* of the C4FM decision chain — the open weak-signal work
 [Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})
 lays out, gated on a real capture.
 

--- a/docs/_posts/2026-09-08-p25-end-to-end-06-cqpsk-lsm.md
+++ b/docs/_posts/2026-09-08-p25-end-to-end-06-cqpsk-lsm.md
@@ -1,0 +1,357 @@
+---
+title: "P25 End to End, Part 6: CQPSK & LSM — The Linear Twin Path"
+description: P25 Phase 1's second physical layer — the opt-in CQPSK/LSM demodulator GopherTrunk runs when an FM discriminator produces near-random dibits, its T/2 fractionally-spaced CMA equalizer and carrier-recovery chain, and the hard rule that simulcast does not imply LSM.
+category: deep-dives
+keywords: p25 cqpsk demodulator, p25 lsm linear simulcast modulation, cqpsk vs c4fm, simulcast p25 decoding, fractionally spaced equalizer cma, costas loop carrier recovery, p25 phase 1 demod mode, sdr p25 simulcast distortion, gophertrunk p25
+tags: [p25-end-to-end, p25, cqpsk, lsm, equalization, dsp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 6
+---
+
+*Part 6 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
+[Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})
+turned channel numbers into hertz; every layer so far rode Part 1's FM
+discriminator. This part is the first full twin pair of the series: the same
+Phase 1 protocol, transmitted as a **linear** modulation that a discriminator
+turns into near-random dibits. It is where the equalizer lives, where the
+carrier-recovery lessons were paid for, and where GopherTrunk's own docs
+were once the bug.*
+
+> **TL;DR:** A minority of P25 Phase 1 sites transmit **LSM/CQPSK** — a
+> π/4-DQPSK-family linear modulation — instead of C4FM. GopherTrunk's
+> opt-in `DemodCQPSK` path (`internal/radio/p25/phase1/receiver/cqpsk.go`)
+> runs coarse carrier seed → NCO → complex RRC matched filter → AGC →
+> Gardner T/2 timing → **`equalizer.FSE`, a fractionally-spaced blind CMA
+> equalizer** (the `fse` field) → Costas fine tracking → differential
+> decode → `lsmDibitRemap`, emitting dibits interchangeable with the C4FM
+> path. Getting it working took four acts on issue #492 (0/8 → 8/8 locks on
+> real captures). And the selection rule is empirical, not inferential:
+> **simulcast does not imply LSM** — forcing CQPSK on a C4FM simulcast site
+> kills the decode (issue #935).
+
+**Key takeaways**
+
+- **Same dibits out, entirely different physics.** The CQPSK path ends in
+  `lsmDibitRemap` so FSW detect, NID parse and the TSBK trellis never know
+  which demodulator ran — one control-channel state machine, two physical
+  layers, and a standing twin-drift risk.
+- **A linear channel is an invertible channel.** Simulcast multipath is a
+  linear distortion of complex symbols, so an equalizer can undo it — the
+  structural reason this path carries a T/2 fractionally-spaced CMA
+  equalizer while the discriminator path has none.
+- **Differential decode removes phase, not rotation.** A residual carrier
+  offset spins the constellation a constant angle per symbol, and at 4800
+  baud it takes 3.75× less offset to break than TETRA's 18000 — why this
+  path needed a coarse seed, an NCO and a Costas loop.
+- **Choose `cqpsk` empirically, never by "the site is simulcast."** LSM is
+  transmitter coordination, not a modulation; emission designators cover
+  both; and a genuinely three-tower simulcast system decodes fine in C4FM
+  (issue #935).
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Mode selection | `"" / c4fm / fm` vs `cqpsk / lsm / linear` | `internal/radio/p25/phase1/receiver/modes.go` (`ParseDemodMode`) |
+| The chain | seed → NCO → RRC → AGC → Gardner → FSE → Costas → decode | `cqpsk.go` (`cqpskDemod.process`) |
+| Blind equalizer | T/2 fractionally-spaced CMA, span 6 symbols | `cqpsk.go` (`fse`, `equalizer.NewFSE`) |
+| Coarse carrier seed | multi-lag fit + multipath modulus-CV gate | `cqpsk.go` (`robustSeedHz`, `seedModulusCV`) |
+| Fine tracking | QPSK Costas loop, 120 Hz BW at 4800 baud | `cqpsk.go` (`sync.NewQPSKCostas`) |
+| Dibit convention | LSM constellation → TIA-102.BAAA dibits | `cqpsk.go` (`lsmRotation`, `lsmDibitRemap`) |
+| Voice-chain wiring | grant's demod mode string → receiver mode | `internal/voice/composer/p25p1_voice.go` (`resolveP25Phase1DemodMode`) |
+
+## In this post
+
+- **Why a linear path exists** — what simulcast does to a discriminator, and what LSM actually is.
+- **The chain in one pass** — from raw IQ to remapped dibits.
+- **The equalizer C4FM never got** — the T/2 FSE and what it opens.
+- **The seed that lies on simulcast** — carrier recovery and its multipath gate.
+- **Two paths, one truth** — twin drift, and the myth the docs taught.
+
+## Why a linear path exists
+
+"Compatible" is the load-bearing word in C4FM's name: the waveform family
+was designed so the same signal can be received either as four-level FM or
+as a phase modulation. Some operators — often, but not only, on simulcast
+systems — transmit **LSM (Linear Simulcast Modulation)**, a
+π/4-DQPSK-family linear waveform, because a linear signal survives
+multi-transmitter overlap better. When several towers transmit the same
+bits with small differential delays, the receiver hears the *sum* of
+delayed copies. For a linear modulation that sum is just a linear channel —
+inter-symbol interference an equalizer can invert
+([the ISI story in general form]({{ '/blog/deep-dives/weak-signal-engineering-03-isi-linear-channel/' | relative_url }})).
+For an FM discriminator the sum is a disaster: FM demodulation is
+nonlinear, so overlapping carriers produce phase-slope artifacts no
+downstream filter can cleanly remove.
+
+Push an actually-linear LSM signal through a quadrature FM discriminator
+and you get near-random dibits and a frame sync word that never matches —
+the issue #275 symptom that motivated this path. So the receiver carries a
+second demod mode:
+
+| | `DemodC4FM` (default) | `DemodCQPSK` |
+|---|---|---|
+| Front half | FM discriminator (real waveform) | complex RRC matched filter |
+| Timing | Mueller-Müller | Gardner (mandatory, T/2 output) |
+| Carrier error | DC bias → `CoarseAFC` | rotation → NCO seed + Costas |
+| Equalizer | none | T/2 fractionally-spaced CMA |
+| Decision | 4-level slicer | differential quadrant + remap |
+| Right for | the large majority of sites — including most simulcast | sites actually transmitting a linear waveform |
+
+The last row is the one the project got wrong for a long time, and we will
+come back to it.
+
+## The chain in one pass
+
+`cqpskDemod` (`internal/radio/p25/phase1/receiver/cqpsk.go`) wraps the same
+`demod.PiOver4DQPSK` primitive TETRA uses — rotation π/4, the TIA-102.BAAA
+LSM constellation — and composes the rest around it:
+
+```go
+// internal/radio/p25/phase1/receiver/cqpsk.go (shape) — process
+func (c *cqpskDemod) process(iq []complex64) []uint8 {
+    if !c.seeded {
+        c.seedBuf = append(c.seedBuf, iq...) // accumulate ≥2048 samples
+        /* … robustSeedHz → nco.SetOffset; reset Costas + FSE … */
+    }
+    c.rotated = c.nco.Mix(c.rotated, iq)           // remove coarse offset
+    c.matched = c.dq.MatchedFilter(c.matched, c.rotated)
+    c.matched = c.agc.Process(c.matched, c.matched) // gain-independence
+    c.twoSps = c.gardner.Process2x(c.twoSps, c.matched) // [mid, on-time]
+    for i := 0; i < nSym; i++ {
+        y, e := c.fse.Process(c.twoSps[2*i], c.twoSps[2*i+1]) // T/2 CMA
+        c.cmaErr = e
+        c.symbols = append(c.symbols, c.costas.Update(y)) // fine carrier
+    }
+    c.dibits = c.dq.Decode(c.dibits, c.symbols)
+    for i, d := range c.dibits {
+        c.dibits[i] = lsmDibitRemap[d&3] // → canonical TIA-102 dibits
+    }
+    return c.dibits
+}
+```
+
+Read the last loop first, because it is the twin-pair contract: after the
+remap, the CQPSK path's dibit values match what `SymbolToDibit` produces
+from C4FM, so everything from
+[Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})'s
+FSW detector to
+[Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})'s
+band plan is demod-agnostic. The AGC matters more than it looks: both the
+Gardner timing-error detector and the CMA weight update use un-normalised,
+amplitude-dependent error terms, so without it the path locked only in a
+narrow RTL-SDR gain window — a regression issue #275's reporters actually
+measured.
+
+## The equalizer C4FM never got
+
+The `fse` field is the piece the series brief keeps pointing at, because it
+is the lever the default C4FM voice path lacks (that gap is
+[Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})'s
+whole subject). Post-Gardner symbols are unit-modulus π/4-DQPSK points, so
+the **Constant Modulus Algorithm** applies — a blind equalizer needing no
+training sequence. Two design choices carry the weight:
+
+- **Fractionally spaced (T/2), not symbol spaced.** Gardner emits the
+  on-time *and* half-symbol samples, and the equalizer runs two taps per
+  symbol (`cqpskFSESymbolSpan = 6` symbols). A T/2 equalizer synthesizes
+  the receive matched filter implicitly, so it opens both simulcast
+  multipath ISI **and** the C4FM-transmit-vs-RRC-receive pulse mismatch —
+  the latter is what left a real C4FM-shaped signal's constellation closed
+  through the linear path (issue #492). A symbol-spaced equalizer cannot
+  fix a pulse-shape mismatch; it only ever sees the symbols the wrong
+  filter already produced.
+- **Brisk step, leaky taps.** `cqpskFSEStep = 0.025` because real
+  control-channel captures are short — the blind equalizer must open the
+  constellation within a few hundred symbols of lead-in before the FSW
+  arrives — and `cqpskFSELeak = 5e-4` pulls the FSE's larger null space
+  toward identity so the taps don't wander on clean, ISI-free input.
+
+The safety analysis is the one the
+[TETRA equalizer work]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
+made a series-wide rule: a continuously-adapting filter ahead of a
+differential decoder is only safe if its phase is constrained, and here the
+Costas loop *after* the FSE pins the constellation to the decision grid
+symbol by symbol, so the differential product sees a stable frame. The
+receiver also retains `cmaErr` — the equalizer's `|y|²−R²` convergence
+proxy — for the replay diagnostics, because "is the equalizer converged" is
+a question you want answerable from a log, not a debugger.
+
+## The seed that lies on simulcast
+
+The differential decode removes a constant carrier *phase* but not a
+constant per-symbol *rotation*: a residual offset Δf turns every symbol by
+2π·Δf/4800, and the FSW never correlates. (TETRA gets away without any
+carrier recovery only because 18000 baud rotates 3.75× less per symbol —
+the comment in `cqpsk.go` says exactly this.) So the path seeds an NCO from
+a one-shot coarse estimate, then lets a 120 Hz Costas loop track the
+residual.
+
+The war story is in the *gate* on that estimate. The bare lag-1 (Kay)
+autocorrelation estimator reads a simulcast channel's multipath as a
+spurious carrier offset — ~650–750 Hz on issue #492's captures — because a
+deep simulcast null shifts the spectral centroid, and an autocorrelation
+estimator cannot tell that bias from a real offset. Mis-tune the NCO by it
+and the Costas loop rails. `robustSeedHz` therefore sharpens the estimate
+with a multi-lag phase-ramp fit, then **checks its own answer**: de-rotate
+by the candidate, run the matched filter, and measure the coefficient of
+variation of the symbol modulus (`seedModulusCV`). A true carrier offset
+only *rotates* a constant-modulus constellation (low CV); multipath *blurs*
+the modulus (high CV, gated at `cqpskSeedMaxModulusCV = 0.24`). A rejected
+seed leaves the NCO identity and lets the loop acquire the necessarily
+in-range true offset on its own.
+
+Issue #492 took four acts to reach that design — no carrier recovery at
+all, then the poisoned seed, then the FSE, then a brute-force BCH hot path
+that only appeared once locking finally worked — and the score went **0/8 →
+3/8 → 8/8 locks** on the reporter's real captures. The full postmortem,
+including the diagnostic line that was reading the *wrong demodulator's*
+state, is
+[From the Issue Tracker Part 6]({{ '/blog/solution-postmortem/from-the-issue-tracker-06-cqpsk-four-acts/' | relative_url }}).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two transmit towers reach one receiver with a differential delay; through the FM discriminator path the summed copies close the C4FM eye with no recovery stage, while through the linear CQPSK path the same sum is a linear channel that the fractionally spaced equalizer inverts to reopen the constellation">
+  <!-- towers -->
+  <polygon points="40,86 52,86 46,40" fill="none" stroke="currentColor"/>
+  <polygon points="40,196 52,196 46,150" fill="none" stroke="currentColor"/>
+  <text x="20" y="104" fill="var(--fg-muted)" font-size="10">tower A</text>
+  <text x="20" y="214" fill="var(--fg-muted)" font-size="10">tower B (+Δt)</text>
+  <line x1="56" y1="60" x2="200" y2="120" stroke="var(--fg-muted)"/>
+  <line x1="56" y1="170" x2="200" y2="130" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <circle cx="208" cy="125" r="7" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="182" y="150" fill="var(--fg-muted)" font-size="10">sum of delayed copies</text>
+  <!-- discriminator branch -->
+  <line x1="215" y1="118" x2="300" y2="70" stroke="currentColor"/>
+  <rect x="302" y="52" width="128" height="30" fill="none" stroke="currentColor"/>
+  <text x="366" y="71" text-anchor="middle" fill="currentColor" font-size="10">FM discriminator</text>
+  <line x1="430" y1="67" x2="472" y2="67" stroke="currentColor"/>
+  <path d="M 480 82 C 500 46 540 90 560 54 M 480 54 C 500 92 540 44 560 82" fill="none" stroke="currentColor"/>
+  <text x="576" y="62" fill="currentColor" font-size="10">closed eye —</text>
+  <text x="576" y="76" fill="currentColor" font-size="10">nonlinear mix,</text>
+  <text x="576" y="90" fill="currentColor" font-size="10">nothing inverts it</text>
+  <!-- linear branch -->
+  <line x1="215" y1="132" x2="300" y2="180" stroke="var(--accent)"/>
+  <rect x="302" y="165" width="128" height="30" fill="none" stroke="var(--accent)"/>
+  <text x="366" y="184" text-anchor="middle" fill="var(--accent)" font-size="10">linear path (CQPSK)</text>
+  <line x1="430" y1="180" x2="446" y2="180" stroke="var(--accent)"/>
+  <rect x="448" y="165" width="70" height="30" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="483" y="184" text-anchor="middle" fill="var(--accent)" font-size="10">T/2 FSE</text>
+  <line x1="518" y1="180" x2="540" y2="180" stroke="var(--accent)"/>
+  <circle cx="580" cy="180" r="26" fill="none" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <circle cx="598" cy="167" r="3" fill="var(--accent)"/><circle cx="562" cy="167" r="3" fill="var(--accent)"/>
+  <circle cx="562" cy="193" r="3" fill="var(--accent)"/><circle cx="598" cy="193" r="3" fill="var(--accent)"/>
+  <text x="548" y="226" fill="var(--accent)" font-size="10">ISI inverted — open again</text>
+  <text x="236" y="238" fill="var(--fg-muted)" font-size="10">same air, two demodulators: only the linear one gives an equalizer something invertible</text>
+</svg>
+<figcaption>Simulcast differential delay is fatal noise after an FM discriminator but an invertible linear channel on the CQPSK path — which is why the equalizer lives here.</figcaption>
+</figure>
+
+## Two paths, one truth
+
+Twin paths drift, and this pair drifted twice in ways worth naming.
+
+First, **selection folklore**. GopherTrunk's docs, config comments and UI
+labels all once taught "simulcast ⇒ CQPSK." Issue #935 disproved it on air:
+a genuinely three-tower simulcast site decodes reliably in **C4FM** — in
+GopherTrunk and SDRTrunk alike — and forcing CQPSK kills it, because LSM is
+transmitter *coordination*, not a modulation, and licensing metadata (the
+site's `10K1D7W` emission designator covers both) can't decide either. The
+`DemodMode` doc comment in `modes.go` now carries the corrected rule in
+permanent form: **C4FM is the default; `cqpsk` is warranted only when a
+strong, clean signal will not lock in C4FM** — near-random dibits, no FSW.
+The full story of unwinding the project's own guidance is
+[From the Issue Tracker Part 7]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }}).
+(The reporter's actual problem was gain entered in the wrong units. The
+myth just kept everyone looking elsewhere.)
+
+Second, **plumbing drift**. The demod mode is a per-system (and per-channel)
+string that has to survive three hand-offs: config → control-channel
+pipeline → grant → voice chain. The composer's
+`resolveP25Phase1DemodMode` (`internal/voice/composer/p25p1_voice.go`)
+parses the string off the grant, warn-logs unknown values, and falls back
+to C4FM — and the voice chain now prints
+`composer: p25p1 voice chain started demod_mode=…` precisely because a
+field log once showed the CC locked on cqpsk with no way to verify the
+voice chain wasn't silently still on c4fm (issue #356 follow-up). The
+wideband pipeline, meanwhile, stamped *no* mode onto its grants at all
+until #935 — CQPSK was decorative on that whole path. Same lesson as the
+[Two Pipelines postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }}):
+when a property exists on one side of a twin pair, audit the other side for
+the entire class.
+
+### How the linear-channel principle shaped the Go code
+
+- **The equalizer sits where the channel is linear.** The FSE runs on
+  complex symbols before the differential decode — the only domain where
+  simulcast delay is a clean convolution — with the Costas loop pinning
+  phase so the differential product stays safe.
+- **Every estimator gates its own output.** `robustSeedHz` rejects its
+  estimate when de-rotation doesn't restore constant modulus; a wrong seed
+  held back is recoverable, a wrong seed applied rails the loop.
+- **The twin contract is enforced at the boundary.** `lsmDibitRemap`
+  converts to canonical TIA-102 dibits inside the demod, so no downstream
+  code ever branches on which physics ran.
+- **Mode strings parse in one place.** `ParseDemodMode` accepts
+  `cqpsk`/`lsm`/`linear`, returns `ok=false` on typos so callers warn and
+  fall back — a config mistake degrades to the default, never to silence.
+
+## Where this goes next
+
+CQPSK is Phase 1 wearing linear clothes; the next twin is a different
+protocol generation on the same control channel.
+[Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})
+takes on Phase 2 TDMA: H-DQPSK at 6000 symbols/s carrying two voice slots
+per 12.5 kHz carrier, the shared differential primitive it borrows from
+TETRA with a π/8 twist, and the FEC-knob hand-off that issue #882 proved
+can silently default to zero on one pipeline.
+
+## FAQ
+
+**How do I know if my P25 site needs CQPSK mode?**
+Empirically, and only empirically: a strong, clean signal that will not
+lock in C4FM — near-random dibits, no frame sync — is the CQPSK signature.
+Do not infer it from "the site is simulcast" (most simulcast is C4FM) or
+from licensing data (emission designators cover both). See issue #935 and
+the `DemodMode` documentation.
+
+**Why does the CQPSK path need carrier recovery when TETRA's π/4-DQPSK
+doesn't?**
+Baud rate. A residual offset rotates the differential constellation by
+2π·Δf per symbol interval; at 4800 baud the same hertz of error costs
+3.75× more rotation than at TETRA's 18000. P25's linear path crosses the
+quadrant boundary at offsets an ordinary tuner routinely has, so it seeds
+an NCO and tracks with a Costas loop.
+
+**What is the difference between LSM and CQPSK?**
+In this context, none that the receiver cares about: LSM is the
+TIA-102.BAAA linear simulcast waveform, CQPSK the modulation family it
+belongs to, and GopherTrunk accepts `cqpsk`, `lsm` and `linear` as aliases
+for the same `DemodCQPSK` path. The important distinction is
+LSM-the-waveform versus simulcast-the-deployment — only the former needs
+this demodulator.
+
+**Can the CQPSK path decode a normal C4FM site?**
+Often, yes — "compatible" 4-level FM is receivable as a phase modulation,
+and the T/2 equalizer exists partly to absorb the C4FM-vs-RRC pulse
+mismatch. But it is the harder road: more stages, more acquisition time,
+and no benefit on a discriminator-friendly signal. That's why C4FM stays
+the default and CQPSK stays opt-in.
+
+**Why is the equalizer only on this path and not on C4FM voice?**
+Because the discriminator output isn't a linear function of the channel —
+there is no clean convolution to invert after nonlinear FM demodulation.
+Equalizing P25 means either the linear path (here) or porting an
+equalizer *ahead* of the decision chain on C4FM — the open weak-signal work
+[Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})
+lays out, gated on a real capture.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: Channel Identifiers & Band Plans — From Channel Number to Hertz]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})
+· Next →
+[Part 7: Phase 2 TDMA — Two Voices per Carrier]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})

--- a/docs/_posts/2026-09-09-from-spec-to-shipping-07-tests-that-can-disagree.md
+++ b/docs/_posts/2026-09-09-from-spec-to-shipping-07-tests-that-can-disagree.md
@@ -1,0 +1,337 @@
+---
+title: "From Spec to Shipping, Part 7: Tests That Can Disagree With You"
+description: "Four ways GopherTrunk engineers the self-consistent trap out of its test suites: fixture transmitters that behave like real radios, independent-path controls, fake servers that enforce the real protocol's strictness, and synthetic streams laid out on the real slot grid."
+category: deep-dives
+keywords: self consistent test trap, round trip test weakness, faithful test fixtures, fake server protocol strictness, independent resampler control, synthetic transmitter slot grid, failing first regression test, sdr decoder testing, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, testing, methodology, tetra, soapyremote, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 7
+---
+
+*Part 7 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 6]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})
+put a real capture in the referee's chair when references disagreed.
+This part turns to the tests themselves — because the series villain,
+**the test that passes because both sides share the same assumption**,
+is not bad luck. It is a design defect with known fixes. The
+[postmortem version]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
+catalogued the wreckage; this is the constructive mirror: four worked
+examples of building a test that retains the power to call your code
+wrong.*
+
+> **TL;DR:** A test can only catch a bug it doesn't share. Four
+> structural fixes from the GopherTrunk tree: **make the encode side
+> unconditional where the air is unconditional** — `dmo_decode_test.go`
+> now scrambles at colour 0 like a real transmitter, turning a
+> passing-either-way round-trip into a failing-first regression for the
+> [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003)
+> descramble skip; **build controls from independent parts** — the
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) verdict
+> stood on decimating a 10 MS/s capture with a resampler the DDC under
+> test doesn't use; **give fakes the real protocol's strictness** —
+> `newFakeSoapyServer` asserts every request body is fully consumed,
+> mirroring the real `~SoapyRPCUnpacker`, and promptly caught two more
+> drifted calls; **make synthetic transmitters structurally faithful** —
+> `buildDMODibitStream` lays bursts on a true 255-dibit slot grid,
+> because the noise-grant bug lived in exactly the structure the old
+> arbitrary-filler fixture didn't model.
+
+**Key takeaways**
+
+- **A round-trip test proves consistency, not correctness.** Encoder and
+  decoder sharing one wrong assumption pass forever; the fix is to pin
+  one side to something external — real-air behaviour, an upstream
+  literal, an independent implementation.
+- **Fixtures must copy the transmitter, not the decoder.** Every "shortcut"
+  in a synthetic stream — skipping a descramble the air performs, filling
+  gaps arbitrarily instead of on the slot grid — is a place your test
+  quietly adopts your code's worldview.
+- **A fake service inherits none of the real service's strictness unless
+  you give it some.** The real SoapyRemote server complains about
+  unconsumed payload bytes; a fake that doesn't is blind to
+  argument-shape drift.
+- **Know which drift class each net catches.** Full-consumption asserts
+  catch argument-shape drift but structurally *cannot* catch opcode
+  drift — both sides move together — which is why upstream-literal pins
+  exist as a separate net.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Unconditional encode side | fixture scrambles at colour 0, as real air does | `internal/radio/tetra/dmo_decode_test.go` (`TestDMTCHSpeechRoundTrip`) |
+| Independent-path control | 4:1 decimation via a separate resampler before replay | `internal/scanner/ccdecoder/ddc_highrate_test.go` (`TestDownconverterSNRInvariantAcrossRate`) |
+| Strict fake server | fails any test leaving unconsumed request bytes | `internal/sdr/soapyremote/driver_test.go` (`newFakeSoapyServer`, `assertCleanProtocol`) |
+| Opcode pins | numeric RPC ids checked against upstream literals | `driver_test.go` (`TestOpenSetAntennaUsesUpstreamOpcode`) |
+| Faithful synthetic transmitter | bursts on a true 255-dibit slot grid | `internal/scanner/ccdecoder/pipelines_dmo_test.go` (`buildDMODibitStream`, `dmoSlot`) |
+| The bug the grid caught | noise-driven grants on an idle channel | `pipelines_dmo_test.go` (`TestTETRADMOPipelineIgnoresIdleChannel`) |
+
+## In this post
+
+- **The trap, stated precisely** — what makes a test unable to disagree.
+- **Rule 1: encode like the air, not like the decoder** — the colour-0
+  scramble.
+- **Rule 2: build the control from parts you're not testing** — the
+  #764 resampler.
+- **Rule 3: fakes must enforce, not just respond** — the strict Soapy
+  server, and its honest limit.
+- **Rule 4: synthetic streams need the real structure** — the 255-dibit
+  slot grid.
+
+## The trap, stated precisely
+
+A test disagrees with your code only where the two embody *different
+beliefs*. A round-trip test — encode, decode, compare — shares every
+belief by construction: the layout, the scrambling policy, the framing,
+all authored by the same hands, usually in the same afternoon. It
+verifies the two directions are inverses, which is worth something, and
+verifies nothing about whether either matches the world. GopherTrunk
+shipped a SmartNet decoder for months on green round-trips over a
+framing no real system transmits
+([Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})).
+
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+literal vectors are the first antidote: pin one side to bytes from
+outside your head. But literal vectors cover parsers; whole subsystems —
+pipelines, drivers, grant logic — need *dynamic* fixtures, and every
+dynamic fixture is a little transmitter you wrote yourself. The
+discipline below is about keeping those little transmitters honest.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="A ladder of test doubles ranked by how much external reality they enforce. Bottom rung: round-trip with shared assumptions, catches nothing about the world. Second rung: fixture pinned to real-air behaviour, such as unconditional scrambling. Third rung: fake service enforcing the real protocol's strictness, full consumption of request bytes. Fourth rung: structurally faithful synthetic transmitter on the real slot grid. Top rung, highlighted: independent implementation or real capture. An arrow up the side reads: more reality enforced, more bugs catchable.">
+  <line x1="70" y1="210" x2="70" y2="20" stroke="var(--fg-muted)"/>
+  <polygon points="66,24 70,14 74,24" fill="var(--fg-muted)"/>
+  <text x="52" y="120" fill="var(--fg-muted)" font-size="9" transform="rotate(-90 52 120)">more reality enforced</text>
+  <rect x="100" y="182" width="440" height="28" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="110" y="200" fill="var(--fg-muted)" font-size="10">round-trip, shared assumptions — proves inverses, not correctness</text>
+  <rect x="100" y="142" width="460" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="110" y="160" fill="currentColor" font-size="10">fixture pinned to real-air behaviour (scramble unconditionally)</text>
+  <rect x="100" y="102" width="480" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="110" y="120" fill="currentColor" font-size="10">fake enforcing the real service's strictness (full consumption)</text>
+  <rect x="100" y="62" width="500" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="110" y="80" fill="currentColor" font-size="10">structurally faithful synthetic transmitter (255-dibit slot grid)</text>
+  <rect x="100" y="22" width="520" height="28" rx="5" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="110" y="40" fill="var(--accent)" font-size="10">independent implementation / real capture (Parts 3, 6, 10)</text>
+</svg>
+<figcaption>Test doubles ranked by the reality they enforce: each rung up removes one class of assumption your code and its test could otherwise share.</figcaption>
+</figure>
+
+## Rule 1: encode like the air, not like the decoder
+
+The DMO colour-0 bug is the cleanest specimen in the tree. TETRA
+scrambling is non-identity at colour 0 — the LFSR seeds to `0xC0000000`
+even with every colour bit zero — but the DMO voice path inherited a
+`if colour != 0` descramble skip from TMO code where the guard happened
+to be safe. Real colour-0 traffic therefore reached the Viterbi still
+scrambled, and clear voice was misread as encrypted for weeks.
+
+The round-trip test passed the whole time, because the fixture's encode
+side skipped scrambling under *the same condition*. Encoder and decoder
+agreed; the air disagreed with both. The fix to the test is one line of
+philosophy: the fixture must do what a **transmitter** does, not what
+the decoder expects.
+
+```go
+// internal/radio/tetra/dmo_decode_test.go (shape) — TestDMTCHSpeechRoundTrip
+for _, colour := range []uint32{0, 0x0AB1F} {
+    type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), nBits)
+    // Scrambled like real air, INCLUDING colour 0 (seed 0xC0000000,
+    // §8.2.5.2) — a real DMO transmitter never skips this.
+    onair := framing.ScrambleTetra(type4, colour)
+    /* … frame as a DNB, extract, decode … */
+    frames := DMBurstTCHSpeech(*dnb, colour)
+    // colour 0: fails against the old skip (0 frames), passes fixed (2).
+}
+```
+
+With the encode side unconditional, the colour-0 iteration became the
+failing-first regression for the fix — verified against the old code:
+zero frames before, two CRC-valid after. **Rule: every conditional in a
+fixture is a shared assumption; hunt them and align each with the
+transmitter's behaviour, not the decoder's.** The air has no `if`.
+
+## Rule 2: build the control from parts you're not testing
+
+Issue [#764]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})
+needed an experiment: a system decoded from a 2.5 MS/s capture but not
+from a 10 MS/s capture of the same site — is the wideband DDC mangling
+high-rate input, or is the deficit in the samples? The obvious test —
+run GopherTrunk's own decimation and compare — is circular: the
+component under suspicion sits inside the control.
+
+The verdict experiment decimated the 10 MS/s file 4:1 with an
+**independent resampler**, then replayed the result through the proven
+2.5 MS/s path. Same ≈9.5 dB demod SNR as the native 10 MS/s decode — so
+the deficit was baked into the captured samples (front-end phase noise
+at the Airspy's native clock), not GopherTrunk's DSP.
+`TestDownconverterSNRInvariantAcrossRate` in
+`internal/scanner/ccdecoder/ddc_highrate_test.go` pins the invariant
+permanently: a noisy channel reaches the receiver at the same in-channel
+SNR whether decoded natively at 10 MS/s or decimated to 2.5 MS/s.
+
+**Rule: when a test compares two paths, the bridge between them must not
+be built from either path.** A control that shares components with the
+hypothesis can only ever confirm it — the experimental twin of the
+round-trip trap.
+
+## Rule 3: fakes must enforce, not just respond
+
+Unit tests for the SoapyRemote driver run against `newFakeSoapyServer`,
+a from-scratch TCP fake. For a long time it was a *permissive* fake: it
+parsed the arguments it knew about and ignored trailing bytes. The real
+`SoapySDRServer` is stricter — its `~SoapyRPCUnpacker` logs
+`Unconsumed payload bytes N` whenever a request carries more than the
+handler consumed. That gap in strictness is exactly where the
+`callSetAntenna = 600` opcode bug lived undetected: the wrong opcode
+invoked a different real handler, left 9 bytes unconsumed, and only the
+*real* server ever said so — in a log line on an operator's machine.
+
+The fake now enforces what the real server enforces, and every test
+gets it without asking:
+
+```go
+// internal/sdr/soapyremote/driver_test.go (shape) — newFakeSoapyServer
+s := &fakeSoapyServer{t: t, ln: ln, quietDone: make(chan struct{})}
+go s.acceptLoop()
+/* … */
+// Every test that drives the fake server gets the wire-shape check
+// for free, so a new or edited call has to account for its own bytes.
+t.Cleanup(func() { s.assertCleanProtocol(t) })
+```
+
+`assertCleanProtocol` fails any test whose session left an unknown call
+id or unconsumed payload bytes. Retrofitting it immediately **caught two
+more calls the fake had not been parsing** — drift that had been sitting
+green for who knows how long.
+
+Just as important is the fake's documented *limit*. The comment on its
+error ledger says it plainly: this net catches **argument-shape** drift,
+but it "cannot catch OPCODE drift on its own: this fake switches on the
+same constants the client packs, so if a constant is wrong both sides
+move together and agree. That is exactly how SET_ANTENNA=600 survived a
+release." Opcodes are pinned by a *different* net —
+`TestOpenSetAntennaUsesUpstreamOpcode`, against literals from upstream's
+`SoapyRemoteDefs.hpp` — a story
+[Part 9]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})
+tells in full. **Rule: give the fake every strictness the real service
+has, and write down which drift class it still cannot see — then build
+the second net for that class.**
+
+## Rule 4: synthetic streams need the real structure
+
+The subtlest example: the DMO pipeline once granted a voice recording
+~230 ms after startup on a **silent channel**. The DNB training-sequence
+correlator false-fires at ~18/s on noise — that's inherent to an
+11-dibit match at tolerance 2 — and the grant logic counted raw
+detections. The fix (`tetra.DMSlotGrid`) exploits a physical fact: one
+radio on one clock puts every burst on one residue mod 255 dibits, while
+noise detections spread uniformly over all 255 residues.
+
+Here's the test-design point: the *old* synthetic fixture could not have
+caught either the bug or verified the fix, because it laid bursts into
+the stream with **arbitrary filler between them** — no slot grid at all.
+A stream without the real structure can't exercise a detector built on
+that structure. The rebuilt fixture is a faithful transmitter down to
+the geometry:
+
+```go
+// internal/scanner/ccdecoder/pipelines_dmo_test.go (shape)
+// A synthetic stream MUST be laid out this way: a real transmitter
+// emits one burst per timeslot from one clock, so all its DNB leads
+// share one residue mod 255 — the property tetra.DMSlotGrid uses to
+// tell traffic from correlator noise.
+const dmoTestSlotDibits = 255
+
+func dmoSlot(seed int, fields ...[]uint8) []uint8 {
+    slot := dmoFiller(seed, dmoTestSlotDibits)
+    /* … place freq-corr / BKN1 / training / BKN2 at dibits 7..234 … */
+    return slot
+}
+```
+
+On that grid, three failing-first regressions became writable —
+`TestTETRADMOPipelineIgnoresIdleChannel`,
+`…GrantsOnlyAfterLock`, `…RearmsBetweenTransmissions` — all three
+failing against the old pipeline
+([TETRA End to End Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})
+has the operator-side story). **Rule: a synthetic transmitter must be
+faithful in structure, not just content.** Detectors exploit physical
+constraints — one clock, one residue, back-to-back frames — and a
+fixture that doesn't model the constraint silently exempts every
+component that depends on it.
+
+### How that principle shaped the Go code
+
+- **Fixture encoders live next to the decoder and mirror the air.**
+  `EncodeTCHS`, `EncodeOSWFrame`, `buildDMODibitStream` — each is the
+  transmitter's behaviour transcribed, unconditional scrambling and slot
+  grids included, so a fixture "shortcut" is a visible diff.
+- **Strictness is installed in the constructor.** The Soapy fake wires
+  `assertCleanProtocol` into `t.Cleanup` inside `newFakeSoapyServer`, so
+  no test can opt out by forgetting.
+- **Every net documents its blind spot.** The fake's comment names the
+  drift class it cannot catch and points at the test that can — the
+  suite is a system of nets, not a pile.
+- **Controls are labelled independent.** The #764 test's comments say
+  *why* the resampler is separate; the independence is the load-bearing
+  property, protected from a well-meaning refactor to "reuse" the DDC.
+
+## Where this goes next
+
+These four rules are defense; the next part is the full offensive
+campaign. [Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})
+replays the SmartNet rebuild end to end — a decoder whose every
+synthetic was green over framing no real system transmits, torn down and
+rebuilt from proven decoders, with reference-literal pins and a
+failing-first real-air regression standing where the round-trips used to.
+
+## FAQ
+
+**What is the self-consistent trap in testing?**
+A test whose expected values derive from the same assumptions as the
+code under test — most commonly an encode/decode round-trip where both
+sides were written together. It verifies internal consistency and passes
+regardless of whether either side matches the real wire format. Every
+worked example in this post is a structural way to reintroduce an
+outside fact.
+
+**Are round-trip tests worthless, then?**
+No — they verify inverse-ness, catch regressions in either direction,
+and exercise buffer handling cheaply. They're insufficient alone: pair
+them with literal vectors pinned to an independent source, and audit the
+fixture's conditionals against transmitter behaviour. GopherTrunk keeps
+its round-trips; it stopped letting them testify about the air.
+
+**How faithful does a synthetic test signal need to be?**
+Faithful in every property some component *exploits*. The DMO grant path
+exploits slot-grid regularity, so the fixture needs a true 255-dibit
+grid; the SmartNet framer exploits back-to-back frames, so its fixture
+emits them back-to-back with the trailing sync. The practical method:
+for each detector or gate in the path, ask "what physical constraint
+does this lean on?" and check the fixture models it.
+
+**How do I test a client against a fake server without fooling myself?**
+Give the fake the real server's observable strictness — parse every
+argument and fail on leftover bytes, unknown ids, out-of-order calls —
+and install those asserts in the constructor so they're universal. Then
+write down what the fake still can't catch (constants both sides share)
+and pin those separately against upstream literals.
+
+**What does "failing-first" add on top of all this?**
+Proof that the test can disagree. Running the new test against the *old*
+code and watching it fail — zero frames at colour 0, zero decodes from
+the real-air SmartNet stream — is the only direct evidence a test has
+discriminating power.
+[Part 12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})
+makes that the standing rule for every bug fix.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: When References Disagree, the Capture Referees]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})
+· Next →
+[Part 8: Case Study — Rebuilding SmartNet From Proven Decoders]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})

--- a/docs/_posts/2026-09-09-operator-cookbook-07-multi-system-pool.md
+++ b/docs/_posts/2026-09-09-operator-cookbook-07-multi-system-pool.md
@@ -1,0 +1,362 @@
+---
+title: "The Operator's Cookbook, Part 7: Many Systems, One Box — The SDR Pool"
+description: "A complete GopherTrunk recipe for monitoring several trunked systems from one daemon: pinning dongles by serial, control vs voice vs wideband roles, sizing the shared voice pool against concurrent calls, and the priority, scan-list and preemption rules that decide who gets a radio."
+category: tutorials
+keywords: multiple sdr dongles scanner, monitor multiple trunked systems, sdr voice pool sizing, talkgroup priority preemption, scan list config sdr, rtl-sdr serial assignment, usb bandwidth multiple sdr, trunking scanner multi system, gophertrunk cookbook
+tags: [operator-cookbook, sdr-pool, priority, scanning, config, hardware]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 7
+---
+
+*Part 7 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 6]({{ '/blog/tutorials/operator-cookbook-06-analog-fm-tone-out/' | relative_url }})
+added analog FM and pager tones to the fleet of things one box can hear.
+Every recipe so far ran one system on one or two dongles; real monitoring
+rarely stays that small. This part is the scale-out recipe: several dongles,
+several systems — P25 county, DMR Tier III utility, and whatever else your
+area runs — behind **one daemon and one shared voice pool**, with the
+priority and preemption rules that decide, when calls outnumber radios,
+which call wins.*
+
+> **TL;DR:** Pin every dongle by **serial** and give it a role: a
+> `role: wideband` device per system carries that system's control channel
+> as a `channels:` tap plus `voice_taps: N` in-window voice slots, and one
+> `role: voice` dongle backstops out-of-window grants for *all* systems.
+> Contention is policy, not luck: talkgroup CSV `Priority` (1 highest, 10
+> lowest) drives preemption — higher preempts lower, equal never preempts,
+> emergency preempts everything, `Lockout` drops a grant entirely —
+> and `scanner.scan_mode: list` follows only talkgroups marked `Scan`.
+> Watch startup for one `device opened … serial=… role=…` line per dongle,
+> and treat `no voice SDR available; voice grants will be dropped` as your
+> sizing alarm.
+
+**Key takeaways**
+
+- **Serials are the only stable identity.** With several identical dongles,
+  "first-found" ordering is a lottery — burn unique serials into your sticks
+  (`rtl_eeprom`) and pin every config entry, or a reboot reshuffles roles.
+- **Wideband taps run in parallel; the cc-hunt runs in series.** Each
+  wideband `channels:` entry gets its own decoder simultaneously; systems
+  left to a single `role: control` dongle are hunted one at a time by the
+  supervisor. Parallel monitoring means a wideband tap per system.
+- **The voice pool is shared, and preemption is the safety valve.** All
+  voice capacity — physical voice dongles and every `voice_taps` slot —
+  serves every system, allocated per grant by talkgroup priority.
+- **Sizing shows up in the log, not in a crash.** An undersized pool drops
+  grants with a specific, greppable WARN; count those lines before buying
+  another dongle.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Device identity | match config to hardware by serial | `sdr.devices[].serial`, `gophertrunk sdr list` |
+| Roles | control / voice / wideband / auto | `sdr.devices[].role` |
+| Per-system CC taps | parallel control decode on one capture | `role: wideband` + `channels:` ([voice taps]({{ '/reference/wideband-voice-taps/' | relative_url }})) |
+| Voice capacity | in-window slots + physical backstop | `voice_taps`, a `role: voice` device |
+| Priority & lockout | who wins a scarce radio | talkgroup CSV `Priority` / `Lockout` columns |
+| Scan list | follow only flagged talkgroups | `scanner.scan_mode: list` + CSV `Scan` column ([priority scan]({{ '/reference/priority-scan/' | relative_url }})) |
+| Hotplug survival | re-acquire vanished dongles by serial | `sdr.watchdog_interval_ms` |
+
+## In this post
+
+- **What you're building** — three systems, four dongles, one cockpit.
+- **The shopping list** — dongles multiply; USB rules multiply faster.
+- **The config** — serials, roles, taps and a prioritized talkgroup file.
+- **First run — what healthy looks like** — the pool assembling itself.
+- **When it doesn't work** — starvation, stealing, shuffling, stalling.
+- **Variations** — one-dongle rotation, multi-site P25, scan-list mode.
+
+## What you're building
+
+The finished rig monitors a P25 system and a DMR Tier III system
+*simultaneously* — both control channels decoding at once, calls from either
+landing in one History panel, one recordings tree, one live-audio cockpit —
+with a third analog-capable dongle in reserve for voice grants that fall
+outside the wideband windows. The machinery underneath is the **SDR pool**:
+a registry of opened devices, keyed by serial, that decoders and voice
+chains borrow from and return to — the
+[pool & concurrency deep dive]({{ '/blog/deep-dives/sdr-internals-03-sdr-pool-streaming-concurrency/' | relative_url }})
+is its full story.
+
+The design question this recipe answers is *contention*. Two systems can
+easily produce five simultaneous calls against three voice slots. GopherTrunk
+resolves that with the trunking engine's
+[voice pool]({{ '/blog/deep-dives/trunking-engine-04-voice-pool/' | relative_url }})
+and its
+[priority & preemption]({{ '/blog/deep-dives/trunking-engine-05-priority-preemption/' | relative_url }})
+rules — policy you write in the talkgroup CSV, enforced per grant.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="The multi-system SDR pool: three dongles pinned by serial feed the pool — a wideband dongle decoding the P25 control channel with three voice tap slots, a second wideband dongle decoding the DMR Tier III control channel with two voice taps, and a physical voice dongle; both control decoders publish grants to the trunking engine, whose priority gate allocates voice capacity from the shared pool and preempts lower-priority calls when slots run out">
+  <rect x="8" y="24" width="118" height="40" rx="4" fill="none" stroke="currentColor"/>
+  <text x="67" y="40" text-anchor="middle" fill="currentColor" font-size="10">dongle A (wideband)</text>
+  <text x="67" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">P25 CC tap + 3 voice taps</text>
+  <rect x="8" y="104" width="118" height="40" rx="4" fill="none" stroke="currentColor"/>
+  <text x="67" y="120" text-anchor="middle" fill="currentColor" font-size="10">dongle B (wideband)</text>
+  <text x="67" y="133" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DMR T3 CC tap + 2 voice taps</text>
+  <rect x="8" y="184" width="118" height="40" rx="4" fill="none" stroke="currentColor"/>
+  <text x="67" y="200" text-anchor="middle" fill="currentColor" font-size="10">dongle C (voice)</text>
+  <text x="67" y="213" text-anchor="middle" fill="var(--fg-muted)" font-size="9">out-of-window backstop</text>
+  <line x1="126" y1="44" x2="168" y2="90" stroke="currentColor"/>
+  <line x1="126" y1="124" x2="168" y2="124" stroke="currentColor"/>
+  <line x1="126" y1="204" x2="168" y2="158" stroke="currentColor"/>
+  <rect x="168" y="84" width="120" height="80" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="228" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="10">SDR pool</text>
+  <text x="228" y="126" text-anchor="middle" fill="var(--fg-muted)" font-size="9">keyed by serial,</text>
+  <text x="228" y="138" text-anchor="middle" fill="var(--fg-muted)" font-size="9">watchdog re-acquires</text>
+  <line x1="288" y1="124" x2="330" y2="124" stroke="currentColor"/>
+  <rect x="330" y="24" width="150" height="56" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="405" y="46" text-anchor="middle" fill="var(--accent)" font-size="10">P25 + DMR CC decoders</text>
+  <text x="405" y="60" text-anchor="middle" fill="var(--fg-muted)" font-size="9">grants, in parallel</text>
+  <rect x="330" y="104" width="150" height="90" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="405" y="126" text-anchor="middle" fill="var(--accent)" font-size="10">trunking engine</text>
+  <text x="405" y="142" text-anchor="middle" fill="var(--fg-muted)" font-size="9">priority gate:</text>
+  <text x="405" y="155" text-anchor="middle" fill="var(--fg-muted)" font-size="9">higher preempts lower,</text>
+  <text x="405" y="168" text-anchor="middle" fill="var(--fg-muted)" font-size="9">emergency beats all,</text>
+  <text x="405" y="181" text-anchor="middle" fill="var(--fg-muted)" font-size="9">lockout drops the grant</text>
+  <line x1="405" y1="80" x2="405" y2="104" stroke="var(--accent)"/>
+  <line x1="480" y1="149" x2="522" y2="149" stroke="currentColor"/>
+  <rect x="522" y="104" width="148" height="90" rx="4" fill="none" stroke="currentColor"/>
+  <text x="596" y="126" text-anchor="middle" fill="currentColor" font-size="10">shared voice capacity</text>
+  <text x="596" y="142" text-anchor="middle" fill="var(--fg-muted)" font-size="9">A: 3 taps · B: 2 taps</text>
+  <text x="596" y="155" text-anchor="middle" fill="var(--fg-muted)" font-size="9">C: physical voice SDR</text>
+  <text x="596" y="176" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ recordings + web console</text>
+</svg>
+<figcaption>Both control channels decode in parallel; the engine allocates one shared pot of voice capacity per grant, with talkgroup priority deciding who gets — and who loses — a radio.</figcaption>
+</figure>
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| 3–4 RTL-SDR dongles | ~$35 each | identical hardware is fine — serials make them distinct |
+| Antennas / splitter | varies | one antenna per band beats one splitter per rig to start |
+| Powered USB hub or rear-panel ports | ~$20 | each dongle streams ~2.4 MS/s continuously; bus power on a passive hub is where multi-dongle rigs die |
+| Computer | $0 | CPU scales with taps — a modern quad-core carries this build easily |
+
+Total: **well under $200** on top of what you own. Before configuring
+anything, give every stick a unique serial (`rtl_eeprom -s 00000101` style)
+and verify with `gophertrunk sdr list` — the
+[USB]({{ '/reference/usb/' | relative_url }}) layer identifies dongles by
+serial and nothing else ([hardware
+checklist]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})).
+
+## The config
+
+```yaml
+log:
+  level: info
+
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+
+sdr:
+  sample_rate: 2_400_000
+  watchdog_interval_ms: 30000
+  devices:
+    - serial: "00000101"            # P25 county
+      role: wideband
+      gain: "auto"
+      center_freq_hz: 858_000_000
+      voice_taps: 3
+      channels:
+        - frequency_hz: 857_262_500
+          system: "County-P25"
+    - serial: "00000102"            # DMR Tier III utility
+      role: wideband
+      gain: "auto"
+      center_freq_hz: 465_000_000
+      voice_taps: 2
+      channels:
+        - frequency_hz: 465_337_500
+          system: "Utility-DMR"
+    - serial: "00000103"            # shared out-of-window voice backstop
+      role: voice
+      gain: "auto"
+
+scanner:
+  scan_mode: list                   # follow only Scan=true talkgroups
+
+trunking:
+  systems:
+    - name: "County-P25"
+      protocol: p25
+      control_channels: [857_262_500, 858_487_500]
+      talkgroup_file: "../config/talkgroups-p25.csv"
+    - name: "Utility-DMR"
+      protocol: dmr
+      control_channels: [465_337_500]
+      talkgroup_file: "../config/talkgroups-dmr.csv"
+      # no dmr_band_plan: the wideband dongle learns LCN→frequency
+      # off the air — see Part 2
+```
+
+And the policy file — a few rows of `talkgroups-p25.csv`:
+
+```
+Decimal,Alpha Tag,Priority,Scan,Lockout
+9001,Fire Dispatch,1,Y,
+9014,PD Tac 2,3,Y,
+9101,Schools Ops,,N,
+9230,Water Dept,,,Y
+```
+
+How the pieces interact. **`Priority` is 1 (highest) to 10 (lowest), 0/empty
+= unset** — and it's what preemption keys on. **`Scan`** matters only
+because `scan_mode: list` is set: unlisted or `Scan=N` talkgroups are
+observed on the control channel but never tie up a voice slot (Emergency
+grants bypass the list). **`Lockout`** (or the classic `L` in the Priority
+column) drops the grant entirely. All three are editable live from the web
+UI too — [Trunking Engine Part
+6]({{ '/blog/deep-dives/trunking-engine-06-talkgroups-scan-modes/' | relative_url }})
+covers the semantics in depth.
+
+**Voice sizing math:** this config has 3 + 2 in-window taps plus one
+physical voice dongle = six concurrent calls before anything is dropped —
+but taps only serve grants inside their own dongle's 2.4 MHz window, and the
+DMR system needs its learned band plan before grants resolve to frequencies
+at all ([Part 2]({{ '/blog/tutorials/operator-cookbook-02-dmr-tier3/' | relative_url }})).
+The physical voice dongle is the flexible remainder: it can tune anywhere,
+for either system.
+
+## First run — what healthy looks like
+
+Startup narrates the pool assembling — one line per stick, and a line for
+anything it *didn't* take:
+
+```
+INF device opened driver=rtlsdr serial=00000101 role=wideband rate_hz=2400000 ppm=0 bias_tee=false
+INF device opened driver=rtlsdr serial=00000102 role=wideband rate_hz=2400000 ppm=0 bias_tee=false
+INF device opened driver=rtlsdr serial=00000103 role=voice rate_hz=2400000 ppm=0 bias_tee=false
+INF skipping non-configured SDR; add its serial to sdr.devices to use it
+```
+
+Then both systems lock — in parallel, no taking turns — and grants start
+flowing. The policy lines are the ones specific to this recipe:
+
+```
+INF grant locked out grant=... tg=Water Dept
+INF call ended device=... reason=preempted
+INF no voice device available for grant grant=...
+```
+
+The first is your `Lockout` column working. The second is priority doing its
+job: a Priority-1 Fire Dispatch grant arrived with every slot busy, and the
+engine tore down the lowest-priority active call to serve it. The rules,
+exactly as the engine's tests pin them: **higher preempts lower; equal never
+preempts** (a stable call holds its radio against peers); **emergency
+preempts everything; a locked-out grant preempts nothing**. The third line
+is your sizing meter — occasional during a genuine pile-up, but if it's
+routine, add a voice dongle or raise `voice_taps` before touching anything
+else. Two sharper WARNs distinguish *why* nothing was available:
+`no voice SDR available; voice grants will be dropped` means the pool has no
+voice capacity at all, and
+`voice grant frequency outside every voice device's tuning window` means it
+has capacity in the wrong place — widen a window or re-center it.
+
+Pull a dongle mid-run to watch the watchdog earn its keep:
+
+```
+WRN sdr: watchdog: device missing from USB enumerate
+INF sdr: watchdog: device reappeared; reacquiring
+```
+
+— re-acquired **by serial**, which is the deep reason this recipe insists on
+unique ones. The [USB hotplug deep
+dive]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }})
+explains the machinery.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Roles land on the wrong dongles after reboot | duplicate/blank serials, first-found matching | Unique serials via `rtl_eeprom`, pin every entry. `matched configured SDR by partial serial` in the log means pin the *full* serial |
+| `configured SDR not present on the bus; check the cable / dmesg / lsusb` | dead port, starved hub, wrong serial | Rear-panel ports or a powered hub; re-check `gophertrunk sdr list` |
+| Frequent `no voice device available for grant` | pool undersized for real concurrency | Count concurrent calls in History at busy hour; raise `voice_taps` (CPU ~linear per tap, warns above 16) or add a voice dongle |
+| High-priority calls missed during pile-ups | priorities unset, so nothing may preempt | Set `Priority` on the talkgroups you care about — an unset incoming grant never preempts a set one |
+| Analog scan list (Part 6) stopped working after adding trunking | the conventional scanner takes the *last* voice device — trunking and the scan list now compete | Add a dedicated voice dongle for the scanner; the daemon auto-detects a spare |
+| One system decodes, its co-tenant tap sits at the noise floor | shared front end: one gain for all taps on a dongle | `gain: "auto"` on multi-tap dongles (issue #749); a genuinely weak system deserves its own dongle |
+| Dongles vanish under load, watchdog churns | USB bandwidth/power exhaustion | Spread across root hubs; powered hub; lower `sample_rate` if the hardware allows |
+| `ccdecoder: decode can't keep up with real time` | CPU oversubscribed by tap count | Shed taps or systems, or move to a bigger box — this WARN means decode, not RF |
+
+### How this recipe shapes operator practice
+
+- **Write policy before you need it.** Priority and lockout only help during
+  the pile-up you didn't predict; a CSV without a `Priority` column is a
+  pool allocated by luck.
+- **Grep, then buy.** The dropped-grant WARN is a precise demand signal —
+  count it for a week before spending $35 on capacity you may not need.
+- **One knob per dongle.** Every device block has exactly serial, role,
+  center and taps; when the pool misbehaves, that's the whole search space.
+
+## Variations
+
+- **One dongle, many systems.** Skip wideband: list every system, give one
+  dongle `role: control`, and the
+  [cc-hunt supervisor]({{ '/blog/deep-dives/the-hunt-06-control-channel-hunting/' | relative_url }})
+  rotates through them (`scanner.cc_hunt` dwell/backoff), sticky to the last
+  lock. Sequential, not parallel — reconnaissance mode, not monitoring mode.
+- **Multi-site P25 on one capture.** Several sites of *one* system fit as
+  multiple `channels:` entries on one wideband dongle — all decoded in
+  parallel ([multisite trunking]({{ '/reference/multisite-trunking/' | relative_url }}),
+  and [The Hunt Part 9]({{ '/blog/deep-dives/the-hunt-09-wideband-multisite-p25/' | relative_url }})
+  for the field story).
+- **`scan_mode: all`** — drop the scan list and follow everything
+  non-locked-out; right for archival builds (Part 10), wrong for a small
+  pool on busy systems.
+- **`role: auto`** lets the daemon assign a spare stick where needed —
+  convenient on a bench, too nondeterministic for a production box.
+
+## Where this goes next
+
+Every dongle so far plugs into the box that decodes it. [Part
+8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+cuts that cable: SoapyRemote, rtl_tcp and ka9q-radio put the radio at the
+antenna and the decoder in the rack — with network budgets, antenna-port
+validation, and the drop counters that tell you which side of the wire is
+actually struggling.
+
+## FAQ
+
+**How many trunked systems can GopherTrunk monitor at once?**
+As many as you give it capture for: each wideband `channels:` tap runs its
+own control-channel decoder in parallel, so the practical limits are dongles,
+USB bandwidth, and CPU (~linear per tap). Systems sharing a single
+`role: control` dongle are instead hunted one at a time.
+
+**How many voice dongles do I need for a trunked system?**
+Count concurrent calls, not talkgroups. Each wideband dongle's `voice_taps`
+serve in-window grants free of extra hardware; one physical voice dongle
+backstops the rest. When `no voice device available for grant` shows up
+routinely, that's the signal to add capacity.
+
+**How does talkgroup priority work in GopherTrunk?**
+`Priority` in the talkgroup CSV runs 1 (highest) to 10 (lowest). When a
+grant arrives and every voice slot is busy, a higher-priority grant preempts
+the lowest-priority active call; equal priorities never preempt; emergency
+grants preempt everything; locked-out talkgroups never follow at all.
+
+**Can I mix protocols on one SDR dongle?**
+Yes — a wideband dongle's `channels:` list can mix P25, DMR, NXDN and more,
+each entry pointing at its own system, provided every frequency fits the
+dongle's `center ± sample_rate/2` window (with a 5% edge guard).
+
+**Why do my dongles swap roles when I reboot?**
+Identical dongles ship with identical serials, and a blank `serial:` matches
+first-found — enumeration order isn't stable across boots. Write unique
+serials with `rtl_eeprom`, pin them in `sdr.devices`, and the pool (and its
+hotplug watchdog) becomes deterministic.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: Analog FM & Tone-Out Paging]({{ '/blog/tutorials/operator-cookbook-06-analog-fm-tone-out/' | relative_url }})
+· Next →
+[Part 8: Radios Far Away — SoapyRemote, rtl_tcp & ka9q]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})

--- a/docs/_posts/2026-09-09-p25-end-to-end-07-phase2-tdma.md
+++ b/docs/_posts/2026-09-09-p25-end-to-end-07-phase2-tdma.md
@@ -1,0 +1,337 @@
+---
+title: "P25 End to End, Part 7: Phase 2 TDMA — Two Voices per Carrier"
+description: How P25 Phase 2 fits two voice calls in one 12.5 kHz channel — H-DQPSK at 6000 symbols per second, the 360 ms superframe and ISCH slot typing, MAC PDUs in place of TSBKs, and the FEC hand-off that silently defaulted to zero on one pipeline.
+category: deep-dives
+keywords: p25 phase 2 tdma, h-dqpsk demodulation, p25 phase 2 mac pdu, p25 superframe isch, two slot tdma 12.5 khz, p25 phase 2 decoder, pn44 scrambler p25, hybrid phase 1 phase 2 system, gophertrunk p25
+tags: [p25-end-to-end, p25, phase2, tdma, mac, dsp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 7
+---
+
+*Part 7 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
+[Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})
+walked Phase 1's linear twin; this part is the generational twin. Phase 2
+keeps the Phase 1 control channel and swaps the traffic channel for a
+2-slot TDMA carrier — two simultaneous calls where Phase 1 fits one. New
+symbol rate, new differential modulation, a MAC layer where TSBKs used to
+be, and a fresh chapter of the running lesson: a knob that exists on one
+pipeline can silently default to zero on its twin.*
+
+> **TL;DR:** P25 Phase 2 traffic channels run **H-DQPSK at 6000 symbols/s**
+> — decoded by the *same* `demod.PiOver4DQPSK` primitive TETRA uses, one
+> rotation argument (π/8) apart. The stream is organised as a **360 ms
+> superframe of twelve 30 ms sub-frames alternating between two
+> timeslots**; a Golay(24,12)-protected **ISCH** field names each
+> sub-frame's SlotType (4V/2V voice or MAC). Signalling arrives as 18-byte
+> **MAC PDUs** through a trellis → RS(24,16,9) → PN44-descramble FEC chain
+> (`internal/radio/p25/phase2/process.go`), the PN44 seeded from
+> WACN/System/NAC. The control channel stays Phase 1 — and issue #882
+> proved the FEC knobs can validate, display, and still never arrive on the
+> wideband pipeline.
+
+**Key takeaways**
+
+- **Phase 2 is a traffic-channel upgrade, not a new system.** The control
+  channel stays Phase 1 C4FM; grants steer subscribers to 6000-baud TDMA
+  carriers, and Part 5's `AccessTDMA` flag routes them into the right
+  voice chain.
+- **The demodulator is a rotation argument.** `PiOver4DQPSK` serves TETRA
+  at π/4 and Phase 2 H-DQPSK at π/8 — one differential core, so a fix in
+  it lands in both protocols at once.
+- **The superframe is the addressing scheme.** Twelve 30 ms sub-frames,
+  even index → timeslot 0, odd → timeslot 1; the ISCH tells you what each
+  carries without inspecting the payload.
+- **Descramble in the channel-bit domain, before the FEC.** The PN44
+  applies to *channel* bits per TIA-102.BBAC-1 §7.2.5; descrambling the
+  information bits after the trellis fails the outer RS on every real
+  scrambled burst (the issue #915 ordering lesson).
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| IQ → dibits | RRC → Gardner → carrier recovery → π/8 differential | `internal/radio/p25/phase2/receiver/receiver.go` |
+| Shared demod core | rotation π/4 = TETRA, π/8 = Phase 2 | `internal/dsp/demod/piover4_dqpsk.go` (`PiOver4DQPSK`) |
+| Superframe slicing | dibits → 12 SlotType-tagged sub-frames | `superframe_decoder.go` (`SuperframeDecoder`) |
+| Slot typing | Golay(24,12)-protected SlotType + counter | `isch.go` (`DecodeISCH`) |
+| MAC FEC chain | descramble → deinterleave → trellis → RS(24,16,9) | `process.go` (`decodeMACPDUDibits`) |
+| MAC opcodes | grants, idle, hangtime, encryption sync, IDEN_UP | `mac.go` / `mac_standard.go` / `mac_vendor.go` |
+| Grant routing | Phase 1 CC stamps Phase 2 FEC config on TDMA grants | `phase1/control.go` (`publishVoiceGrant`) |
+
+## In this post
+
+- **Two voices per carrier** — TDMA arithmetic and the hybrid reality.
+- **π/8 on a shared core** — the H-DQPSK receiver's borrowed lessons.
+- **The superframe and the ISCH** — how 30 ms sub-frames get names.
+- **MAC PDUs, where TSBKs used to be** — the FEC chain's ordering lesson.
+- **The knob that defaulted to zero** — issue #882, twin-pipeline audit.
+
+## Two voices per carrier
+
+Phase 1 spends a whole 12.5 kHz channel on one call. Phase 2 raises the
+symbol rate from 4800 to **6000** — one dibit per symbol, 12 kbps of
+channel capacity — then time-division-multiplexes it into two slots, each
+sufficient for one AMBE+2 voice stream plus signalling. Two concurrent
+calls per carrier: half the frequencies, or twice the capacity:
+
+| Axis | Phase 1 FDMA | Phase 2 TDMA |
+|---|---|---|
+| Symbol rate | 4800 sym/s | 6000 sym/s |
+| Modulation (downlink) | C4FM (or CQPSK/LSM) | H-DQPSK |
+| Calls per 12.5 kHz | 1 | 2 |
+| Voice codec | IMBE 4400 | AMBE+2 |
+| Signalling unit | TSBK | MAC PDU |
+| Control channel | Phase 1 | still Phase 1 |
+
+The last row is the practical one. On real deployments the **control
+channel stays Phase 1** — FDMA, 4800 baud, C4FM, everything Parts 2–5
+built — and voice grants direct subscribers to Phase 2 traffic carriers.
+GopherTrunk models this exactly: the Phase 1 CC resolves a grant through
+the band plan, asks `BandPlan.IsTDMA(channelID)` (the 0x33 IDEN_UP flag
+from [Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})),
+and publishes it with `Protocol: "p25-phase2"` plus a `P25Phase2Decode`
+config block — trellis/RS/interleave/scrambler modes and the PN44 seed —
+so the composer's Phase 2 voice chain decodes the traffic carrier the way
+this site expects. Hybrid systems that lost this routing were issue #376;
+the config block that rode along badly was #882, below.
+
+## π/8 on a shared core
+
+The Phase 2 receiver (`internal/radio/p25/phase2/receiver`) recovers the
+dibit stream with a familiar chain: RRC matched filter (α = 0.20, span 8
+symbols), Gardner timing, carrier recovery, differential decode. The
+differential core is not new code — it is the same `PiOver4DQPSK`
+primitive that decodes TETRA, selected by one constructor argument:
+
+```go
+// internal/dsp/demod/piover4_dqpsk.go (shape)
+// The same primitive serves multiple control-channel modulations; the
+// rotation argument selects between them:
+//   - math.Pi/4 — true π/4-DQPSK as used by TETRA TMO (18000 sym/s, α=0.35)
+//   - math.Pi/8 — the π/8-shifted variant P25 Phase 2 H-DQPSK
+//     (6000 sym/s, α=0.20)
+func NewPiOver4DQPSK(sps, span int, alpha, rotation float64) *PiOver4DQPSK
+```
+
+One primitive, one rotation apart — so the differential-decode lessons the
+[TETRA series]({{ '/blog/deep-dives/tetra-end-to-end-01-pi4-dqpsk-carrier/' | relative_url }})
+paid for apply here for free, and a fix in the core lands in both
+protocols. The borrowing runs deeper. At 6000 baud a residual carrier
+offset of ~750 Hz already rotates every symbol a full π/4 into the wrong
+quadrant, so the receiver's `ClockGardner` path carries the same
+coarse-seed → NCO → Costas architecture
+[Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})'s
+CQPSK path built for issue #492 — ported for issue #813, multipath
+modulus-CV seed gate included, retuned for the rate (`costasLoopBWHz =
+150`, the same ~2.5%-of-baud normalised bandwidth).
+
+And Phase 2 got the levers Phase 1 C4FM still lacks: an opt-in **blind CMA
+equalizer** on the recovered symbol stream and a per-bit **soft-decision**
+track feeding a true soft Viterbi in the MAC path (both issue #915), plus
+an opt-in DC blocker for zero-IF spurs. The receiver options read like a
+checklist of everything the weak-signal work concluded — which makes the
+default C4FM voice path's bare chain, Part 12's subject, all the more
+conspicuous.
+
+## The superframe and the ISCH
+
+A Phase 2 carrier is a continuous dibit stream with a strict rhythm: a
+**360 ms superframe** of **twelve 30 ms sub-frames** (180 dibits each),
+alternating between the two timeslots — even sub-frame index → timeslot 0,
+odd → timeslot 1 (`Subframe.Timeslot = i & 1` in
+`superframe_decoder.go`). `SuperframeDecoder` anchors that grid on the
+20-dibit outbound sync word and slices the stream into tagged sub-frames.
+
+The tag is the **ISCH** — the Inter-Slot Signalling Channel field
+prefixing every sub-frame: a 12-bit word protected by extended
+Golay(24,12,8), carrying a 4-bit SlotType and a 0..11 sub-frame counter
+(`DecodeISCH`, `isch.go`). The SlotType says what a sub-frame carries
+without touching the payload:
+
+| SlotType | Carries |
+|---|---|
+| `Voice4V` | 4 AMBE+2 voice frames |
+| `Voice2V` | 2 voice frames + MAC |
+| `MAC_PTT` / `MAC_END` | transmission start / end signalling |
+| `MAC_IDLE` / `MAC_ACTIVE` / `MAC_HANGTIME` | channel state |
+| `MAC_SIGNALING` / `MAC_END_CONT` | signalling / end + continuation |
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="One 12.5 kilohertz carrier at 6000 symbols per second splits into a 360 millisecond superframe of twelve 30 millisecond sub-frames; even sub-frames belong to timeslot 0 and odd sub-frames to timeslot 1, so two independent voice calls interleave on one carrier, each sub-frame prefixed by an ISCH naming its slot type">
+  <text x="30" y="30" fill="currentColor" font-size="11" font-weight="bold">one 12.5 kHz carrier · 6000 sym/s</text>
+  <line x1="30" y1="44" x2="650" y2="44" stroke="currentColor"/>
+  <!-- superframe row -->
+  <text x="30" y="72" fill="var(--fg-muted)" font-size="10">superframe (360 ms):</text>
+  <!-- 12 subframes, alternate accent -->
+  <rect x="170" y="58" width="40" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="210" y="58" width="40" height="26" fill="none" stroke="currentColor"/>
+  <rect x="250" y="58" width="40" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="290" y="58" width="40" height="26" fill="none" stroke="currentColor"/>
+  <rect x="330" y="58" width="40" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="370" y="58" width="40" height="26" fill="none" stroke="currentColor"/>
+  <text x="440" y="76" fill="var(--fg-muted)" font-size="11">…</text>
+  <rect x="570" y="58" width="40" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="610" y="58" width="40" height="26" fill="none" stroke="currentColor"/>
+  <text x="190" y="75" text-anchor="middle" fill="var(--accent)" font-size="9">0</text>
+  <text x="230" y="75" text-anchor="middle" fill="currentColor" font-size="9">1</text>
+  <text x="270" y="75" text-anchor="middle" fill="var(--accent)" font-size="9">2</text>
+  <text x="630" y="75" text-anchor="middle" fill="currentColor" font-size="9">11</text>
+  <text x="170" y="100" fill="var(--fg-muted)" font-size="9">each sub-frame: 30 ms · 180 dibits · ISCH prefix names its SlotType</text>
+  <!-- slot lanes -->
+  <text x="30" y="140" fill="var(--accent)" font-size="10" font-weight="bold">timeslot 0 (even) — call A</text>
+  <rect x="240" y="126" width="52" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="304" y="126" width="52" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <rect x="368" y="126" width="52" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="266" y="141" text-anchor="middle" fill="var(--accent)" font-size="9">4V</text>
+  <text x="330" y="141" text-anchor="middle" fill="var(--accent)" font-size="9">4V</text>
+  <text x="394" y="141" text-anchor="middle" fill="var(--accent)" font-size="9">2V</text>
+  <text x="30" y="180" fill="currentColor" font-size="10" font-weight="bold">timeslot 1 (odd) — call B</text>
+  <rect x="240" y="166" width="52" height="22" fill="none" stroke="currentColor"/>
+  <rect x="304" y="166" width="52" height="22" fill="none" stroke="currentColor"/>
+  <rect x="368" y="166" width="52" height="22" fill="none" stroke="currentColor"/>
+  <text x="266" y="181" text-anchor="middle" fill="currentColor" font-size="9">4V</text>
+  <text x="330" y="181" text-anchor="middle" fill="currentColor" font-size="9">MAC</text>
+  <text x="394" y="181" text-anchor="middle" fill="currentColor" font-size="9">4V</text>
+  <text x="440" y="141" fill="var(--fg-muted)" font-size="9">← two independent calls,</text>
+  <text x="440" y="155" fill="var(--fg-muted)" font-size="9">interleaved 30 ms at a time</text>
+  <text x="30" y="222" fill="var(--fg-muted)" font-size="10">Subframe.Timeslot = index &amp; 1 — the grid, not the payload, assigns each sub-frame to its call</text>
+</svg>
+<figcaption>The 360 ms Phase 2 superframe: twelve ISCH-tagged sub-frames alternating between two timeslots, so one carrier interleaves two independent voice calls.</figcaption>
+</figure>
+
+One honesty note the package documentation (`phase2.go`) makes explicitly:
+several TIA-102.BBAB/BBAC wire details — the exact sync cadence, the ISCH
+bit packing, the per-burst interleaver — are not in the spec figures the
+project has access to, so each is a **documented working model confined to
+one file with a symmetric encoder**. If a real capture shows the sync
+recurring at a different sub-frame, the fix is one constant
+(`SyncSubframeIndex`). Containment is what separates a working model from
+folklore.
+
+## MAC PDUs, where TSBKs used to be
+
+Phase 2 signalling arrives as **MAC PDUs**: after FEC removal, an 18-byte
+unit — opcode byte, optional MFID for vendor messages, then payload. The
+opcode families rhyme with Part 3's TSBKs (`OpGroupVoiceChannelGrant`,
+`OpIdentifierUpdate`, `OpNetworkStatusBroadcastUpdate`…) plus
+TDMA-specific channel-state messages (`OpMACIdle`, `OpMACHangtime`,
+`OpEncryptionSync`). The FEC chain recovering one is the densest in the
+P25 tree, and its *ordering* carries a paid-for lesson:
+
+```go
+// internal/radio/p25/phase2/process.go (shape) — the MAC FEC chain
+// Per TIA-102.BBAC-1 §7.2.5 the PN44 scrambler applies to CHANNEL bits:
+// descramble the 146 on-wire dibits first, then deinterleave, then the
+// 4-state ½-rate trellis, then re-group to 24 hex symbols for the outer
+// RS(24, 16, 9). Descrambling the recovered information bits AFTER the
+// trellis fails the outer RS on a genuinely scrambled burst.
+func decodeMACPDUDibits(macDibits []uint8, mode TrellisMode, /* … */) (MACPDU, bool)
+```
+
+GopherTrunk originally descrambled the 144 information bits after the
+trellis. Synthetic round-trips that made the same choice on both sides
+stayed green — the same self-consistency trap as Part 1's RRC filter and
+Part 3's SCCB offsets — while the outer RS(24,16,9) would have failed on
+any genuinely scrambled on-air burst. Issue #915 fixed the order and put
+the rule in the comment. The PN44 runs continuously over the 4320-bit
+superframe with per-slot offsets, seeded from the site's identity:
+`framing.PN44SeedFromIdentity(WACN, SystemID, NAC)` — which is why the
+Phase 1 control channel snapshots its network model at grant time and
+ships the seed *with* the grant. A wrong or missing seed doesn't look like
+"wrong seed"; it looks like a dead traffic channel.
+
+## The knob that defaulted to zero
+
+That config block riding on the grant is where issue #882 lived — this
+series' cleanest specimen of the twin-pipeline failure. The single-channel
+CC pipeline (`internal/scanner/ccdecoder/pipelines.go`) parsed the Phase 2
+FEC options — trellis, RS, interleave, scrambler — and passed them into
+the decoder it built. The wideband engine
+(`internal/scanner/widebandt2/engine.go`) built the same decoder and
+passed **none of them**: they defaulted to zero. The options validated,
+the API read them back correctly, and the decoder never saw them — and
+the reporter's topology, a Phase 1 CC granting Phase 2 voice on a hybrid
+system, fell exactly in the gap.
+
+The observable tell was one field in a startup line: `composer: p25p2
+voice chain started trellis=0` where a correctly-plumbed system says
+`trellis=1`. The composer now warn-logs the configuration itself — live
+Phase 2 MAC PDUs are always trellis-encoded, so `trellis=0` on a real
+system is announced as a misconfiguration rather than discovered as
+silence. The fix (`parseP25Phase2FECModes` in the wideband engine,
+mirroring the ccdecoder path) verified on air the same day, and the
+deferred remainder — the wideband path also dropped the Phase 1 demod
+mode — became Part 6's issue #935. The full postmortem is the
+[Two Pipelines finale]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }});
+the durable rule: **a config knob is only real once the pipeline announces
+its effective value and the announcement matches the file.**
+
+### How the twin-generation design shaped the Go code
+
+- **Shared primitives, parameterised.** `PiOver4DQPSK(rotation)` and the
+  ported carrier-recovery stack mean Phase 2 inherits every
+  differential-decode fix TETRA and CQPSK earn, instead of forking one.
+- **Working models are quarantined.** Each unverified wire detail lives in
+  one file with one constant and a symmetric encoder, so a real-capture
+  correction is a local change, never archaeology.
+- **The grant carries the decode contract.** `P25Phase2Decode` ships FEC
+  modes and the PN44 seed from the CC that knows them to the voice chain
+  that needs them — resolved once, announced at chain start.
+- **Slot identity is grid arithmetic.** `Timeslot = index & 1` comes from
+  the sync-anchored superframe, not payload inspection, so voice routing
+  survives sub-frames whose payload FEC fails.
+
+## Where this goes next
+
+Phase 2 splits a carrier between two AMBE+2 streams; Phase 1 gives one
+IMBE stream the whole channel — the voice most P25 systems still carry.
+[Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }})
+follows it end to end: the 1728-bit LDU with nine IMBE frames woven
+between link-control words, the Golay/Hamming FEC, and the composer chain
+that turns a grant into a WAV — including the layout bug that let only two
+of nine voice frames decode while every test stayed green.
+
+## FAQ
+
+**Does GopherTrunk need a separate control channel config for Phase 2?**
+Usually not. Most Phase 2 deployments keep a Phase 1 control channel, so
+you configure the system like any P25 system; grants to TDMA carriers are
+detected via the 0x33 IDEN_UP flag and routed automatically. The
+per-system Phase 2 FEC knobs exist for sites whose MAC framing needs
+non-default handling.
+
+**How is P25 Phase 2's modulation related to TETRA's?**
+Both are differential QPSK variants with a per-symbol rotation — TETRA at
+π/4 and 18000 baud, Phase 2 H-DQPSK at π/8 and 6000 baud. GopherTrunk
+decodes both with one primitive (`demod.PiOver4DQPSK`) parameterised by
+rotation, which is why equalizer and soft-decision work migrates between
+them so readily.
+
+**Why did Phase 2 change vocoder from IMBE to AMBE+2?**
+Each TDMA slot has roughly half a Phase 1 channel's bit budget, and AMBE+2
+delivers comparable voice at a lower rate — the same codec family DMR and
+NXDN use, which is why GopherTrunk's Phase 2 voice extraction delegates
+its frame FEC to the shared DMR path.
+
+**What does `trellis=0` in my p25p2 startup log mean?**
+That the voice chain believes MAC PDUs arrive un-trellis-coded — true only
+for pre-stripped test fixtures, never for live air. On a real system it
+means the Phase 2 FEC options aren't reaching this pipeline (the issue
+#882 failure) or are misconfigured; set `p25_phase2_trellis_mode=on` and
+check the startup line agrees.
+
+**Can GopherTrunk decode both timeslots at once?**
+Yes — the superframe grid assigns every sub-frame to its slot by index,
+and each granted call's voice chain consumes its own slot. Two concurrent
+calls on one Phase 2 carrier are two calls, recorded separately.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: CQPSK & LSM — The Linear Twin Path]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})
+· Next →
+[Part 8: IMBE Voice — From LDU to WAV]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }})

--- a/docs/_posts/2026-09-09-p25-end-to-end-07-phase2-tdma.md
+++ b/docs/_posts/2026-09-09-p25-end-to-end-07-phase2-tdma.md
@@ -214,8 +214,10 @@ folklore.
 
 ## MAC PDUs, where TSBKs used to be
 
-Phase 2 signalling arrives as **MAC PDUs**: after FEC removal, an 18-byte
-unit — opcode byte, optional MFID for vendor messages, then payload. The
+Phase 2 signalling arrives as **MAC PDUs** (surveyed in
+[Protocol Decoders Part 4]({{ '/blog/deep-dives/protocol-decoders-04-p25-phase-2-tdma-mac/' | relative_url }})):
+after FEC removal, an 18-byte unit — opcode byte, optional MFID for
+vendor messages, then payload. The
 opcode families rhyme with Part 3's TSBKs (`OpGroupVoiceChannelGrant`,
 `OpIdentifierUpdate`, `OpNetworkStatusBroadcastUpdate`…) plus
 TDMA-specific channel-state messages (`OpMACIdle`, `OpMACHangtime`,
@@ -307,12 +309,12 @@ non-default handling.
 **How is P25 Phase 2's modulation related to TETRA's?**
 Both are differential QPSK variants with a per-symbol rotation — TETRA at
 π/4 and 18000 baud, Phase 2 H-DQPSK at π/8 and 6000 baud. GopherTrunk
-decodes both with one primitive (`demod.PiOver4DQPSK`) parameterised by
-rotation, which is why equalizer and soft-decision work migrates between
-them so readily.
+decodes both with one rotation-parameterised primitive, which is why
+equalizer and soft-decision work migrates between them so readily.
 
 **Why did Phase 2 change vocoder from IMBE to AMBE+2?**
-Each TDMA slot has roughly half a Phase 1 channel's bit budget, and AMBE+2
+Each TDMA slot has roughly half a Phase 1 channel's bit budget, and
+[AMBE+2]({{ '/blog/deep-dives/voice-coding-07-ambe-plus-2/' | relative_url }})
 delivers comparable voice at a lower rate — the same codec family DMR and
 NXDN use, which is why GopherTrunk's Phase 2 voice extraction delegates
 its frame FEC to the shared DMR path.

--- a/docs/_posts/2026-09-09-p25-end-to-end-07-phase2-tdma.md
+++ b/docs/_posts/2026-09-09-p25-end-to-end-07-phase2-tdma.md
@@ -30,8 +30,8 @@ pipeline can silently default to zero on its twin.*
 > **MAC PDUs** through a trellis → RS(24,16,9) → PN44-descramble FEC chain
 > (`internal/radio/p25/phase2/process.go`), the PN44 seeded from
 > WACN/System/NAC. The control channel stays Phase 1 — and issue #882
-> proved the FEC knobs can validate, display, and still never arrive on the
-> wideband pipeline.
+> proved the FEC knobs can validate, display, and still never arrive on
+> one pipeline.
 
 **Key takeaways**
 
@@ -40,11 +40,11 @@ pipeline can silently default to zero on its twin.*
   carriers, and Part 5's `AccessTDMA` flag routes them into the right
   voice chain.
 - **The demodulator is a rotation argument.** `PiOver4DQPSK` serves TETRA
-  at π/4 and Phase 2 H-DQPSK at π/8 — one differential core, so a fix in
-  it lands in both protocols at once.
+  at π/4 and Phase 2 H-DQPSK at π/8 — one differential core, so a fix
+  lands in both protocols at once.
 - **The superframe is the addressing scheme.** Twelve 30 ms sub-frames,
-  even index → timeslot 0, odd → timeslot 1; the ISCH tells you what each
-  carries without inspecting the payload.
+  even index → timeslot 0, odd → timeslot 1; the ISCH names what each
+  carries without payload inspection.
 - **Descramble in the channel-bit domain, before the FEC.** The PN44
   applies to *channel* bits per TIA-102.BBAC-1 §7.2.5; descrambling the
   information bits after the trellis fails the outer RS on every real
@@ -144,7 +144,7 @@ A Phase 2 carrier is a continuous dibit stream with a strict rhythm: a
 alternating between the two timeslots — even sub-frame index → timeslot 0,
 odd → timeslot 1 (`Subframe.Timeslot = i & 1` in
 `superframe_decoder.go`). `SuperframeDecoder` anchors that grid on the
-20-dibit outbound sync word and slices the stream into tagged sub-frames.
+20-dibit outbound sync word and slices out tagged sub-frames.
 
 The tag is the **ISCH** — the Inter-Slot Signalling Channel field
 prefixing every sub-frame: a 12-bit word protected by extended
@@ -180,7 +180,7 @@ without touching the payload:
   <text x="230" y="75" text-anchor="middle" fill="currentColor" font-size="9">1</text>
   <text x="270" y="75" text-anchor="middle" fill="var(--accent)" font-size="9">2</text>
   <text x="630" y="75" text-anchor="middle" fill="currentColor" font-size="9">11</text>
-  <text x="170" y="100" fill="var(--fg-muted)" font-size="9">each sub-frame: 30 ms · 180 dibits · ISCH prefix names its SlotType</text>
+  <text x="170" y="100" fill="var(--fg-muted)" font-size="9">each sub-frame: 30 ms · 180 dibits · ISCH prefix names the SlotType</text>
   <!-- slot lanes -->
   <text x="30" y="140" fill="var(--accent)" font-size="10" font-weight="bold">timeslot 0 (even) — call A</text>
   <rect x="240" y="126" width="52" height="22" fill="none" stroke="var(--accent)" stroke-width="2"/>
@@ -320,11 +320,11 @@ NXDN use, which is why GopherTrunk's Phase 2 voice extraction delegates
 its frame FEC to the shared DMR path.
 
 **What does `trellis=0` in my p25p2 startup log mean?**
-That the voice chain believes MAC PDUs arrive un-trellis-coded — true only
-for pre-stripped test fixtures, never for live air. On a real system it
-means the Phase 2 FEC options aren't reaching this pipeline (the issue
-#882 failure) or are misconfigured; set `p25_phase2_trellis_mode=on` and
-check the startup line agrees.
+That the voice chain believes MAC PDUs arrive un-trellis-coded — true
+only for pre-stripped fixtures, never live air. On a real system it means
+the Phase 2 FEC options aren't reaching this pipeline (the #882 failure)
+or are misconfigured; set `p25_phase2_trellis_mode=on` and check the
+startup line agrees.
 
 **Can GopherTrunk decode both timeslots at once?**
 Yes — the superframe grid assigns every sub-frame to its slot by index,

--- a/docs/_posts/2026-09-10-from-spec-to-shipping-08-smartnet-rebuild.md
+++ b/docs/_posts/2026-09-10-from-spec-to-shipping-08-smartnet-rebuild.md
@@ -1,0 +1,347 @@
+---
+title: "From Spec to Shipping, Part 8: Case Study — Rebuilding SmartNet From Proven Decoders"
+description: "The full #1143 arc as a method case study: a Motorola SmartNet decoder green on every synthetic test yet unable to lock any real system, diagnosed as fabricated framing and rebuilt from OP25 and trunk-recorder — 8-bit sync 0xAC, stride-19 deinterleave, inverted data, CRC-10."
+category: deep-dives
+keywords: motorola smartnet decoder, smartnet osw format, smartnet control channel 3600 baud, op25 rx_smartnet, trunk-recorder smartnetparser, smartnet deinterleave crc, smartnet band plan 800 mhz, rebuilding a broken decoder, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, smartnet, motorola, trunking, case-study, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 8
+---
+
+*Part 8 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+laid out the rules for tests that keep the power to call your code
+wrong. This part is the campaign where every one of those rules — and
+most of the series' others — got exercised at once: the Motorola
+Type II / SmartNet decoder, shipped on framing that matched no real
+reference, caught by an operator who could never lock, and rebuilt
+constant-by-constant from decoders proven on air. It is the villain's
+biggest scene and the method's clearest demonstration.*
+
+> **TL;DR:** GopherTrunk's original SmartNet decoder framed on a
+> **24-bit sync `0xA4D7AA`**, a 32-bit OSW and **BCH(64,16,11)** —
+> a format matching **no real reference**, so every operator hunt ended
+> in `cchunt: hunt failed` while every synthetic test stayed green
+> ([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)).
+> The rebuild (`internal/radio/motorola/`) ports the real format from
+> OP25 `rx_smartnet` and trunk-recorder's `SmartnetParser`: **8-bit sync
+> `0xAC`**, 84-bit frames trusted only when the *next* sync lands 76
+> bits later, stride-19 deinterleave, `parity[i]=info[i]^info[i-1]`
+> ECC, 27 data + 10 CRC bits with the data **inverted on the wire**
+> (masks `0xCC38`/`0x0D5`, CRC complemented) — and a physical layer
+> re-laid as **3600-baud 2-FSK at ±1.2 kHz** into an 18 kHz DDC with a
+> slow DC tracker. Pinned by reference-literal tests plus a
+> failing-first real-air regression; still awaiting the reporter's
+> capture for on-air verification, and the post says so.
+
+**Key takeaways**
+
+- **A fabricated format is worse than a missing one.** Placeholder
+  framing plus round-trip tests produced a decoder that *looked*
+  finished for months — the most expensive state a feature can be in,
+  because nothing flags it but an operator's silence.
+- **Rebuild from implementations proven on air, not from prose.** OP25
+  and trunk-recorder have decoded live SmartNet systems for years; every
+  constant in the new decoder cites one of them, per
+  [Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})'s
+  first rule.
+- **The physical layer was fabricated too.** Not just the framing:
+  the modem was wrong (MSK-flavoured, wide DDC) — a reminder that a
+  fabricated stack is fabricated all the way down, and the audit has to
+  start at the antenna.
+- **Green synthetics still prove nothing.** The rebuild's own tests are
+  reference-pinned and failing-first — and the decoder is still marked
+  unverified until a real capture decodes, because that gate
+  ([Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }}))
+  is the whole lesson.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Frame codec | sync + deinterleave + ECC + CRC-10 → 27-bit OSW | `internal/radio/motorola/frame.go` (`DecodeOSWPayload`) |
+| Bracket framer | trusts a frame only when the next sync lands 76 bits later | `internal/radio/motorola/process.go` (`ControlChannel.Process`) |
+| OSW semantics | 16-bit address + group bit + 10-bit command; 1–3-OSW sequences | `internal/radio/motorola/osw.go`, `control.go` |
+| Band plans | channel number → frequency; 800 standard/rebanded/splinter, 900 | `internal/radio/motorola/bandplan.go` (`ParseBandPlan`) |
+| Physical layer | 3600-baud 2-FSK ±1.2 kHz, DC tracker, M&M timing | `internal/radio/motorola/receiver/receiver.go` |
+| Channel rate | 18 kHz DDC target (5 samples/symbol) | `internal/scanner/ccdecoder/ddc.go` (`motorolaDDCTargetRateHz`) |
+| Reference pins | sync bits, interleave permutation, XOR masks vs OP25 literals | `frame_test.go`; real-air regression in `process_test.go` |
+
+## In this post
+
+- **The symptom** — green CI, and a hunt that never locks.
+- **The diagnosis** — framing that matched no reference anywhere.
+- **The real format** — the OSW wire chain, constant by constant.
+- **The physical layer, re-laid** — 2-FSK, 18 kHz, and a DC tracker
+  that earns its keep.
+- **Pinning it down** — the tests that can catch this class of bug, and
+  the gate still open.
+
+## The symptom
+
+The report was as undramatic as protocol bugs get: an operator
+configured a SmartNet system, and GopherTrunk's control-channel hunt
+cycled candidates forever — `cchunt: hunt failed — no control-channel
+lock`, every pass. No decode errors, no CRC storms, no partial locks.
+Meanwhile the repository's SmartNet tests were green, had always been
+green, and covered encode, decode, corruption handling and grant
+sequencing.
+
+That combination — *zero* on-air function with *total* synthetic
+success — is the signature
+[From the Issue Tracker Part 17]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }})
+taught us to dread, and it should now trigger a specific reflex: audit
+the constants against an independent reference before touching the DSP.
+A weak-signal problem degrades; a wrong-constant problem is binary. This
+was binary.
+
+## The diagnosis
+
+The audit was short and brutal. The original package framed on a 24-bit
+sync word `0xA4D7AA`, wrapped a 32-bit OSW in two BCH(64,16,11)
+codewords, and none of it — not the sync, not the width, not the code —
+appears in OP25, trunk-recorder, gr-smartnet, or the venerable
+`mottrunk.txt` notes that all of them descend from. The framing had not
+been mis-transcribed from a reference; it had been **fabricated**, and
+the round-trip tests enshrined it: the encoder produced the invented
+format, the decoder consumed it, and the two agreed perfectly about a
+protocol that exists nowhere —
+[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})'s
+trap at maximum severity. The new `frame.go` header states the history
+in the code itself, so the next reader inherits the scar tissue along
+with the constants.
+
+SmartNet has no public standards document, which is how the vacuum
+formed. But it has something
+[Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})
+rates even higher than a spec: **two independent implementations proven
+on live systems for years** — OP25's `rx_smartnet.cc/.h` and
+trunk-recorder's `SmartnetParser` — that agree with each other. The
+rebuild ported every constant and transform from them, cited line by
+line.
+
+## The real format
+
+The genuine control channel is austere: 84-bit frames, back-to-back,
+forever.
+
+```go
+// internal/radio/motorola/frame.go (shape)
+const (
+    SyncBits        = 8    // frame sync length
+    OutboundSyncHex uint32 = 0xAC // 10101100
+    PayloadBits     = 76   // coded payload after sync
+    FrameBits       = SyncBits + PayloadBits // 84
+
+    // Data rides inverted on the wire (rx_smartnet.h:
+    // ID_XOR 0x33C7, CMD_XOR 0x32A).
+    idXORMask  uint16 = ^uint16(0x33C7)        // 0xCC38
+    cmdXORMask uint16 = ^uint16(0x32A) & 0x3FF // 0x0D5
+
+    // CRC-10 registers (rx_smartnet.cc crc_check).
+    crcInit uint16 = 0x0393
+    crcOp   uint16 = 0x036E
+    crcPoly uint16 = 0x0225
+)
+```
+
+An 8-bit sync word is alarmingly short — random data matches it every
+256 bits — and the reference design compensates structurally: frames
+run back-to-back, so the framer **trusts a frame only when the next
+frame's sync arrives exactly 76 bits after the previous one ended**
+(`process.go`, a port of `rx_smartnet::rx_sym`; pinned by
+`TestProcessRequiresBracketSync`). Bracketing syncs plus the CRC-10
+make the short sync safe.
+
+Inside the bracket, the 76 payload bits deinterleave at **stride 19** —
+wire position `k + l*19` reads out to sequence position `k*4 + l` —
+into 38 `(info, parity)` pairs with `parity[i] = info[i] ^ info[i-1]`;
+two consecutive flipped parity syndromes pinpoint a flipped info bit
+between them, a single-error-correcting convolutional parity check. The
+first 37 corrected bits are 27 data + 10 CRC (the 38th pair is spare),
+and the data is **inverted on the wire**: the address and command
+fields un-invert through the XOR masks above, and the CRC field is
+bitwise-complemented. The surviving 27 bits form one Outbound Status
+Word — 16-bit address, one group bit, 10-bit command — and the
+protocol's most striking economy: **there are no opcodes.** A command
+value that falls inside the system's band plan *is* a voice channel
+number; grants, system-ID broadcasts and extended functions span one to
+three consecutive OSWs sequenced by a state machine (`control.go`),
+with `0x308`/`0x30B` opening the multi-OSW sequences and `0x2F8` as
+idle. Which also explains two config keys: `motorola_band_plan` selects
+`800_standard`/`800_rebanded`/`800_splinter`/`900` (channel→frequency
+formulas from trunk-recorder's `get_freq`), and the old `motorola_bch_mode`
+is now accepted-but-ignored — it configured a FEC layer the real
+protocol never had.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Side-by-side comparison of the fabricated and real SmartNet frame structures. Top, muted and crossed out: the fabricated frame with a 24-bit sync 0xA4D7AA and two BCH 64,16,11 codewords around a 32-bit OSW — matching no real reference. Bottom, accented: the real 84-bit frame with an 8-bit sync 0xAC, a 76-bit interleaved payload, and the next frame's sync bracketing it; beneath it the decode chain: stride-19 deinterleave, doubled-parity ECC, 27 data plus 10 CRC bits, XOR un-inversion.">
+  <text x="20" y="24" fill="var(--fg-muted)" font-size="11" font-weight="bold">fabricated (pre-#1143) — matched no real reference</text>
+  <rect x="20" y="34" width="90" height="30" rx="4" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="65" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">24-bit sync</text>
+  <rect x="110" y="34" width="180" height="30" rx="4" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="200" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BCH(64,16,11) codeword</text>
+  <rect x="290" y="34" width="140" height="30" rx="4" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="360" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">32-bit OSW</text>
+  <rect x="430" y="34" width="180" height="30" rx="4" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="520" y="53" text-anchor="middle" fill="var(--fg-muted)" font-size="9">BCH(64,16,11) codeword</text>
+  <line x1="20" y1="30" x2="610" y2="68" stroke="var(--fg-muted)"/>
+  <line x1="20" y1="68" x2="610" y2="30" stroke="var(--fg-muted)"/>
+  <text x="20" y="106" fill="var(--accent)" font-size="11" font-weight="bold">real air format (OP25 / trunk-recorder) — 84 bits, back-to-back</text>
+  <rect x="20" y="116" width="60" height="32" rx="4" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="50" y="132" text-anchor="middle" fill="var(--accent)" font-size="9">sync</text>
+  <text x="50" y="143" text-anchor="middle" fill="var(--accent)" font-size="9">0xAC</text>
+  <rect x="80" y="116" width="430" height="32" rx="4" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="295" y="136" text-anchor="middle" fill="currentColor" font-size="10">76-bit interleaved payload (38 info/parity pairs)</text>
+  <rect x="510" y="116" width="60" height="32" rx="4" fill="none" stroke="var(--accent)" stroke-width="2" stroke-dasharray="5 3"/>
+  <text x="540" y="132" text-anchor="middle" fill="var(--accent)" font-size="9">next</text>
+  <text x="540" y="143" text-anchor="middle" fill="var(--accent)" font-size="9">sync</text>
+  <text x="596" y="136" fill="var(--fg-muted)" font-size="9">…brackets</text>
+  <text x="596" y="147" fill="var(--fg-muted)" font-size="9">the frame</text>
+  <line x1="295" y1="148" x2="295" y2="170" stroke="currentColor"/>
+  <polygon points="291,168 295,176 299,168" fill="currentColor"/>
+  <rect x="60" y="178" width="150" height="28" rx="4" fill="none" stroke="currentColor"/>
+  <text x="135" y="196" text-anchor="middle" fill="currentColor" font-size="9">deinterleave, stride 19</text>
+  <rect x="220" y="178" width="170" height="28" rx="4" fill="none" stroke="currentColor"/>
+  <text x="305" y="196" text-anchor="middle" fill="currentColor" font-size="9">ECC: parity[i]=info[i]^info[i−1]</text>
+  <rect x="400" y="178" width="130" height="28" rx="4" fill="none" stroke="currentColor"/>
+  <text x="465" y="196" text-anchor="middle" fill="currentColor" font-size="9">27 data + 10 CRC</text>
+  <rect x="540" y="178" width="120" height="28" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="600" y="191" text-anchor="middle" fill="var(--accent)" font-size="9">un-invert:</text>
+  <text x="600" y="202" text-anchor="middle" fill="var(--accent)" font-size="9">^0xCC38 / ^0x0D5</text>
+  <text x="340" y="236" text-anchor="middle" fill="var(--fg-muted)" font-size="10">every constant cites rx_smartnet.cc/.h — none is original to this project, by design</text>
+</svg>
+<figcaption>The fabricated frame and the real one: nothing survives the comparison — sync length, payload width, FEC and field encoding are all different, which is why no synthetic test overlap existed with reality.</figcaption>
+</figure>
+
+## The physical layer, re-laid
+
+The audit couldn't stop at the framing, because a fabricated stack is
+rarely fabricated in only one layer. The real control channel is
+**3600-baud binary FSK at roughly ±1.2 kHz deviation** — not the
+MSK-flavoured ±900 Hz modem the old path assumed — and the rebuild
+mirrors trunk-recorder's proven `smartnet_fsk2_demod`: FM discriminator,
+a slow DC tracker, a one-symbol boxcar filter, Mueller-Müller timing,
+zero-threshold slicer (`internal/radio/motorola/receiver/`).
+
+Two physical choices carry most of the value. The channel now
+downconverts to an **18 kHz target** (5 samples/symbol,
+`motorolaDDCTargetRateHz` in `ccdecoder/ddc.go`) instead of riding the
+48 kHz C4FM-family default — whose ±24 kHz passband also admitted
+25 kHz-spaced neighbours straight into the discriminator. And the DC
+tracker is load-bearing, not hygiene: at ±1.2 kHz deviation, a few
+hundred hertz of residual carrier offset is a *large* slicer bias —
+`dcTrackSeconds = 0.1` holds the tracker long against the ~23 ms frame
+so NRZ content is untouched, short enough to pull in oscillator drift,
+and `TestReceiverToleratesCarrierOffset` pins the tolerance. Protocols
+with wide deviation can shrug that bias off; a 3600-baud narrow-shift
+FSK cannot, and knowing *which* kind you have is a physical-layer
+reading skill straight from
+[Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }}).
+
+## Pinning it down
+
+The new test suite is built so this class of failure cannot re-enter
+quietly, layering exactly the nets from
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+and Part 7:
+
+| Net | What it pins | Test |
+|---|---|---|
+| Reference literals | sync bits vs OP25's `SMARTNET_SYNC_MAGIC` | `TestOutboundSyncBitsMatchReference` |
+| Reference literals | the documented interleave permutation, probed bit-by-bit | `TestDeinterleavePermutationMatchesReference` |
+| Reference literals | `0xCC38` / `0x0D5` masks vs `ID_XOR`/`CMD_XOR` | `TestXORMasksMatchReference` |
+| Failing-first, real-air | a real-format stream → lock + grant; old decoder decodes **nothing** | `TestProcessDecodesRealAirFormat` |
+| Structure | chunk-boundary survival, bracket-sync requirement, ECC/CRC behaviour | `process_test.go`, `frame_test.go` |
+
+The reference-literal tests are the only ones that can catch **constant
+drift** — a round-trip can't, since both sides drift together. The
+real-air regression is the failing-first proof: run against the
+pre-#1143 decoder, it decodes zero OSWs from a stream in the format
+real systems transmit.
+
+And then the honest line, because the method demands it: **this decoder
+is synthetic-green, not on-air-verified.** The #1143 reporter's
+854.5625 MHz capture (Airspy R2, 3 MS/s cfile) is the outstanding gate,
+and until it decodes, the rebuild is a strong hypothesis with excellent
+provenance — nothing more. (One aside from that capture's metadata: its
+"≈550.3 ppm" frequency-correction warning almost certainly reflects the
+capture tool's 11 ms probe window latching a different
+momentarily-strong carrier in the 3 MHz span, not a genuinely
+wild oscillator — sample-count math says the file really is 3 MS/s.)
+
+### How that principle shaped the Go code
+
+- **Provenance in the header, history included.** `frame.go` opens by
+  naming its sources *and* the fabricated format it replaced, so the
+  next audit starts with the full story.
+- **Semantics stay with their reference.** OSW field meanings cite
+  OP25/trunk-recorder in `osw.go`; band-plan formulas cite
+  `SmartnetParser::get_freq` — every layer's authority is greppable.
+- **Obsolete config degrades loudly but harmlessly.**
+  `motorola_bch_mode` logs "obsolete and ignored" instead of failing
+  configs written against the old decoder.
+- **The fixture encoder is the real format's inverse.**
+  `EncodeOSWFrame` exists for tests — and emits frames back-to-back
+  with the trailing sync, because Part 7's faithful-transmitter rule
+  applies to the fix as much as it did to the bug.
+
+## Where this goes next
+
+SmartNet's constants were fabricated; the next part's were merely
+*wrong* — and the wire had no way to say so.
+[Part 9]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})
+takes the same discipline to RPC protocols, where `callSetAntenna = 600`
+silently invoked a different handler on a real server for a release —
+and the fixes are the same nets, aimed at a `.hpp` instead of a PDF.
+
+## FAQ
+
+**Why did every SmartNet test pass while no real system ever decoded?**
+Because encoder and decoder shared the same invented format — the
+self-consistent trap. Round-trip tests verify that two functions are
+inverses, not that either matches the air; when both were authored from
+the same fabricated constants, green was guaranteed and meaningless.
+
+**Where does the real SmartNet framing knowledge come from if there's no
+public spec?**
+From implementations proven on live systems: OP25's `rx_smartnet` and
+trunk-recorder's `SmartnetParser`, which descend from gr-smartnet and
+the mottrunk.txt reverse-engineering notes. Two independent, on-air
+lineages that agree — which
+[Part 2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})
+argues beats any single document, prose specs included.
+
+**How can an 8-bit sync word possibly be reliable?**
+Alone, it isn't — random bits match it every 256 positions. The real
+design trusts a frame only when it is *bracketed*: the next frame's sync
+must arrive exactly 76 bits after the last one ended, which the
+back-to-back control channel guarantees, and the CRC-10 gates whatever
+survives. Short sync, structural redundancy — a pattern worth
+recognizing in other legacy formats.
+
+**What does "data inverted on the wire" mean for the OSW?**
+The 27 information bits are transmitted complemented. The decoder
+un-inverts the address and command fields by XOR with `0xCC38` and
+`0x0D5` (the complements of OP25's `ID_XOR`/`CMD_XOR` masks) and
+compares against a complemented CRC field — three constants that,
+wrong, produce plausible-looking garbage rather than errors, which is
+why each is pinned against upstream literals.
+
+**Is the rebuilt decoder verified on a real SmartNet system yet?**
+Not yet, and the code says so. The framing is reference-pinned and the
+regression suite fails against the old decoder, but per the #764/#771
+discipline a green synthetic is not an on-air verdict — the reporter's
+854.5625 MHz capture is the open verification gate, and the issue stays
+open until it decodes.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Tests That Can Disagree With You]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+· Next →
+[Part 9: Wire Protocols Without Schemas]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})

--- a/docs/_posts/2026-09-10-operator-cookbook-08-remote-radios.md
+++ b/docs/_posts/2026-09-10-operator-cookbook-08-remote-radios.md
@@ -1,0 +1,326 @@
+---
+title: "The Operator's Cookbook, Part 8: Radios Far Away — SoapyRemote, rtl_tcp & ka9q"
+description: "A complete GopherTrunk recipe for putting the antenna where reception is and the decoder where the CPU is: sdr.soapy_remote, rtl_tcp and ka9q_radio config, the network bandwidth math per format, validated antenna-port selection, and why host_drops means your decoder stalled — not your network."
+category: tutorials
+keywords: sdr over network, rtl_tcp gophertrunk setup, soapyremote sdr server config, ka9q-radio multicast iq, remote sdr antenna attic, usrp remote streaming, sdr network bandwidth calculator, antenna port selection usrp, gophertrunk cookbook
+tags: [operator-cookbook, soapyremote, rtl-tcp, ka9q, networking, config]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 8
+---
+
+*Part 8 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})
+filled one box with dongles; this part cuts the USB cable. The best antenna
+spot — attic, roof, a shed on a hill — is rarely where you want a computer,
+and the best decode box is rarely worth hauling up a ladder. GopherTrunk
+mounts three kinds of network radio as first-class virtual tuners:
+**rtl_tcp** for cheap dongles, **SoapyRemote** for everything up to a USRP,
+and **ka9q-radio** for multicast channel feeds. Same pool, same decoders,
+same web console — just with an Ethernet run where the coax used to be.*
+
+> **TL;DR:** A Pi at the antenna runs `rtl_tcp` or `SoapySDRServer`; the
+> rack box lists it under `sdr.rtl_tcp:` / `sdr.soapy_remote:` /
+> `sdr.ka9q_radio:` and it joins the pool like local hardware — roles,
+> voice, everything. Budget the wire first: 2.4 MS/s costs ~38 Mbit/s as
+> rtl_tcp's 8-bit stream and ~77 Mbit/s as SoapyRemote CS16. USRP
+> [antenna ports]({{ '/reference/soapyremote/' | relative_url }}) are set
+> with `antenna: [RX2]` — validated against the device's port list and
+> **read back** after setting, a hard-won behavior. And when
+> `SDR overruns … host_drops` appears, the network is innocent: the
+> *decode side* stopped draining. All three transports are plaintext —
+> trusted networks or a tunnel only.
+
+**Key takeaways**
+
+- **A remote radio is a pool citizen, not a special case.** Each entry
+  mounts as a virtual tuner with a serial and a role; every recipe in this
+  series works unchanged on top of one.
+- **Format sets the bill.** rtl_tcp is hardcoded 8-bit; SoapyRemote carries
+  CS16 (default) or CF32 at 2× the bytes; ka9q-radio ships narrow
+  per-channel streams that barely register. Do the multiplication before
+  blaming the network.
+- **Antenna selection is verified, not hoped.** The port name is checked
+  against what the device advertises, set, and read back — because for a
+  long time the "set antenna" call silently invoked the wrong remote
+  function and nobody's config did anything.
+- **`host_drops` points downstream.** The driver sheds samples only when
+  the consumer stops draining its buffer — pair it with the ccdecoder's
+  can't-keep-up WARN and fix CPU, not cables.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Cheap remote dongle | 8-bit rtl_tcp stream as a virtual tuner | `sdr.rtl_tcp[]` ([rtl_tcp]({{ '/reference/rtl-tcp/' | relative_url }})) |
+| High-end remote radio | CS16/CF32, full tuning control | `sdr.soapy_remote[]` ([SoapySDR]({{ '/reference/soapysdr/' | relative_url }})) |
+| Multicast channels | radiod RTP channels, one entry per SSRC | `sdr.ka9q_radio[]` ([ka9q-radio]({{ '/reference/ka9q-radio/' | relative_url }})) |
+| Antenna port | per-channel RX port, validated + read back | `soapy_remote[].antenna: [RX2]` |
+| Link tuning | MTU / flow-control window for fat or slow links | `stream_mtu`, `stream_window` |
+| Exact USRP rates | make sample_rate an integer clock division | `master_clock_rate` ([USRP B210]({{ '/reference/usrp-b210/' | relative_url }})) |
+| RPC forensics | log every control call + hex dump | `verbose_debug: true` (needs `log.level: debug`) |
+
+## In this post
+
+- **What you're building** — antenna in the attic, decoder in the rack.
+- **The shopping list** — a Pi, a dongle, and honest Ethernet.
+- **The network budget** — bytes per second, before anything else.
+- **The config** — all three transports, every key verified.
+- **First run — what healthy looks like** — three connected lines and a read-back.
+- **When it doesn't work** — the heaviest troubleshooting table in the series.
+
+## What you're building
+
+The finished rig is two boxes. At the antenna: a Raspberry Pi with the
+radio on a short, low-loss coax run — physics happy. In the rack: the
+GopherTrunk daemon from Parts 1–7, CPU and disk happy, with the remote
+radio in its pool next to any local dongles. Decoders, voice pool,
+recordings, web console — none of them know the IQ crossed a wire.
+
+Which transport fits which build:
+
+| Transport | Hardware | Stream | Best for |
+|---|---|---|---|
+| `rtl_tcp` | RTL-SDR dongles | 8-bit, fixed | the $35 attic dongle |
+| `soapy_remote` | USRP, LimeSDR, Airspy, HackRF, bladeRF, SDRplay, RTL | CS16 / CF32, full control | serious remote front ends, diversity rigs |
+| `ka9q_radio` | radiod + RX888/Airspy/RTL | per-channel RTP multicast | one shared receiver feeding many consumers on a LAN |
+
+All three are **plaintext** with no authentication — keep them on a trusted
+LAN or inside an SSH/WireGuard tunnel, the same posture logic as the
+[API auth deep dive]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }}).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 230" width="680" height="230" role="img" aria-label="The remote-radio topology: at the antenna site a mast feeds a radio attached to a Raspberry Pi running rtl_tcp or SoapySDRServer or radiod; an Ethernet link annotated with per-format bandwidth carries raw IQ to the rack box, where GopherTrunk's rtl_tcp, soapyremote and ka9q drivers mount each stream as a virtual tuner in the SDR pool feeding the usual decoders, recordings and web console">
+  <rect x="8" y="20" width="200" height="190" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="108" y="38" text-anchor="middle" fill="var(--fg-muted)" font-size="10">antenna site (attic / roof / shed)</text>
+  <rect x="24" y="52" width="70" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="59" y="72" text-anchor="middle" fill="currentColor" font-size="10">antenna</text>
+  <line x1="59" y1="84" x2="59" y2="104" stroke="currentColor"/>
+  <text x="110" y="98" fill="var(--fg-muted)" font-size="9">short coax</text>
+  <rect x="24" y="104" width="70" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="59" y="124" text-anchor="middle" fill="currentColor" font-size="10">radio</text>
+  <line x1="94" y1="120" x2="122" y2="120" stroke="currentColor"/>
+  <rect x="122" y="96" width="74" height="70" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="159" y="114" text-anchor="middle" fill="var(--accent)" font-size="10">Pi</text>
+  <text x="159" y="130" text-anchor="middle" fill="var(--fg-muted)" font-size="9">rtl_tcp /</text>
+  <text x="159" y="142" text-anchor="middle" fill="var(--fg-muted)" font-size="9">SoapySDRServer /</text>
+  <text x="159" y="154" text-anchor="middle" fill="var(--fg-muted)" font-size="9">radiod</text>
+  <line x1="208" y1="120" x2="330" y2="120" stroke="var(--accent)" stroke-width="2"/>
+  <text x="269" y="108" text-anchor="middle" fill="var(--accent)" font-size="10">Ethernet</text>
+  <text x="269" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">u8 ~38 Mbit/s</text>
+  <text x="269" y="152" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CS16 ~77 Mbit/s</text>
+  <text x="269" y="164" text-anchor="middle" fill="var(--fg-muted)" font-size="9">@ 2.4 MS/s</text>
+  <rect x="330" y="20" width="340" height="190" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="500" y="38" text-anchor="middle" fill="var(--fg-muted)" font-size="10">rack box — GopherTrunk daemon</text>
+  <rect x="346" y="52" width="140" height="110" rx="4" fill="none" stroke="currentColor"/>
+  <text x="416" y="70" text-anchor="middle" fill="currentColor" font-size="10">network drivers</text>
+  <text x="416" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">rtltcp: connected</text>
+  <text x="416" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">soapyremote: connected</text>
+  <text x="416" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ka9qradio: connected</text>
+  <text x="416" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ virtual tuners, by serial</text>
+  <line x1="486" y1="107" x2="516" y2="107" stroke="currentColor"/>
+  <rect x="516" y="52" width="140" height="52" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="586" y="72" text-anchor="middle" fill="var(--accent)" font-size="10">SDR pool (Part 7)</text>
+  <text x="586" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="9">roles, watchdog, voice</text>
+  <rect x="516" y="120" width="140" height="52" rx="4" fill="none" stroke="currentColor"/>
+  <text x="586" y="140" text-anchor="middle" fill="currentColor" font-size="10">decoders → recordings</text>
+  <text x="586" y="156" text-anchor="middle" fill="var(--fg-muted)" font-size="9">→ web console</text>
+  <line x1="586" y1="104" x2="586" y2="120" stroke="currentColor"/>
+  <text x="500" y="196" text-anchor="middle" fill="var(--fg-muted)" font-size="10">plaintext transports — trusted LAN or tunnel only</text>
+</svg>
+<figcaption>The coax run shrinks to inches and the network carries the IQ instead: each remote stream mounts as a virtual tuner in the same pool every other recipe uses.</figcaption>
+</figure>
+
+## The network budget
+
+Do this arithmetic before anything else:
+**bytes/s = sample_rate × bytes-per-complex-sample.**
+
+| Stream | @ 2.4 MS/s | @ 6.25 MS/s (USRP) |
+|---|---|---|
+| rtl_tcp (u8, 2 B/sample) | ~4.8 MB/s ≈ 38 Mbit/s | — |
+| SoapyRemote CS16 (4 B) | ~9.6 MB/s ≈ 77 Mbit/s | ~25 MB/s ≈ 200 Mbit/s |
+| SoapyRemote CF32 (8 B) | ~19 MB/s ≈ 154 Mbit/s | ~50 MB/s ≈ 400 Mbit/s |
+| ka9q-radio channel | kilobits–a few Mbit/s each | (per channel, not per band) |
+
+Wired gigabit [Ethernet]({{ '/reference/ethernet/' | relative_url }})
+carries all of it; Wi-Fi carries the rtl_tcp row on a good day and nothing
+above it reliably. CS16 is the right SoapyRemote default — CF32 doubles the
+bill for dynamic range a trunking decode doesn't need. And the
+[sample rate]({{ '/reference/sample-rate/' | relative_url }}) is *your*
+knob: a remote USRP needn't stream its whole capability.
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| Raspberry Pi (or any SBC/old laptop) | ~$50 | runs the server end at the antenna |
+| Radio | ~$35 and up | whatever the recipe you're remoting called for |
+| Ethernet run / PoE | ~$20 | wired; a PoE splitter powers the Pi over the same cable |
+
+## The config
+
+One entry per transport, to show all three (use the ones you need):
+
+```yaml
+sdr:
+  sample_rate: 2_400_000
+
+  rtl_tcp:
+    - addr: "192.168.1.50:1234"
+      serial: "antenna-pi"
+      role: control
+      ppm: 0
+      gain: "auto"
+      connect_timeout_ms: 3000
+
+  soapy_remote:
+    - addr: "192.168.1.60:55132"   # bare host gets :55132 appended
+      driver: "uhd"
+      serial: "usrp-roof"
+      role: control
+      format: "CS16"               # or CF32 at 2x the bandwidth
+      antenna: [RX2]               # validated against the device, read back
+      master_clock_rate: 0         # see note below for exact rates
+      stream_mtu: 0                # raise (e.g. 8192) on jumbo-frame links
+      stream_window: 0             # raise on high-latency links
+      gain: "auto"
+      connect_timeout_ms: 3000
+
+  ka9q_radio:
+    - addr: "hf.local"             # radiod status group (mDNS or 239.x.x.x:5006)
+      ssrc: 162550                 # the channel's RTP SSRC
+      serial: "ka9q-wx"
+      role: control
+      connect_timeout_ms: 3000
+```
+
+Notes that earn their place. **`antenna:` is the real key, not `args`.** An
+`antenna=` inside the `args` kwargs only reaches device construction and
+never selects the per-channel port — GopherTrunk rejects it there. Port
+names are device-specific (a B210 has `TX/RX` and `RX2`; a TwinRX has `RX1`
+and `RX2`), so a config moved between rigs *should* fail loudly.
+**`master_clock_rate`** exists because a USRP only streams integer
+divisions of its clock: a B210 set to `61_440_000` makes a 6.144 MS/s
+`sample_rate` exact instead of letting UHD coerce to a nearby rate.
+**ka9q entries consume existing radiod channels** — configure the channel
+in `radiod@.conf` first; GopherTrunk discovers its multicast group, rate
+and encoding from the status stream.
+
+## First run — what healthy looks like
+
+Each transport announces itself once the stream is up:
+
+```
+INF rtltcp: connected addr=192.168.1.50:1234 tuner=R820T gain_count=29
+INF soapyremote: connected addr=192.168.1.60:55132 format=CS16 proto=tcp diversity=none
+INF soapyremote: rx antenna set addr=192.168.1.60:55132 channel=0 antenna=RX2
+INF ka9qradio: connected status=239.1.2.3:5006 data=239.1.2.4:5004 ssrc=162550 samprate=48000
+```
+
+The third line deserves a pause. For a long time the "set antenna" RPC used
+the **wrong opcode** — the SoapyRemote wire carries no schema, so the call
+silently invoked a *different* remote function whose first arguments
+happened to fit. Every `antennas:` config did nothing, and the only trace
+was a cryptic `~SoapyRPCUnpacker: Unconsumed payload bytes 9` on the
+server. The unit tests couldn't catch it — the fake test server switched on
+the same wrong constant, the classic
+[self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
+Today the driver validates your port name against the device's advertised
+list, sets it, **reads it back**, and logs what the device itself reports —
+the full saga is in
+[From the Issue Tracker Part 18]({{ '/blog/solution-postmortem/from-the-issue-tracker-18-the-stall-that-wasnt/' | relative_url }}).
+When you see `rx antenna set`, it happened.
+
+From here, everything is Parts 1–7: control locks, grants, calls,
+recordings. One more line matters on remote rigs specifically — the
+overrun WARN:
+
+```
+WRN soapyremote: SDR overruns — the host can't keep up with the configured sample rate, so samples are being dropped and decoded audio will glitch. Lower sdr.sample_rate or reduce the channel/tap count. addr=... device_overflows=0 host_drops=412
+```
+
+Read the counters, not the vibes. **`host_drops` means the decode side
+stalled**: the driver sheds the oldest queued chunk only when its consumer
+stops draining a ~400 ms buffer, so a climbing `host_drops` says something
+*downstream* got slow — check for the companion
+`ccdecoder: decode can't keep up with real time` WARN, which confirms CPU
+rather than network. `device_overflows` climbing instead points at the
+remote host or the wire. When this fires, ask what you recently made
+slower.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Daemon starts cleanly, but no radio and no error | remote-only config on an old build — the pool gate once required a *local* device list, so a config with only `soapy_remote`/`ka9q_radio` registered no driver at all | Fixed (pinned by `TestRemoteOnlySDRConfigsRegisterTheirDriver`); on current builds grep for the `connected` line — absent with no error means the block isn't under `sdr:` where you think |
+| No `connected` line, then timeouts | server not running / wrong port / firewall | `SoapySDRServer --bind` on the radio host, rtl_tcp on 1234; test with `nc host port`; raise `connect_timeout_ms` on slow links |
+| `channel 0 antenna "RX9" is not a port on this device (available: RX1, RX2)` | port name from a different radio model | Use a name from the error's own list — this failing loudly is the feature |
+| `antenna set to "RX2" but device reports "RX1"` | server-side driver ignored the set | Read-back caught it; check the remote SoapySDR module/version for that hardware |
+| Audio glitches, `host_drops` climbing, `device_overflows` ~0 | decode box CPU exhausted — consumer stalled | Shed taps/systems, lower `sdr.sample_rate`, bigger box. The network is innocent on this signature |
+| Glitches with `device_overflows` climbing | remote host or link can't sustain the rate | Check the budget table; wired link; lower rate; on jumbo/high-latency links raise `stream_mtu` / `stream_window` |
+| USRP runs at a slightly different rate than configured | UHD coerced to an integer clock division | Set `master_clock_rate` so `sample_rate` divides it exactly |
+| `~SoapyRPCUnpacker: Unconsumed payload bytes N` on the server | a mis-shaped RPC — the wire has no schema | `verbose_debug: true` + `log.level: debug` logs every call with a hex dump; file it with that output |
+| ka9q entry mounts but decodes nothing | wrong `ssrc`, or channel not in raw IQ mode | Match the SSRC from `radiod@.conf`; the channel needs `output_channels = 2` — the `channel is not 2-channel IQ` WARN is the tell |
+| Works on the bench, dies over Wi-Fi | the budget table | Wire it. Raw IQ and Wi-Fi are enemies at trunking rates |
+
+### How this recipe shapes operator practice
+
+- **Budget the wire like you budget the feedline.** Format × rate is the
+  network's version of
+  [coax loss]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})
+  — decided before any software runs.
+- **Trust read-backs over acknowledgements.** The antenna lesson
+  generalizes: a setting the device *reports* is real; a setting that
+  merely didn't error may be fiction.
+- **Blame by counter, not by topology.** "It's remote, so it's the network"
+  is exactly what `host_drops` exists to refute.
+
+## Where this goes next
+
+The rig now hears everything from anywhere. [Part
+9]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})
+turns it outward: Broadcastify Calls, RdioScanner, OpenMHz, Icecast and
+webhooks — the broadcast config that shares your calls with the world, each
+backend's quirks, and the key hygiene that keeps your API secrets out of
+your config file.
+
+## FAQ
+
+**Can GopherTrunk use an SDR on another computer?**
+Yes, three ways: `sdr.rtl_tcp` for RTL-SDR dongles behind rtl_tcp,
+`sdr.soapy_remote` for anything SoapySDR serves, and `sdr.ka9q_radio` for
+radiod multicast channels. Each mounts as a virtual tuner with a serial and
+role, indistinguishable to the decoders from local USB hardware.
+
+**How much network bandwidth does a remote SDR need?**
+Sample rate times bytes per sample: at 2.4 MS/s, rtl_tcp's 8-bit stream is
+~38 Mbit/s and SoapyRemote CS16 is ~77 Mbit/s; a USRP at 6.25 MS/s in CS16
+is ~200 Mbit/s. Wired gigabit handles all of it; Wi-Fi doesn't.
+
+**What does the host_drops counter mean in the SDR overruns warning?**
+That GopherTrunk's own decode side stopped draining the driver's buffer —
+the oldest queued IQ was shed to keep the stream live. It signals CPU or a
+stalled consumer on the decode box, not a network problem;
+`device_overflows` is the counter that points at the remote end.
+
+**How do I select the RX antenna port on a remote USRP?**
+Set `antenna: [RX2]` (or `[RX1, RX2]` per channel under diversity) in the
+`soapy_remote` entry — not `antenna=` inside `args`, which is rejected. The
+name is validated against the ports the device advertises and read back
+after setting, so a wrong name fails at startup instead of silently doing
+nothing.
+
+**Is rtl_tcp or SoapyRemote traffic encrypted?**
+No — both are plaintext with no authentication, as is ka9q-radio's
+multicast. Keep them on a trusted LAN, or carry them through an SSH or
+WireGuard tunnel; never expose the ports to the internet.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Many Systems, One Box — The SDR Pool]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})
+· Next →
+[Part 9: Sharing the Feed — Broadcastify, OpenMHz & Friends]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})

--- a/docs/_posts/2026-09-10-p25-end-to-end-08-imbe-voice.md
+++ b/docs/_posts/2026-09-10-p25-end-to-end-08-imbe-voice.md
@@ -1,0 +1,332 @@
+---
+title: "P25 End to End, Part 8: IMBE Voice — From LDU to WAV"
+description: How P25 Phase 1 voice travels — the 1728-bit LDU carrying nine IMBE frames woven between link-control words, the Golay and Hamming FEC that turns 144 channel bits into 88, and the composer chain in GopherTrunk that gates, decodes and records a call.
+category: deep-dives
+keywords: p25 imbe decoder, p25 ldu1 ldu2 structure, imbe 144 channel bits, p25 voice frame extraction, golay hamming imbe fec, p25 link control talkgroup, pure go imbe vocoder, p25 voice recording pipeline, gophertrunk p25
+tags: [p25-end-to-end, p25, imbe, vocoder, voice, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 8
+---
+
+*Part 8 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
+[Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})
+split a Phase 2 carrier between two AMBE+2 slots; this part returns to the
+voice most P25 systems actually carry. A Phase 1 traffic channel streams
+**LDUs** — 1728-bit units carrying nine IMBE frames each, with the call's
+own metadata woven between them — and this part follows one from frame
+sync to WAV, including the layout bug that decoded exactly two of nine
+voice frames while every test stayed green.*
+
+> **TL;DR:** Phase 1 voice arrives as alternating **LDU1/LDU2** units:
+> 1728 bits = FS + NID + **9 IMBE frames × 144 channel bits** + 240 bits
+> of Link Control (LDU1) or Encryption Sync (LDU2) + 32 bits of low-speed
+> data + 24 status symbols interleaved every 70 bits
+> (`internal/radio/p25/phase1/ldu.go`). Each 144-bit frame deinterleaves,
+> descrambles, and FEC-decodes — Golay(23,12) ×4, Hamming(15,11) ×3, one
+> unprotected vector — to **88 information bits**
+> (`internal/voice/imbe`), which the pure-Go IMBE vocoder renders as
+> 160 PCM samples at 8 kHz per 20 ms frame. The composer chain
+> (`internal/voice/composer/p25p1_voice.go`) gates audio by the LC
+> talkgroup, splits files on terminators, and only trusts a call's AFC
+> measurement past `minAutotuneLDUs = 5`.
+
+**Key takeaways**
+
+- **An LDU is a superframe, not a frame.** Nine 20 ms voice frames — 180 ms
+  of audio — travel with the call's own signalling threaded between them,
+  so a late-tuning receiver learns who is talking from the voice channel
+  itself.
+- **The field layout is sourced, not derived.** The interleaving order of
+  voice, LC and LSD inside the 1680-bit payload came from an independent
+  decoder (szechyjs/dsd); the previous, plausible layout round-tripped
+  green while only u_0 and u_8 decoded on air (issue #489 follow-up).
+- **FEC strength follows bit sensitivity.** Golay(23,12) guards the four
+  most-perceptible parameter vectors, Hamming(15,11) the next three, and
+  the least-sensitive seven bits ride unprotected — a budget, not an
+  oversight.
+- **Voice frames flow even when FEC loses.** An uncorrectable vector still
+  yields a (degraded) frame plus an error count the decoder's adaptive
+  smoothing consumes — and the counters (`uncorrectable_ldus`,
+  `gated_ldus`) are the operator's garbled-audio instrument.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| LDU structure | 1728-bit layout constants + compile-time sum check | `internal/radio/p25/phase1/ldu.go` |
+| Status symbols | strip 24 × 2 bits interleaved every 70 payload bits | `ldu.go` (`StripStatusSymbols`) |
+| Voice extraction | 9 × 144-bit frames → 11-byte decoded frames | `ldu.go` (`ExtractVoiceFramesDetailed`) |
+| LDU framing | dibit stream → complete 1728-bit LDUs | `ldu_assembler.go` (`LDUAssembler`) |
+| IMBE channel FEC | deinterleave + descramble + Golay/Hamming, 144→88 | `internal/voice/imbe/channel.go` (`DecodeChannelToFrame`) |
+| The voice chain | gating, telemetry, ES publish, autotune | `internal/voice/composer/p25p1_voice.go` (`runP25Phase1VoiceChain`) |
+| Vocoder mapping | protocol `"p25"` → pure-Go `imbe`, 8 kHz PCM | `internal/voice/recorder.go` (`DefaultVocoderForProtocol`) |
+
+## In this post
+
+- **The LDU superframe** — nine voice frames and the metadata between them.
+- **The layout that round-tripped green and decoded wrong** — issue #489's lesson.
+- **From 144 bits to 88** — the IMBE channel-coding inverse, surveyed.
+- **The composer chain** — gating, terminators, and the telemetry that names bad audio.
+- **What LDU2 carries** — encryption sync, and the out-of-set guard.
+
+## The LDU superframe
+
+After [Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})'s
+frame sync and NID, a voice transmission is a run of LDUs — LDU1 and LDU2
+alternating, each 1728 bits, each 180 ms. The budget is fixed by
+TIA-102.BAAA and pinned in `ldu.go` with a compile-time check that the
+fields still sum to 1728:
+
+| Field | Bits | Carries |
+|---|---|---|
+| Frame sync | 48 | the FSW from Part 2 |
+| NID | 64 | NAC + DUID (BCH-protected) |
+| Voice | 9 × 144 | IMBE frames u_0..u_8, 20 ms each |
+| LC or ES | 240 | Link Control (LDU1) / Encryption Sync (LDU2) |
+| Low-speed data | 32 | 2 cyclic codewords |
+| Status symbols | 24 × 2 | trunking-layer signalling, interleaved |
+
+The status symbols come out first: two bits after every 70 payload bits,
+24 times (`StripStatusSymbols`), leaving a 1680-bit payload. What remains
+is not voice-then-metadata but a deliberate weave — u_0 and u_1
+back-to-back, then a 40-bit LC/ES block after each of u_1 through u_6,
+both 16-bit LSD blocks together between u_7 and u_8. The weave is the
+design: link control arrives in six pieces spread across 180 ms, so a
+receiver that tunes in mid-call (which a trunking scanner *always* does)
+assembles who-is-talking-to-whom from the voice channel itself, and a
+burst error takes a slice of everything rather than all of one thing.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="The 1680-bit LDU payload after status-symbol removal: nine 144-bit IMBE voice frames with six 40-bit link-control or encryption-sync blocks woven after frames two through seven and two 16-bit low-speed-data blocks before the final frame">
+  <text x="30" y="26" fill="currentColor" font-size="11" font-weight="bold">LDU payload (1680 bits, status symbols stripped)</text>
+  <!-- row 1 -->
+  <rect x="30" y="40" width="44" height="26" fill="none" stroke="var(--fg-muted)"/>
+  <text x="52" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">FS+NID</text>
+  <rect x="74" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="104" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_0</text>
+  <rect x="134" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="164" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_1</text>
+  <rect x="194" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
+  <text x="207" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC1</text>
+  <rect x="220" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="250" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_2</text>
+  <rect x="280" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
+  <text x="293" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC2</text>
+  <rect x="306" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="336" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_3</text>
+  <rect x="366" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
+  <text x="379" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC3</text>
+  <rect x="392" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="422" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_4</text>
+  <rect x="452" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
+  <text x="465" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC4</text>
+  <rect x="478" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="508" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_5</text>
+  <rect x="538" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
+  <text x="551" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC5</text>
+  <!-- row 2 -->
+  <rect x="30" y="86" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="60" y="103" text-anchor="middle" fill="var(--accent)" font-size="9">u_6</text>
+  <rect x="90" y="86" width="26" height="26" fill="none" stroke="currentColor"/>
+  <text x="103" y="103" text-anchor="middle" fill="currentColor" font-size="8">LC6</text>
+  <rect x="116" y="86" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="146" y="103" text-anchor="middle" fill="var(--accent)" font-size="9">u_7</text>
+  <rect x="176" y="86" width="20" height="26" fill="none" stroke="var(--fg-muted)"/>
+  <rect x="196" y="86" width="20" height="26" fill="none" stroke="var(--fg-muted)"/>
+  <text x="196" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="8">LSD</text>
+  <rect x="216" y="86" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="246" y="103" text-anchor="middle" fill="var(--accent)" font-size="9">u_8</text>
+  <text x="300" y="97" fill="var(--fg-muted)" font-size="10">9 voice frames × 144 bits = 180 ms of audio;</text>
+  <text x="300" y="111" fill="var(--fg-muted)" font-size="10">LC/ES split into six 40-bit blocks between them</text>
+  <!-- annotations -->
+  <text x="30" y="146" fill="currentColor" font-size="10" font-weight="bold">the trap: the old layout put LC1 between u_0 and u_1</text>
+  <text x="30" y="162" fill="var(--fg-muted)" font-size="10">— shifting u_1..u_7 by 40 bits. Round-trip tests passed (encoder shared the</text>
+  <text x="30" y="178" fill="var(--fg-muted)" font-size="10">error); on air only u_0 and u_8 decoded. Layout now pinned to szechyjs/dsd</text>
+  <text x="30" y="194" fill="var(--fg-muted)" font-size="10">(process_p25_ldu1) + a real-air capture test — issue #489 follow-up.</text>
+</svg>
+<figcaption>The LDU weave: nine IMBE frames with link control threaded between them — and the 40-bit layout shift that once silenced seven of the nine.</figcaption>
+</figure>
+
+## The layout that round-tripped green and decoded wrong
+
+The figure's annotation deserves its paragraph, because it is this
+series' recurring villain caught in the act. The original `lduVoiceOffsets`
+table placed an LC/ES block between u_0 and u_1 (and the LSD between u_6
+and u_7) — plausible, tidy, and wrong: every offset from u_1 to u_7 was 40
+bits off. GopherTrunk's own `InjectStatusSymbols`/encode side used the
+same table, so **every round-trip test passed** while on real air only u_0
+and u_8 — the two frames whose offsets happened to coincide — produced
+audio. Recordings existed, contained mostly garble, and nothing failed.
+
+The fix (issue #489 follow-up) re-sourced the layout from an independent
+implementation — szechyjs/dsd's `process_p25_ldu1` read order — and the
+current `ldu.go` documents the cumulative bit table field by field, with
+`ldu_realair_test.go` holding it against a real capture. Same lesson as
+Part 3's SCCB byte offset and Part 7's scrambler ordering: **a
+self-consistent codec validates its assumptions against nothing.** Pin
+layouts with literal vectors from an implementation that has decoded real
+air.
+
+## From 144 bits to 88
+
+Each extracted 144-bit voice frame then runs the IMBE channel-coding
+inverse (`internal/voice/imbe`), three layers deep — deinterleave
+(§7.5), descramble (§7.4, a PRBS keyed off u_0, which itself rides
+unscrambled), then per-vector FEC:
+
+```go
+// internal/voice/imbe/channel.go (shape)
+// IMBE 4400 channel coding maps 88 information bits to 144 channel bits:
+//   u_0..u_3  23 bits each  Golay(23,12,7)   — most sensitive parameters
+//   u_4..u_6  15 bits each  Hamming(15,11,3)
+//   u_7        7 bits       no FEC           — least-sensitive bits
+func DecodeChannel(channel []byte) ([]byte, int, error) {
+    /* … per-vector Golay/Hamming decode, summing corrected bits … */
+    // ErrUncorrectable when a vector exceeds its radius — the partially
+    // recovered info bits are STILL returned so callers can log +
+    // frame-repeat upstream rather than drop 20 ms of audio.
+}
+```
+
+The 88 recovered bits are the vocoder's model parameters — fundamental
+frequency, voicing decisions, spectral amplitudes — and the pure-Go
+decoder synthesizes each frame into **160 PCM samples at 8 kHz** (20 ms).
+The deep math has its own series:
+[what a vocoder is]({{ '/blog/deep-dives/voice-coding-01-what-is-a-vocoder/' | relative_url }}),
+[the MBE model]({{ '/blog/deep-dives/voice-coding-02-the-mbe-model/' | relative_url }}),
+[the IMBE decode]({{ '/blog/deep-dives/voice-coding-04-imbe-decode/' | relative_url }})
+and [the FEC + deinterleave layer]({{ '/blog/deep-dives/voice-coding-05-imbe-fec-deinterleave/' | relative_url }})
+own it. Two facts matter here. First, the error *count* travels with the
+frame: `ExtractVoiceFramesDetailed` reports per-frame corrected bits, and
+the recorder hands them to the decoder's adaptive smoothing so a noisy
+channel gets gentler synthesis instead of harsh artifacts. Second, the
+honest one-liner from the project's vocoder-conformance work: measured
+against a reference decode of identical frames, GopherTrunk's IMBE shows a
+mild high-band energy deficit — the same direction as the measured AMBE+2
+3600×2450 gap, much milder — known and bounded rather than a mystery.
+
+## The composer chain
+
+`runP25Phase1VoiceChain` (`internal/voice/composer/p25p1_voice.go`) is
+where a grant becomes a recording. IQ for the granted frequency arrives on
+a channel; the chain runs a **±6.25 kHz channel-select front end** (half
+the P25 channel spacing — without it, a wideband tap's ±24 kHz span lets
+the FM capture effect lock onto a stronger adjacent channel during the
+talker's syllable gaps, recording foreign talkgroups and garble), then the
+Part 1 receiver, then `LDUAssembler`, and finally a sink that dispatches
+per LDU:
+
+- **Terminators end transmissions.** A TDU/TDULC rolls the recording for
+  the next over — after harvesting the terminator's link control, since
+  Motorola systems carry the talker alias there as often as in LDU1
+  (issue #376).
+- **The talkgroup gate decides writes.** LDU1's Link Control names the
+  talkgroup; the boundary tracker compares it to the grant and drops
+  non-matching audio — a shared voice frequency must never
+  cross-contaminate a recording. When the LC's outer RS is uncorrectable
+  the talkgroup is *untrusted*, so the tracker inherits the last decision
+  rather than gating 20 ms of real audio on garbage — the dominant cause
+  of fragmented recordings in one field capture.
+- **Telemetry names the failure.** The rolling
+  `composer: p25p1 decode quality` line carries `ldus`,
+  `uncorrectable_ldus`, `gated_ldus`, `corrected_bit_errs` and the
+  LC/ES RS counters — so "audio is garbled" resolves to *which layer* is
+  losing, and an operator can watch the rate fall as they fix gain
+  (issue #356 follow-up).
+
+The chain also feeds the per-dongle **autotune** average — each call's AFC
+residual estimates the tuner's frequency error — but only from calls that
+earn trust: `minAutotuneLDUs = 5` (roughly a second of voice) plus a <10%
+uncorrectable rate, because a short or noisy call yields a data-dependent
+snapshot that would drag the correction toward the kilohertz. A threshold
+worth knowing when a marginal system's calls run four LDUs long — that is
+also [Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})'s
+opening symptom. Decoded frames land through the recorder, whose default
+map sends protocol `"p25"` to the pure-Go `imbe` vocoder
+(`DefaultVocoderForProtocol`, `internal/voice/recorder.go`), and the
+[recording layer]({{ '/blog/deep-dives/recording-streaming-03-assembling-a-call/' | relative_url }})
+takes it from PCM to WAV on disk.
+
+## What LDU2 carries
+
+LDU2's 240-bit slot holds **Encryption Sync** instead of link control:
+Message Indicator, Algorithm ID, Key ID. The chain parses it every LDU2
+but publishes a bus event only when something changed — ALGID/KID/MI are
+stable within a call, and re-announcing them every 180 ms is noise. One
+guard is worth flagging now: an ES whose outer RS "succeeds" but yields an
+Algorithm ID outside the TIA-102 set is a residual-error mis-decode, and
+GopherTrunk drops it rather than surface a phantom key (issue #924) —
+downstream, a fake algorithm is indistinguishable from a real one.
+Everything else about the encryption story — where the flags live, the
+four-layer path to the call log, and what policy does with them — is
+[Part 9]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }})'s
+whole subject.
+
+### How the superframe design shaped the Go code
+
+- **Constants that add up, or don't compile.** `ldu.go` closes with a
+  compile-time identity over the field widths, so a field edit that breaks
+  the 1728-bit budget fails at build, not on air.
+- **Extraction returns partial results.** Uncorrectable vectors still
+  yield frames plus error counts — the audio chain degrades instead of
+  gapping, and the counts feed both smoothing and telemetry.
+- **Metadata outruns the gate.** Talker aliases, source IDs and ES are
+  surfaced even for gated audio, because identity is worth learning from a
+  call you chose not to record.
+- **Trust thresholds are named constants.** `minAutotuneLDUs`,
+  `qualityLogEveryLDUs`, the RS-uncorrectable counters — every judgment
+  call in the chain is a greppable number with a comment, not folklore.
+
+## Where this goes next
+
+LDU2 just introduced the encryption fields;
+[Part 9]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }})
+follows them the whole way: where "encrypted" actually lives on the air
+across HDU, LDU2 and Phase 2's MAC, the postmortem of a flag and its
+metadata separated by four layers, and what GopherTrunk's policy engine —
+follow, log metadata, or skip — does with a call it cannot listen to.
+
+## FAQ
+
+**Why does P25 voice come in 180 ms chunks?**
+The LDU is the framing unit: nine 20 ms IMBE frames plus the signalling
+overhead amortised across them. GopherTrunk's receiver emits complete
+LDUs (`LDUAssembler`), so voice latency through the decode path is
+bounded by LDU assembly plus synthesis — well under real-time for live
+listening.
+
+**What is the difference between LDU1 and LDU2?**
+Only the 240-bit metadata slot: LDU1 carries Link Control (talkgroup,
+source, service options), LDU2 carries Encryption Sync (MI/ALGID/KID).
+Voice layout is identical, and they alternate for the duration of a
+transmission so both kinds of metadata repeat about every 360 ms.
+
+**Why is my P25 recording missing pieces of a conversation?**
+Check `gated_ldus` in the decode-quality log line. A high count means the
+in-band talkgroup didn't match the grant — adjacent-channel bleed on a
+wideband tap or a shared voice frequency — so the composer correctly
+dropped that audio. `frames − gatedLDUs` approximates what actually
+reached the WAV.
+
+**Does GopherTrunk use mbelib or DVSI hardware for IMBE?**
+Neither by default: `internal/voice/imbe` is a clean pure-Go IMBE 4400
+decoder, the sole backend in default builds, mapped from protocol `"p25"`
+by the recorder. The `.imb`/`.amb` sidecar option (`recordings.mbe_files`)
+writes DSD-FME-compatible frame files if you want to A/B against another
+decoder — the interop is frame-exact, per `docs/vocoders.md`.
+
+**Can GopherTrunk decode encrypted P25 voice?**
+No — like SDRTrunk, it identifies encryption (ALGID, KID, MI) and applies
+policy, but does not decrypt. What it does with that identification —
+skip, record-silent, or follow with metadata — is Part 9.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7: Phase 2 TDMA — Two Voices per Carrier]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})
+· Next →
+[Part 9: Encryption Signalling — Flags, Metadata & Policy]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }})

--- a/docs/_posts/2026-09-10-p25-end-to-end-08-imbe-voice.md
+++ b/docs/_posts/2026-09-10-p25-end-to-end-08-imbe-voice.md
@@ -111,33 +111,33 @@ burst error takes a slice of everything rather than all of one thing.
   <rect x="134" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="164" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_1</text>
   <rect x="194" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
-  <text x="207" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC1</text>
+  <text x="207" y="57" text-anchor="middle" fill="currentColor" font-size="9">LC1</text>
   <rect x="220" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="250" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_2</text>
   <rect x="280" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
-  <text x="293" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC2</text>
+  <text x="293" y="57" text-anchor="middle" fill="currentColor" font-size="9">LC2</text>
   <rect x="306" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="336" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_3</text>
   <rect x="366" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
-  <text x="379" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC3</text>
+  <text x="379" y="57" text-anchor="middle" fill="currentColor" font-size="9">LC3</text>
   <rect x="392" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="422" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_4</text>
   <rect x="452" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
-  <text x="465" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC4</text>
+  <text x="465" y="57" text-anchor="middle" fill="currentColor" font-size="9">LC4</text>
   <rect x="478" y="40" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="508" y="57" text-anchor="middle" fill="var(--accent)" font-size="9">u_5</text>
   <rect x="538" y="40" width="26" height="26" fill="none" stroke="currentColor"/>
-  <text x="551" y="57" text-anchor="middle" fill="currentColor" font-size="8">LC5</text>
+  <text x="551" y="57" text-anchor="middle" fill="currentColor" font-size="9">LC5</text>
   <!-- row 2 -->
   <rect x="30" y="86" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="60" y="103" text-anchor="middle" fill="var(--accent)" font-size="9">u_6</text>
   <rect x="90" y="86" width="26" height="26" fill="none" stroke="currentColor"/>
-  <text x="103" y="103" text-anchor="middle" fill="currentColor" font-size="8">LC6</text>
+  <text x="103" y="103" text-anchor="middle" fill="currentColor" font-size="9">LC6</text>
   <rect x="116" y="86" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="146" y="103" text-anchor="middle" fill="var(--accent)" font-size="9">u_7</text>
   <rect x="176" y="86" width="20" height="26" fill="none" stroke="var(--fg-muted)"/>
   <rect x="196" y="86" width="20" height="26" fill="none" stroke="var(--fg-muted)"/>
-  <text x="196" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="8">LSD</text>
+  <text x="196" y="103" text-anchor="middle" fill="var(--fg-muted)" font-size="9">LSD</text>
   <rect x="216" y="86" width="60" height="26" fill="none" stroke="var(--accent)" stroke-width="2"/>
   <text x="246" y="103" text-anchor="middle" fill="var(--accent)" font-size="9">u_8</text>
   <text x="300" y="97" fill="var(--fg-muted)" font-size="10">9 voice frames × 144 bits = 180 ms of audio;</text>

--- a/docs/_posts/2026-09-11-from-spec-to-shipping-09-wire-protocols-without-schemas.md
+++ b/docs/_posts/2026-09-11-from-spec-to-shipping-09-wire-protocols-without-schemas.md
@@ -27,32 +27,32 @@ about sync words applies to them.*
 > to match, the leftover antenna-name string produced only a server-side
 > `~SoapyRPCUnpacker: Unconsumed payload bytes 9`, and the `bool` reply
 > carried no exception — so `rpcVoid` logged "rx antenna set" for a call
-> that never ran. The fake server in the tests switched on the **same
-> constant**, so every test was green — the
+> that never ran. The fake server switched on the **same constant**, so
+> every test was green — the
 > [self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
-> at the RPC layer. The fixes live in `internal/sdr/soapyremote/`:
+> at the RPC layer. The fixes, all in `internal/sdr/soapyremote/`:
 > opcodes pinned against upstream literals
-> (`TestOpenSetAntennaUsesUpstreamOpcode`), a fake that asserts every
-> request byte is consumed, and an `applyAntennas` that validates against
-> `LIST_ANTENNAS` and reads back with `GET_ANTENNA`.
+> (`TestOpenSetAntennaUsesUpstreamOpcode`), a fake asserting every request
+> byte consumed, and `applyAntennas` validating against `LIST_ANTENNAS`
+> and reading back with `GET_ANTENNA`.
 
 **Key takeaways**
 
-- **A schemaless wire cannot tell you you're wrong.** With no field names
-  and no signature check, a wrong call id dispatches to whichever handler
-  lives at that number — and if the leading argument types line up, the
-  call "works." The failure is silent by construction.
+- **A schemaless wire cannot tell you you're wrong.** A wrong call id
+  dispatches to whichever handler lives at that number — and if the
+  leading argument types line up, the call "works." The failure is silent
+  by construction.
 - **Numeric ids from someone else's enum are extracted constants.**
   Part 1's rule for sync words and CRC polynomials applies verbatim: cite
-  the source (`SoapyRemoteDefs.hpp`), and pin the value with a literal an
+  the source (`SoapyRemoteDefs.hpp`), pin the value with a literal an
   independent party wrote.
 - **A test double is only worth the strictness it enforces.** A fake that
   tolerates leftover bytes hides argument-shape drift; one that switches
   on your own constants can never see opcode drift. The two nets catch
-  different bugs, and GopherTrunk needed both.
+  different bugs; GopherTrunk needed both.
 - **Read back what you set.** A success reply proves the server didn't
   throw, not that the device changed. `applyAntennas` now asks the device
-  what port it is actually on — the only assertion that survives a wrong
+  what port it is actually on — the assertion that survives a wrong
   opcode, a permissive driver, or a config moved between rigs.
 
 ## Cheat sheet
@@ -113,9 +113,9 @@ const (
 
 Read that next to
 [Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})'s
-rule — *constants first, every constant cites its source* — and this part
-is half written. An opcode is a sync word for a TCP stream: one wrong
-value and you are invoking something else entirely, with no error message.
+rule — *constants first, every constant cites its source*. An opcode is a
+sync word for a TCP stream: one wrong value and you are invoking
+something else entirely, with no error message.
 
 ## Opcode 600: anatomy of a silent miss
 
@@ -130,17 +130,17 @@ query. Walk through what the wire did with that, step by step:
    to match** — and returns a `bool`.
 3. The antenna-name string is never read. The server's unpacker destructor
    logs `~SoapyRPCUnpacker: Unconsumed payload bytes 9` — a string tag, a
-   tagged length, and `"RX2"` — once per channel, on the *server's*
-   console, without saying which call.
+   tagged length, `"RX2"` — once per channel, on the *server's* console,
+   without saying which call.
 4. The `bool` reply reaches the client. `rpcVoid` checks only for an
-   exception value; a `bool` is not one, so the call reports success and
-   GopherTrunk logs `rx antenna set` for an antenna that was never set.
+   exception value; a `bool` is not one, so GopherTrunk logs
+   `rx antenna set` for an antenna that was never set.
 
 The operator-visible symptom was maximally misleading: `antennas: [RX1,
 RX2]` did nothing, every radio kept its *driver default* port, and the
 same config therefore behaved differently on an X310 and a B210. Nothing
 failed; nothing warned client-side. The only witness was a cryptic
-destructor message on a machine in another room.
+destructor message in another room.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two-column RPC ladder comparing the intended SET_ANTENNA call with what opcode 600 actually did. Left column: client packs call 501 with direction, channel and the antenna name; the setAntenna handler consumes all arguments, switches the port, and replies void. Right column: client packs call 600 with the same arguments; the HAS_DC_OFFSET_MODE handler consumes only direction and channel, leaves 9 bytes unconsumed which the server logs, never touches the antenna, and replies with a bool that the client's exception check reads as success.">
@@ -175,29 +175,37 @@ destructor message on a machine in another room.
 ## Why every test was green
 
 The unit tests could not catch this — the series' villain in a new
-costume. The package's tests run against `newFakeSoapyServer`, a real TCP
-listener speaking the real framing. But the fake's dispatch `switch` was
+costume. The package tests against `newFakeSoapyServer`, a real TCP
+listener speaking the real framing — but the fake's dispatch `switch` was
 written against **the same Go constants the client packs**. Change
-`callSetAntenna` to any value at all and both sides move together: the
-client sends 600, the fake's `case callSetAntenna` matches 600, the test
-passes. The test verified that GopherTrunk agrees with itself — which it
-always does.
+`callSetAntenna` to any value and both sides move together: the client
+sends 600, the fake's `case callSetAntenna` matches 600, the test passes.
+The test verified that GopherTrunk agrees with itself — which it always
+does.
 
-That is character-for-character the round-trip failure of
+That is the round-trip failure of
 [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
 SCCB parser and
 [Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})'s
 fabricated SmartNet framing, transplanted to a TCP socket. A shared
-constant is a shared assumption, and no test that lives entirely inside
-the assumption can falsify it. (Not this protocol's first postmortem,
-either — the stream-handshake saga in
+constant is a shared assumption, and no test living entirely inside the
+assumption can falsify it. (Not this protocol's first postmortem, either —
+the stream-handshake saga in
 [From the Issue Tracker Part 13]({{ '/blog/solution-postmortem/from-the-issue-tracker-13-soapyremote-handshake/' | relative_url }})
 is the same wire biting a different way.)
 
 ## The four nets, and what each one catches
 
 The fix was not one test but four distinct nets, because the failure has
-four distinct faces — and any one net alone leaves a hole.
+four distinct faces — and any one net alone leaves a hole:
+
+| Failure face | Net that catches it | Pinned by |
+|---|---|---|
+| Opcode drift — wrong call id | literals transcribed from upstream | `TestOpenSetAntennaUsesUpstreamOpcode` |
+| Argument-shape drift | fake asserts full byte consumption | `newFakeSoapyServer` cleanup |
+| Port name not on this device | validate via `LIST_ANTENNAS` | `TestOpenRejectsAntennaNotOnDevice` |
+| Setter silently ignored | `GET_ANTENNA` read-back | `applyAntennas` |
+| "Which call was that?" | decoded per-frame RPC trace | `verbose_debug` (`rpcdebug.go`) |
 
 **Net 1: pin opcodes against upstream literals.** The only test that
 catches *opcode* drift is one whose expected value came from outside the
@@ -238,13 +246,13 @@ lands in `protocolErrs`, and `newFakeSoapyServer` registers an
 check for free. This catches *argument-shape* drift — and adding it
 immediately found **two more calls** the fake had silently not been
 parsing. It cannot catch opcode drift (the fake still switches on the
-client's constants; the comment in the file says so), which is why Net 1
-exists separately. The general rule — test doubles ranked by how much
-reality they enforce — got its own treatment in
+client's constants), which is why Net 1 exists separately. The general
+rule — test doubles ranked by how much reality they enforce — got its own
+treatment in
 [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }}).
 
 **Net 3: introspect, then read back.** The deepest fix is in the
-production path, not the tests:
+production path:
 
 ```go
 // internal/sdr/soapyremote/driver.go (shape) — applyAntennas
@@ -267,18 +275,17 @@ Three RPCs where one used to be. `LIST_ANTENNAS` matters because port
 names do not transfer between radios — a TwinRX offers `RX1`/`RX2`, a
 B210 `TX/RX`/`RX2` — so a config moved between rigs must fail loudly with
 the names that *do* exist (`TestOpenRejectsAntennaNotOnDevice` pins the
-error message). And the `GET_ANTENNA` read-back survives everything: a
-wrong opcode, a driver that ignores the setter, a typo'd port. The log
-line now reports what the **device** said, where it used to report what
-GopherTrunk had asked — the entire difference between a log and an
-instrument.
+error message). The `GET_ANTENNA` read-back survives everything: a wrong
+opcode, a driver that ignores the setter, a typo'd port. And the log line
+now reports what the **device** said, not what GopherTrunk had asked —
+the entire difference between a log and an instrument.
 
 **Net 4: make the wire visible.** `sdr.soapy_remote[].verbose_debug`
-enables a per-frame RPC tracer (`rpcdebug.go`) rendering each request and
-response as a *decoded* argument list, paired by sequence number — the
-form that lines up against upstream's handler source, which a raw hex
-dump does not. When the server next says "Unconsumed payload bytes N,"
-the question "which call?" has a client-side answer.
+enables a per-frame RPC tracer rendering each request and response as a
+*decoded* argument list — the form that lines up against upstream's
+handler source, which a raw hex dump does not. When the server next says
+"Unconsumed payload bytes N," the question "which call?" has a
+client-side answer.
 
 ## The rules, genericized
 
@@ -287,22 +294,22 @@ vendor USB control protocol, a register map, a serial command set — has
 the same failure faces, and earns the same nets:
 
 - **Treat foreign enum values as extracted constants** (Part 1's rule):
-  cite the defining file, and pin every value with a literal transcribed
-  from it — never from your own header.
+  cite the defining file, pin every value with a literal transcribed from
+  it — never from your own header.
 - **Give your test double the real endpoint's strictness, mechanically** —
-  wired into the constructor, so no individual test can forget it.
-- **Prefer the protocol's introspection to your beliefs.** A peer that can
-  enumerate its own capabilities is an independent reference shipping
-  inside the protocol itself.
-- **Read back every write that matters, and log the read-back.** A
-  non-exception reply means "the server didn't throw," nothing more —
-  a rule the [testing module]({{ '/learn/testing/' | relative_url }})
-  generalizes beyond wire protocols.
+  wired into the constructor, so no test can forget it.
+- **Prefer the protocol's introspection to your beliefs.** A peer that
+  enumerates its own capabilities is an independent reference shipping
+  inside the protocol.
+- **Read back every write that matters.** A non-exception reply means
+  "the server didn't throw," nothing more — a rule the
+  [testing module]({{ '/learn/testing/' | relative_url }}) generalizes
+  beyond wire protocols.
 
 ## Where this goes next
 
-Every net in this part defends a claim made *before* the hardware is in
-the loop — and passing all four still proves nothing on a real system.
+Every net here defends a claim made *before* the hardware is in the
+loop — and passing all four still proves nothing on a real system.
 [Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
 makes that boundary explicit: the on-air gate, the ladder of evidence
 every decoder claim climbs, and the DMO "encrypted" verdict overturned
@@ -317,17 +324,16 @@ near-universal prefixes in SoapySDR calls — it runs happily on the
 prefix, and the surplus bytes are at most a log line in a destructor.
 
 **Why not just generate the Go constants from SoapyRemoteDefs.hpp?**
-Generation moves the trust to the generator and its input snapshot, and a
-stale snapshot drifts just as silently. The literal test is smaller and
-cleaner: sixteen numbers transcribed from the authority, and any refactor
-that changes one has to argue with a named upstream file in the failure
-message.
+Generation moves the trust to the generator and its input snapshot, which
+can drift just as silently. The literal test is smaller and cleaner:
+sixteen numbers transcribed from the authority, and any refactor changing
+one must argue with a named upstream file in the failure message.
 
 **What does "Unconsumed payload bytes N" from SoapySDRServer actually mean?**
 The dispatched handler finished unpacking with N bytes of your request
 still unread — your call id and your argument list belong to two
-different calls. It does not say which RPC, which is why GopherTrunk grew
-a client-side tracer (`verbose_debug`) that decodes each outgoing frame.
+different calls. It doesn't say which RPC; the client-side tracer
+(`verbose_debug`) exists to answer that.
 
 **Is a fake server worth having if it can't catch opcode drift?**
 Yes — it catches everything else: framing, argument shapes, sequencing,

--- a/docs/_posts/2026-09-11-from-spec-to-shipping-09-wire-protocols-without-schemas.md
+++ b/docs/_posts/2026-09-11-from-spec-to-shipping-09-wire-protocols-without-schemas.md
@@ -68,10 +68,10 @@ about sync words applies to them.*
 
 ## In this post
 
-- **A schema is a shared assumption** — what the SoapyRemote wire actually
+- **A schema is a shared assumption** — what the SoapyRemote wire
   carries, and what it doesn't check.
-- **Opcode 600: anatomy of a silent miss** — how a wrong id becomes a
-  successful call to the wrong function.
+- **Opcode 600: anatomy of a silent miss** — a wrong id as a successful
+  call to the wrong function.
 - **Why every test was green** — the self-consistent trap, RPC edition.
 - **The four nets** — literal pins, strict fakes, introspection, read-back.
 - **The general rules** — what transfers to any schemaless wire format.
@@ -79,18 +79,18 @@ about sync words applies to them.*
 ## A schema is a shared assumption you don't get to check
 
 SoapyRemote is how GopherTrunk drives a networked SDR — a USRP X310
-behind a `SoapySDRServer`. GopherTrunk speaks the protocol with a pure-Go
-client (`internal/sdr/soapyremote/`), reverse-engineered from upstream's
+behind a `SoapySDRServer` — with a pure-Go client
+(`internal/sdr/soapyremote/`) reverse-engineered from upstream's
 `SoapyRPCPacket.hpp` and packer/unpacker sources, in the spirit of the
 [device-contract]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})
 approach the driver stack takes everywhere.
 
 The format is simple and completely trusting: a 12-byte header (`"SRPC"`,
-a version, a length), a payload of type-tagged values, a 4-byte trailer.
-The first value is a CALL carrying a numeric id; the arguments follow as
-bare tagged values — no names, no arity, no signature. The server
-dispatches on the id, and the handler unpacks however many arguments *it*
-believes the call takes.
+version, length), a payload of type-tagged values, a 4-byte trailer. The
+first value is a CALL carrying a numeric id; the arguments follow as bare
+tagged values — no names, no arity, no signature. The server dispatches
+on the id, and the handler unpacks however many arguments *it* believes
+the call takes.
 
 So the call ids are not values GopherTrunk gets to choose. They are
 **positions in an upstream enum**, and the comment in `rpc.go` says so:
@@ -111,12 +111,11 @@ const (
 )
 ```
 
-Read that comment next to
+Read that next to
 [Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})'s
-rule — *constants first, and every constant cites its source* — and this
-part is half written. An opcode is a sync word for a TCP stream: one
-wrong value and you are invoking something else entirely, with no error
-message.
+rule — *constants first, every constant cites its source* — and this part
+is half written. An opcode is a sync word for a TCP stream: one wrong
+value and you are invoking something else entirely, with no error message.
 
 ## Opcode 600: anatomy of a silent miss
 
@@ -138,10 +137,10 @@ query. Walk through what the wire did with that, step by step:
    GopherTrunk logs `rx antenna set` for an antenna that was never set.
 
 The operator-visible symptom was maximally misleading: `antennas: [RX1,
-RX2]` in the config did nothing, every radio kept its *driver default*
-port, and the same config therefore behaved differently on an X310 and a
-B210. Nothing failed; nothing warned on the client side. The only witness
-was a cryptic destructor message on a machine in another room.
+RX2]` did nothing, every radio kept its *driver default* port, and the
+same config therefore behaved differently on an X310 and a B210. Nothing
+failed; nothing warned client-side. The only witness was a cryptic
+destructor message on a machine in another room.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two-column RPC ladder comparing the intended SET_ANTENNA call with what opcode 600 actually did. Left column: client packs call 501 with direction, channel and the antenna name; the setAntenna handler consumes all arguments, switches the port, and replies void. Right column: client packs call 600 with the same arguments; the HAS_DC_OFFSET_MODE handler consumes only direction and channel, leaves 9 bytes unconsumed which the server logs, never touches the antenna, and replies with a bool that the client's exception check reads as success.">
@@ -236,12 +235,12 @@ the real `~SoapyRPCUnpacker`'s log line into a failure: every handler
 parses its arguments, a request with bytes left over (or an unknown id)
 lands in `protocolErrs`, and `newFakeSoapyServer` registers an
 `assertCleanProtocol` cleanup so **every** test in the package gets the
-check for free. This catches *argument-shape* drift — and when it was
-added it immediately found **two more calls** the fake had silently not
-been parsing. It cannot catch opcode drift (the fake still switches on
-the client's constants; the comment in the file says so), which is why
-Net 1 exists separately. The general rule — test doubles ranked by how
-much reality they enforce — got its own treatment in
+check for free. This catches *argument-shape* drift — and adding it
+immediately found **two more calls** the fake had silently not been
+parsing. It cannot catch opcode drift (the fake still switches on the
+client's constants; the comment in the file says so), which is why Net 1
+exists separately. The general rule — test doubles ranked by how much
+reality they enforce — got its own treatment in
 [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }}).
 
 **Net 3: introspect, then read back.** The deepest fix is in the
@@ -268,11 +267,11 @@ Three RPCs where one used to be. `LIST_ANTENNAS` matters because port
 names do not transfer between radios — a TwinRX offers `RX1`/`RX2`, a
 B210 `TX/RX`/`RX2` — so a config moved between rigs must fail loudly with
 the names that *do* exist (`TestOpenRejectsAntennaNotOnDevice` pins the
-error message). And the `GET_ANTENNA` read-back is the assertion that
-survives everything: a wrong opcode, a driver that ignores the setter, a
-typo'd port. The log line now reports what the **device** said, where it
-used to report what GopherTrunk had asked for — the entire difference
-between a log and an instrument.
+error message). And the `GET_ANTENNA` read-back survives everything: a
+wrong opcode, a driver that ignores the setter, a typo'd port. The log
+line now reports what the **device** said, where it used to report what
+GopherTrunk had asked — the entire difference between a log and an
+instrument.
 
 **Net 4: make the wire visible.** `sdr.soapy_remote[].verbose_debug`
 enables a per-frame RPC tracer (`rpcdebug.go`) rendering each request and
@@ -283,9 +282,9 @@ the question "which call?" has a client-side answer.
 
 ## The rules, genericized
 
-Nothing above is SoapySDR-specific. Any wire format without a schema — a
-binary RPC, a vendor USB control protocol, a register map, a serial
-command set — has the same four failure faces, and earns the same nets:
+Nothing above is SoapySDR-specific. Any schemaless wire — a binary RPC, a
+vendor USB control protocol, a register map, a serial command set — has
+the same failure faces, and earns the same nets:
 
 - **Treat foreign enum values as extracted constants** (Part 1's rule):
   cite the defining file, and pin every value with a literal transcribed
@@ -313,8 +312,8 @@ capture by capture.
 
 **How does a wrong RPC opcode go unnoticed when the arguments don't match?**
 Because nothing compares them. The handler unpacks what *it* expects; if
-the leading argument types coincide — a direction byte and a channel int
-are near-universal prefixes in SoapySDR calls — it runs happily on the
+the leading types coincide — a direction byte and a channel int are
+near-universal prefixes in SoapySDR calls — it runs happily on the
 prefix, and the surplus bytes are at most a log line in a destructor.
 
 **Why not just generate the Go constants from SoapyRemoteDefs.hpp?**
@@ -338,9 +337,8 @@ covering that face with a different net, not retiring the double.
 **Do these rules apply to protocols that have schemas, like gRPC?**
 Less force, same direction. A schema checks names and types, but semantic
 drift — wrong units, a deprecated endpoint that still answers — passes
-any schema. Read-back and introspection-validation stay worth their cost
-wherever a success reply is cheaper for the peer to send than the write
-is to perform.
+any schema. Read-back and introspection stay worth their cost wherever a
+success reply is cheaper to send than the write is to perform.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-11-from-spec-to-shipping-09-wire-protocols-without-schemas.md
+++ b/docs/_posts/2026-09-11-from-spec-to-shipping-09-wire-protocols-without-schemas.md
@@ -1,0 +1,350 @@
+---
+title: "From Spec to Shipping, Part 9: Wire Protocols Without Schemas"
+description: "How GopherTrunk shipped a SoapyRemote client that asked for HAS_DC_OFFSET_MODE when it meant SET_ANTENNA — opcode 600 instead of 501 — and the rules that catch schemaless wire drift: pin constants against upstream literals, validate through introspection, read back what you set."
+category: deep-dives
+keywords: soapyremote rpc protocol, soapysdr set antenna, unconsumed payload bytes, rpc opcode drift, schemaless wire protocol testing, fake server test double, soapyremotedefs.hpp opcodes, read back configuration, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, soapysdr, rpc, drivers, testing, methodology]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 9
+---
+
+*Part 9 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})
+rebuilt a fabricated air interface from decoders proven on air. This part
+takes the same discipline off the air: the RPC socket between GopherTrunk
+and a remote radio server, where a wrong constant doesn't fail to lock —
+it politely invokes a **different function** and reports success. Enums
+copied out of a `.hpp` file are constants too, and everything Part 1 said
+about sync words applies to them.*
+
+> **TL;DR:** GopherTrunk's pure-Go SoapyRemote client packed `SET_ANTENNA`
+> as opcode **600** — which upstream defines as `HAS_DC_OFFSET_MODE`. The
+> wire carries no schema, the wrong handler's first two arguments happened
+> to match, the leftover antenna-name string produced only a server-side
+> `~SoapyRPCUnpacker: Unconsumed payload bytes 9`, and the `bool` reply
+> carried no exception — so `rpcVoid` logged "rx antenna set" for a call
+> that never ran. The fake server in the tests switched on the **same
+> constant**, so every test was green — the
+> [self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
+> at the RPC layer. The fixes live in `internal/sdr/soapyremote/`:
+> opcodes pinned against upstream literals
+> (`TestOpenSetAntennaUsesUpstreamOpcode`), a fake that asserts every
+> request byte is consumed, and an `applyAntennas` that validates against
+> `LIST_ANTENNAS` and reads back with `GET_ANTENNA`.
+
+**Key takeaways**
+
+- **A schemaless wire cannot tell you you're wrong.** With no field names
+  and no signature check, a wrong call id dispatches to whichever handler
+  lives at that number — and if the leading argument types line up, the
+  call "works." The failure is silent by construction.
+- **Numeric ids from someone else's enum are extracted constants.**
+  Part 1's rule for sync words and CRC polynomials applies verbatim: cite
+  the source (`SoapyRemoteDefs.hpp`), and pin the value with a literal an
+  independent party wrote.
+- **A test double is only worth the strictness it enforces.** A fake that
+  tolerates leftover bytes hides argument-shape drift; one that switches
+  on your own constants can never see opcode drift. The two nets catch
+  different bugs, and GopherTrunk needed both.
+- **Read back what you set.** A success reply proves the server didn't
+  throw, not that the device changed. `applyAntennas` now asks the device
+  what port it is actually on — the only assertion that survives a wrong
+  opcode, a permissive driver, or a config moved between rigs.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| RPC wire format | 12-byte `SRPC` header + type-tagged values + `CPRS` trailer | `internal/sdr/soapyremote/rpc.go` (packer/unpacker) |
+| Call ids | positions in upstream's enum, cited to `SoapyRemoteDefs.hpp` | `rpc.go` (`callSetAntenna` = 501 and friends) |
+| Opcode pin | numeric ids compared to upstream **literals** | `driver_test.go` (`TestOpenSetAntennaUsesUpstreamOpcode`) |
+| Full-consumption check | fake server asserts zero leftover request bytes | `driver_test.go` (`newFakeSoapyServer`, `protocolErrs`) |
+| Validate + read back | `LIST_ANTENNAS` before the set, `GET_ANTENNA` after | `driver.go` (`applyAntennas`) |
+| Wire visibility | per-frame decoded RPC trace, off by default | `rpcdebug.go` (`sdr.soapy_remote[].verbose_debug`) |
+
+## In this post
+
+- **A schema is a shared assumption** — what the SoapyRemote wire actually
+  carries, and what it doesn't check.
+- **Opcode 600: anatomy of a silent miss** — how a wrong id becomes a
+  successful call to the wrong function.
+- **Why every test was green** — the self-consistent trap, RPC edition.
+- **The four nets** — literal pins, strict fakes, introspection, read-back.
+- **The general rules** — what transfers to any schemaless wire format.
+
+## A schema is a shared assumption you don't get to check
+
+SoapyRemote is how GopherTrunk drives a networked SDR — a USRP X310
+behind a `SoapySDRServer`. GopherTrunk speaks the protocol with a pure-Go
+client (`internal/sdr/soapyremote/`), reverse-engineered from upstream's
+`SoapyRPCPacket.hpp` and packer/unpacker sources, in the spirit of the
+[device-contract]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})
+approach the driver stack takes everywhere.
+
+The format is simple and completely trusting: a 12-byte header (`"SRPC"`,
+a version, a length), a payload of type-tagged values, a 4-byte trailer.
+The first value is a CALL carrying a numeric id; the arguments follow as
+bare tagged values — no names, no arity, no signature. The server
+dispatches on the id, and the handler unpacks however many arguments *it*
+believes the call takes.
+
+So the call ids are not values GopherTrunk gets to choose. They are
+**positions in an upstream enum**, and the comment in `rpc.go` says so:
+
+```go
+// internal/sdr/soapyremote/rpc.go (shape)
+// SoapyRemoteCalls — the subset of RPC call IDs this client issues.
+//
+// These are POSITIONS IN AN UPSTREAM ENUM, not values GopherTrunk gets to
+// choose: the wire carries no schema, so a wrong ID silently invokes a
+// different server handler whose argument shape happens to start the same
+// way. The authority is pothosware/SoapyRemote common/SoapyRemoteDefs.hpp.
+const (
+    callListAntennas int32 = 500
+    callSetAntenna   int32 = 501
+    callGetAntenna   int32 = 502
+    /* … callSetGain 703, callSetFrequency 800, callSetSampleRate 900 … */
+)
+```
+
+Read that comment next to
+[Part 1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})'s
+rule — *constants first, and every constant cites its source* — and this
+part is half written. An opcode is a sync word for a TCP stream: one
+wrong value and you are invoking something else entirely, with no error
+message.
+
+## Opcode 600: anatomy of a silent miss
+
+For one release, `callSetAntenna` was **600**. Upstream's enum puts
+`SET_ANTENNA` at **501**; 600 is `HAS_DC_OFFSET_MODE` — a capability
+query. Walk through what the wire did with that, step by step:
+
+1. GopherTrunk packs `CALL(600), char(direction), i32(channel),
+   str("RX2")` — the correct argument shape *for SET_ANTENNA*.
+2. The server dispatches to the `HAS_DC_OFFSET_MODE` handler, which
+   unpacks a direction and a channel — the first two arguments **happened
+   to match** — and returns a `bool`.
+3. The antenna-name string is never read. The server's unpacker destructor
+   logs `~SoapyRPCUnpacker: Unconsumed payload bytes 9` — a string tag, a
+   tagged length, and `"RX2"` — once per channel, on the *server's*
+   console, without saying which call.
+4. The `bool` reply reaches the client. `rpcVoid` checks only for an
+   exception value; a `bool` is not one, so the call reports success and
+   GopherTrunk logs `rx antenna set` for an antenna that was never set.
+
+The operator-visible symptom was maximally misleading: `antennas: [RX1,
+RX2]` in the config did nothing, every radio kept its *driver default*
+port, and the same config therefore behaved differently on an X310 and a
+B210. Nothing failed; nothing warned on the client side. The only witness
+was a cryptic destructor message on a machine in another room.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two-column RPC ladder comparing the intended SET_ANTENNA call with what opcode 600 actually did. Left column: client packs call 501 with direction, channel and the antenna name; the setAntenna handler consumes all arguments, switches the port, and replies void. Right column: client packs call 600 with the same arguments; the HAS_DC_OFFSET_MODE handler consumes only direction and channel, leaves 9 bytes unconsumed which the server logs, never touches the antenna, and replies with a bool that the client's exception check reads as success.">
+  <text x="170" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">intended: CALL 501 (SET_ANTENNA)</text>
+  <text x="510" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">shipped: CALL 600 (HAS_DC_OFFSET_MODE)</text>
+  <rect x="40" y="32" width="260" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="170" y="51" text-anchor="middle" fill="currentColor" font-size="10">client packs: dir, channel, "RX2"</text>
+  <rect x="380" y="32" width="260" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="510" y="51" text-anchor="middle" fill="currentColor" font-size="10">client packs: dir, channel, "RX2"</text>
+  <line x1="170" y1="62" x2="170" y2="80" stroke="var(--fg-muted)"/><polygon points="166,78 170,86 174,78" fill="var(--fg-muted)"/>
+  <line x1="510" y1="62" x2="510" y2="80" stroke="var(--fg-muted)"/><polygon points="506,78 510,86 514,78" fill="var(--fg-muted)"/>
+  <rect x="40" y="86" width="260" height="44" rx="5" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="170" y="104" text-anchor="middle" fill="var(--accent)" font-size="10">setAntenna handler: consumes ALL args,</text>
+  <text x="170" y="119" text-anchor="middle" fill="var(--accent)" font-size="10">switches the RX port on the device</text>
+  <rect x="380" y="86" width="260" height="44" rx="5" fill="none" stroke="var(--fg-muted)"/>
+  <text x="510" y="104" text-anchor="middle" fill="currentColor" font-size="10">capability handler: consumes dir + channel,</text>
+  <text x="510" y="119" text-anchor="middle" fill="currentColor" font-size="10">never reads "RX2" — antenna untouched</text>
+  <line x1="170" y1="130" x2="170" y2="148" stroke="var(--fg-muted)"/><polygon points="166,146 170,154 174,146" fill="var(--fg-muted)"/>
+  <line x1="510" y1="130" x2="510" y2="148" stroke="var(--fg-muted)"/><polygon points="506,146 510,154 514,146" fill="var(--fg-muted)"/>
+  <rect x="40" y="154" width="260" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="170" y="173" text-anchor="middle" fill="currentColor" font-size="10">reply: void → success, and true</text>
+  <rect x="380" y="154" width="260" height="30" rx="5" fill="none" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="510" y="173" text-anchor="middle" fill="currentColor" font-size="10">reply: bool → no exception → "success"</text>
+  <rect x="380" y="192" width="260" height="30" rx="5" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="510" y="211" text-anchor="middle" fill="var(--fg-muted)" font-size="10">server log: "Unconsumed payload bytes 9"</text>
+  <text x="170" y="211" text-anchor="middle" fill="var(--fg-muted)" font-size="10">device is on RX2</text>
+  <text x="340" y="240" text-anchor="middle" fill="currentColor" font-size="10">same bytes from the client, two different functions — and both ladders report success</text>
+</svg>
+<figcaption>The wrong opcode doesn't fail — it dispatches to a handler whose leading argument types happen to fit, and the only evidence is a destructor complaint on the far machine.</figcaption>
+</figure>
+
+## Why every test was green
+
+The unit tests could not catch this — the series' villain in a new
+costume. The package's tests run against `newFakeSoapyServer`, a real TCP
+listener speaking the real framing. But the fake's dispatch `switch` was
+written against **the same Go constants the client packs**. Change
+`callSetAntenna` to any value at all and both sides move together: the
+client sends 600, the fake's `case callSetAntenna` matches 600, the test
+passes. The test verified that GopherTrunk agrees with itself — which it
+always does.
+
+That is character-for-character the round-trip failure of
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+SCCB parser and
+[Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})'s
+fabricated SmartNet framing, transplanted to a TCP socket. A shared
+constant is a shared assumption, and no test that lives entirely inside
+the assumption can falsify it. (Not this protocol's first postmortem,
+either — the stream-handshake saga in
+[From the Issue Tracker Part 13]({{ '/blog/solution-postmortem/from-the-issue-tracker-13-soapyremote-handshake/' | relative_url }})
+is the same wire biting a different way.)
+
+## The four nets, and what each one catches
+
+The fix was not one test but four distinct nets, because the failure has
+four distinct faces — and any one net alone leaves a hole.
+
+**Net 1: pin opcodes against upstream literals.** The only test that
+catches *opcode* drift is one whose expected value came from outside the
+codebase:
+
+```go
+// internal/sdr/soapyremote/driver_test.go (shape) — TestOpenSetAntennaUsesUpstreamOpcode
+// Values from pothosware/SoapyRemote common/SoapyRemoteDefs.hpp. Written
+// as literals on purpose: comparing the constant to itself proves nothing.
+for _, tc := range []struct {
+    name string
+    got  int32
+    want int32
+}{
+    {"LIST_ANTENNAS", callListAntennas, 500},
+    {"SET_ANTENNA", callSetAntenna, 501},
+    {"GET_ANTENNA", callGetAntenna, 502},
+    /* … SET_GAIN 703, SET_FREQUENCY 800, SETUP_STREAM 300 … */
+} {
+    if tc.got != tc.want {
+        t.Errorf("%s opcode = %d, want %d (upstream SoapyRemoteDefs.hpp)",
+            tc.name, tc.got, tc.want)
+    }
+}
+```
+
+Sixteen calls, sixteen literals transcribed from the `.hpp`. It looks too
+dumb to be a test — `501 == 501` — and that is the point: the literal is
+a fact from an independent source, the role the OP25 CRC spans and the
+ETSI reference codec play elsewhere in this series. Reference-literal
+tests are the only tests that catch constant drift, on the air or off it.
+
+**Net 2: make the fake as strict as the real server.** The fake now turns
+the real `~SoapyRPCUnpacker`'s log line into a failure: every handler
+parses its arguments, a request with bytes left over (or an unknown id)
+lands in `protocolErrs`, and `newFakeSoapyServer` registers an
+`assertCleanProtocol` cleanup so **every** test in the package gets the
+check for free. This catches *argument-shape* drift — and when it was
+added it immediately found **two more calls** the fake had silently not
+been parsing. It cannot catch opcode drift (the fake still switches on
+the client's constants; the comment in the file says so), which is why
+Net 1 exists separately. The general rule — test doubles ranked by how
+much reality they enforce — got its own treatment in
+[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }}).
+
+**Net 3: introspect, then read back.** The deepest fix is in the
+production path, not the tests:
+
+```go
+// internal/sdr/soapyremote/driver.go (shape) — applyAntennas
+avail, err := d.listAntennas(ch) // LIST_ANTENNAS (500)
+/* … */
+if len(avail) > 0 && !slices.Contains(avail, name) {
+    return fmt.Errorf("channel %d antenna %q is not a port on this device (available: %s)",
+        ch, name, strings.Join(avail, ", "))
+}
+/* … SET_ANTENNA (501) … */
+got, err := d.getAntenna(ch) // GET_ANTENNA (502)
+/* … */
+if got != name {
+    return fmt.Errorf("channel %d antenna set to %q but device reports %q", ch, name, got)
+}
+d.log.Info("soapyremote: rx antenna set", "addr", d.addr, "channel", ch, "antenna", got)
+```
+
+Three RPCs where one used to be. `LIST_ANTENNAS` matters because port
+names do not transfer between radios — a TwinRX offers `RX1`/`RX2`, a
+B210 `TX/RX`/`RX2` — so a config moved between rigs must fail loudly with
+the names that *do* exist (`TestOpenRejectsAntennaNotOnDevice` pins the
+error message). And the `GET_ANTENNA` read-back is the assertion that
+survives everything: a wrong opcode, a driver that ignores the setter, a
+typo'd port. The log line now reports what the **device** said, where it
+used to report what GopherTrunk had asked for — the entire difference
+between a log and an instrument.
+
+**Net 4: make the wire visible.** `sdr.soapy_remote[].verbose_debug`
+enables a per-frame RPC tracer (`rpcdebug.go`) rendering each request and
+response as a *decoded* argument list, paired by sequence number — the
+form that lines up against upstream's handler source, which a raw hex
+dump does not. When the server next says "Unconsumed payload bytes N,"
+the question "which call?" has a client-side answer.
+
+## The rules, genericized
+
+Nothing above is SoapySDR-specific. Any wire format without a schema — a
+binary RPC, a vendor USB control protocol, a register map, a serial
+command set — has the same four failure faces, and earns the same nets:
+
+- **Treat foreign enum values as extracted constants** (Part 1's rule):
+  cite the defining file, and pin every value with a literal transcribed
+  from it — never from your own header.
+- **Give your test double the real endpoint's strictness, mechanically** —
+  wired into the constructor, so no individual test can forget it.
+- **Prefer the protocol's introspection to your beliefs.** A peer that can
+  enumerate its own capabilities is an independent reference shipping
+  inside the protocol itself.
+- **Read back every write that matters, and log the read-back.** A
+  non-exception reply means "the server didn't throw," nothing more —
+  a rule the [testing module]({{ '/learn/testing/' | relative_url }})
+  generalizes beyond wire protocols.
+
+## Where this goes next
+
+Every net in this part defends a claim made *before* the hardware is in
+the loop — and passing all four still proves nothing on a real system.
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+makes that boundary explicit: the on-air gate, the ladder of evidence
+every decoder claim climbs, and the DMO "encrypted" verdict overturned
+capture by capture.
+
+## FAQ
+
+**How does a wrong RPC opcode go unnoticed when the arguments don't match?**
+Because nothing compares them. The handler unpacks what *it* expects; if
+the leading argument types coincide — a direction byte and a channel int
+are near-universal prefixes in SoapySDR calls — it runs happily on the
+prefix, and the surplus bytes are at most a log line in a destructor.
+
+**Why not just generate the Go constants from SoapyRemoteDefs.hpp?**
+Generation moves the trust to the generator and its input snapshot, and a
+stale snapshot drifts just as silently. The literal test is smaller and
+cleaner: sixteen numbers transcribed from the authority, and any refactor
+that changes one has to argue with a named upstream file in the failure
+message.
+
+**What does "Unconsumed payload bytes N" from SoapySDRServer actually mean?**
+The dispatched handler finished unpacking with N bytes of your request
+still unread — your call id and your argument list belong to two
+different calls. It does not say which RPC, which is why GopherTrunk grew
+a client-side tracer (`verbose_debug`) that decodes each outgoing frame.
+
+**Is a fake server worth having if it can't catch opcode drift?**
+Yes — it catches everything else: framing, argument shapes, sequencing,
+error paths. The discipline is knowing what a double *cannot* see and
+covering that face with a different net, not retiring the double.
+
+**Do these rules apply to protocols that have schemas, like gRPC?**
+Less force, same direction. A schema checks names and types, but semantic
+drift — wrong units, a deprecated endpoint that still answers — passes
+any schema. Read-back and introspection-validation stay worth their cost
+wherever a success reply is cheaper for the peer to send than the write
+is to perform.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: Case Study — Rebuilding SmartNet From Proven Decoders]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})
+· Next →
+[Part 10: The On-Air Gate — Green Synthetics Prove Nothing]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})

--- a/docs/_posts/2026-09-11-operator-cookbook-09-sharing-the-feed.md
+++ b/docs/_posts/2026-09-11-operator-cookbook-09-sharing-the-feed.md
@@ -1,0 +1,356 @@
+---
+title: "The Operator's Cookbook, Part 9: Sharing the Feed — Broadcastify, OpenMHz & Friends"
+description: Turn a working GopherTrunk rig into a public feed — copy-paste broadcast config for Broadcastify Calls, RdioScanner, OpenMHz, Icecast and webhooks, the MP3 transcode and loudness settings that make uploads sound right, and a troubleshooting table for uploads that fail or vanish.
+category: tutorials
+keywords: broadcastify calls upload sdr, rdioscanner upload gophertrunk, openmhz api upload, icecast scanner feed, police scanner streaming setup, sdr call upload mp3, trunking call webhook, scanner feed loudness normalization, gophertrunk cookbook
+tags: [operator-cookbook, broadcastify, openmhz, rdioscanner, icecast, streaming]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 9
+---
+
+*Part 9 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+put the radios far away and piped their IQ home over the network. This part
+points the pipe the other direction: your rig has been quietly recording clean
+calls for eight parts, and now other people get to hear them. One `broadcast:`
+block turns the box into an upload station for Broadcastify Calls, RdioScanner,
+OpenMHz and an Icecast live mount — all at once, from the same recordings —
+plus JSON webhooks for anything you want to build yourself.*
+
+> **TL;DR:** Everything outbound lives under one `broadcast:` key in
+> `config.yaml`, verified against `config.example.yaml`: `broadcastify:`,
+> `rdioscanner:`, `openmhz:`, `icecast:`, `webhook:` and `grant_webhook:` are
+> each a **list of feeds**, and every completed call fans out to every feed
+> that accepts its system. GopherTrunk transcodes each call to MP3 in pure Go
+> (8 kHz mono lands in the MPEG-2.5 family at 32 kbps) and retries uploads
+> with exponential backoff. The healthy log line is
+> `broadcast: call streamed backend=… system=… tg=… attempt=1`; the two you
+> troubleshoot are `broadcast: upload failed` and
+> `broadcast: upload queue full, dropping call`. Loudness for the *distributed*
+> copy is `recordings.normalize.apply_to: distributed` — the on-disk file stays
+> untouched.
+
+**Key takeaways**
+
+- **One rig, many feeds, zero extra hardware.** The broadcast manager is a
+  fan-out: each backend is a list entry, each entry filters by `systems:`, and
+  a call uploads to every feed that wants it. Running Broadcastify *and*
+  OpenMHz *and* your own webhook is three blocks, not three rigs.
+- **Per-call and live are different animals.** Broadcastify Calls, RdioScanner
+  and OpenMHz take one MP3 per completed call; Icecast is a continuous source
+  connection GopherTrunk keeps fed with calls back-to-back, padded with
+  silence between them.
+- **Uploads fail loudly and drop safely.** Every send gets retries with
+  backoff and a 60-second per-attempt timeout; a wedged backend fills a queue
+  that *drops calls rather than stall the recorder*. Your recordings are never
+  hostage to someone else's server.
+- **API keys are credentials — treat them like it.** Every backend key sits in
+  `config.yaml`, which is exactly why that file must never land in a public
+  repo or a support paste. The hygiene section below is short and
+  non-negotiable.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Global gates | drop short calls, size the upload pool | `broadcast.min_duration_ms`, `broadcast.workers` |
+| Broadcastify Calls | metadata POST → one-time URL → MP3 PUT | `broadcast.broadcastify[]`: `api_key`, `system_id` |
+| RdioScanner | multipart POST to your own instance | `broadcast.rdioscanner[]`: `url`, `api_key`, `system_id` |
+| OpenMHz | multipart POST to api.openmhz.com | `broadcast.openmhz[]`: `api_key`, `short_name` |
+| Icecast / ShoutCast | live source mount, calls + silence | `broadcast.icecast[]`: `host`, `port`, `mount`, `password` |
+| Webhooks | per-call JSON, per-grant JSON | `broadcast.webhook[]`, `broadcast.grant_webhook[]` |
+| Loudness of the MP3 | normalize the distributed copy only | `recordings.normalize.apply_to: distributed`, [loudness deep dive]({{ '/blog/deep-dives/recording-streaming-08-loudness-output-stage/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — one rig feeding aggregators, a live stream, and your own endpoints.
+- **The shopping list** — accounts and keys, not hardware.
+- **The config** — every backend block, every key verified.
+- **First run — what healthy looks like** — the upload log lines that matter.
+- **When it doesn't work** — symptom → cause → fix for silent and missing uploads.
+- **Variations** — webhooks-only rigs, encrypted-call policy, multi-system routing.
+
+## What you're building
+
+The finished rig is any working build from Parts 1–8 with its outputs made
+public: every completed call is transcoded to MP3 and pushed to the call
+aggregators you've signed up for, a live Icecast mount plays your system like
+a classic scanner feed, and a JSON webhook mirrors call metadata into whatever
+you run — a Discord relay, a Grafana pipeline, a database. The architecture is
+covered in depth on the deep-dive side
+([the broadcast manager]({{ '/blog/deep-dives/recording-streaming-13-broadcast-manager/' | relative_url }})
+and [the aggregator backends]({{ '/blog/deep-dives/recording-streaming-14-aggregator-backends/' | relative_url }}));
+this recipe is the operator's view of the same machinery.
+
+Two design facts shape everything below. First, the manager subscribes to
+*completed calls* — the recorder finishes a file, then upload workers
+(`broadcast.workers`, default 2) fan it out, so a slow aggregator can never
+back up into the decode path. Second, each feed carries an optional
+`systems:` list matching your `trunking.systems[].name` values, so a
+multi-system rig from [Part 7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }})
+can send the county P25 to Broadcastify and keep the business DMR private.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the sharing rig: the recorder emits a completed call which enters the broadcast manager, is filtered by minimum duration and per-feed system lists, transcoded once to a 32 kilobit MP3 with optional loudness normalization, then fanned out by upload workers to Broadcastify Calls, RdioScanner, OpenMHz, an Icecast live mount padded with silence, and a JSON webhook; a separate grant webhook path runs straight from the control-channel decoder without audio">
+  <rect x="10" y="96" width="104" height="38" rx="4" fill="none" stroke="currentColor"/>
+  <text x="62" y="112" text-anchor="middle" fill="currentColor" font-size="10">recorder</text>
+  <text x="62" y="125" text-anchor="middle" fill="var(--fg-muted)" font-size="9">completed call</text>
+  <line x1="114" y1="115" x2="148" y2="115" stroke="currentColor"/>
+  <rect x="148" y="60" width="180" height="110" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="238" y="78" text-anchor="middle" fill="var(--accent)" font-size="10">broadcast manager</text>
+  <text x="238" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="9">min_duration_ms · systems filter</text>
+  <text x="238" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="9">tg stream: false honored</text>
+  <text x="238" y="132" text-anchor="middle" fill="currentColor" font-size="10">MP3 encode (32 kbps)</text>
+  <text x="238" y="147" text-anchor="middle" fill="var(--fg-muted)" font-size="9">± loudness normalize (distributed)</text>
+  <text x="238" y="162" text-anchor="middle" fill="var(--fg-muted)" font-size="9">workers · retry w/ backoff</text>
+  <line x1="328" y1="90" x2="392" y2="40" stroke="currentColor"/>
+  <line x1="328" y1="105" x2="392" y2="86" stroke="currentColor"/>
+  <line x1="328" y1="120" x2="392" y2="132" stroke="currentColor"/>
+  <line x1="328" y1="140" x2="392" y2="178" stroke="currentColor"/>
+  <rect x="392" y="24" width="272" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="528" y="44" text-anchor="middle" fill="currentColor" font-size="10">Broadcastify Calls · RdioScanner · OpenMHz</text>
+  <rect x="392" y="70" width="272" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="528" y="84" text-anchor="middle" fill="currentColor" font-size="10">Icecast live mount</text>
+  <text x="528" y="96" text-anchor="middle" fill="var(--fg-muted)" font-size="9">calls back-to-back, silence between</text>
+  <rect x="392" y="116" width="272" height="32" rx="4" fill="none" stroke="currentColor"/>
+  <text x="528" y="136" text-anchor="middle" fill="currentColor" font-size="10">webhook: per-call JSON (± base64 MP3)</text>
+  <rect x="392" y="162" width="272" height="32" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="528" y="176" text-anchor="middle" fill="var(--accent)" font-size="10">grant_webhook: per-grant JSON, no audio</text>
+  <text x="528" y="188" text-anchor="middle" fill="var(--fg-muted)" font-size="9">fed by the CC decoder, not the recorder</text>
+  <rect x="10" y="176" width="104" height="38" rx="4" fill="none" stroke="var(--fg-muted)"/>
+  <text x="62" y="192" text-anchor="middle" fill="var(--fg-muted)" font-size="10">CC decoder</text>
+  <text x="62" y="205" text-anchor="middle" fill="var(--fg-muted)" font-size="9">every grant</text>
+  <line x1="114" y1="195" x2="392" y2="180" stroke="var(--fg-muted)" stroke-dasharray="3 3"/>
+  <text x="340" y="238" text-anchor="middle" fill="var(--fg-muted)" font-size="10">one recording, encoded once, delivered everywhere — and dropped, never blocking, when a backend wedges</text>
+</svg>
+<figcaption>The fan-out: per-call MP3s to the aggregators and webhooks, a paced live stream to Icecast, and grants pushed straight off the control channel.</figcaption>
+</figure>
+
+## The shopping list
+
+No hardware this time — the shopping is accounts and keys:
+
+| Item | Cost | What you need from it |
+|---|---|---|
+| Broadcastify Calls account | free to provide a feed | a Calls **API key** and your node's **system ID** |
+| OpenMHz system | free | an **API key** and your system's **short_name** |
+| RdioScanner instance | free, self-hosted | its **URL** and an **API key** you mint in its admin |
+| Icecast server | free, self-hosted (or a host you have a source login on) | host, port, **mount**, source password |
+| Your own endpoint | whatever you build | a URL that accepts JSON POSTs |
+
+Pick any subset — data-only rigs skip straight to the webhook variation. And
+a word before signing up anywhere: streaming public-safety audio is subject
+to local law and the aggregators' own rules; that homework is yours.
+
+## The config
+
+Append to a working rig from any earlier part. Every key below exists in
+`config.example.yaml`:
+
+```yaml
+broadcast:
+  min_duration_ms: 1500     # skip squelch crackle & failed decodes
+  workers: 0                # 0 = default upload pool (2)
+
+  broadcastify:
+    - enabled: true
+      name: "bcfy-metro"
+      api_key: "YOUR_BROADCASTIFY_CALLS_API_KEY"
+      system_id: 12345
+      systems: ["Metro-P25"]        # omit to stream every system
+
+  rdioscanner:
+    - enabled: true
+      name: "local-rdio"
+      url: "https://scanner.example.org"
+      api_key: "YOUR_RDIOSCANNER_API_KEY"
+      system_id: 1
+
+  openmhz:
+    - enabled: true
+      name: "openmhz-metro"
+      api_key: "YOUR_OPENMHZ_API_KEY"
+      short_name: "metro911"
+
+  icecast:
+    - enabled: true
+      name: "live-feed"
+      host: "stream.example.org"
+      port: 8000
+      mount: "/gophertrunk"
+      username: "source"
+      password: "YOUR_ICECAST_SOURCE_PASSWORD"
+      stream_name: "GopherTrunk Live"
+
+  webhook:
+    - enabled: true
+      name: "analytics"
+      url: "https://example.org/gophertrunk/calls"
+      auth_header: "Bearer YOUR_TOKEN"
+      include_audio: false          # true embeds the base64 MP3
+
+  grant_webhook:
+    - enabled: true
+      name: "grant-log"
+      url: "https://example.org/gophertrunk/grants"
+      auth_header: "Bearer YOUR_TOKEN"
+
+recordings:
+  normalize:
+    enabled: true
+    apply_to: distributed   # normalize the MP3 only; disk file untouched
+    target_lufs: -16.0
+    true_peak_dbtp: -1.5
+    max_boost_db: 12.0
+```
+
+Decisions worth explaining. **`min_duration_ms`** is your feed-quality knob:
+sub-second files are almost always dead keys, and aggregators judge feeds by
+signal-to-noise in the human sense too. **`apply_to: distributed`** runs the
+EBU R128 loudness normalize on the in-memory MP3 while leaving your archive
+faithful — the right split for a rig that's also the Part 10 archival build;
+[the loudness deep dive]({{ '/blog/deep-dives/recording-streaming-08-loudness-output-stage/' | relative_url }})
+explains the −16 LUFS target. **`grant_webhook`** is not a duplicate of
+`webhook`: it fires per control-channel *grant* the moment it decodes, carries
+no audio, and exists so consumers can retire a separate grant-log dependency
+(issue [#915](https://github.com/MattCheramie/GopherTrunk/issues/915)).
+The per-call webhook payload carries system, talkgroup, source RID, call
+type, frequency, P25 site identity, encryption and emergency flags, and
+start/stop timestamps.
+
+Two quieter filters also apply: a talkgroup with `stream: false` in your
+talkgroup CSV is excluded from **all** feeds (Part 13 covers the roster
+columns), and `recordings.skip_encrypted: true` suppresses the completed-call
+backends for encrypted calls — keep it `false` if your webhook consumer wants
+encrypted-call metadata (issue
+[#897](https://github.com/MattCheramie/GopherTrunk/issues/897)).
+
+### Key hygiene
+
+Every string above that says `YOUR_…` is a credential. Three rules: keep
+`config.yaml` out of version control and out of support pastes (the daemon's
+diagnostics never print it, but *you* might); on a shared box, make it
+readable only by the daemon's user — the systemd recipe in
+[Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
+installs it mode `0640`; and when a key does leak, rotate it at the provider
+first and in the file second. The API bearer token has a `token_file`
+indirection for exactly this reason
+([auth posture]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }}));
+broadcast keys live inline, so the file itself is the secret.
+
+## First run — what healthy looks like
+
+Restart the daemon and key up the system (or wait). Per completed call, per
+feed, the line you want is:
+
+```
+INF broadcast: call streamed backend=bcfy-metro system=Metro-P25 tg=9001 attempt=1
+```
+
+`attempt=1` means it worked first try. The Icecast source announces itself
+once at startup and again after any reconnect:
+
+```
+INF broadcast: icecast source connected backend=live-feed mount=/gophertrunk
+```
+
+Then verify at the far end: your call appears on the Broadcastify Calls
+node / OpenMHz system page within seconds, RdioScanner shows it in its own
+UI, and the Icecast mount plays your calls with silence between them —
+that's the pacing design, not a fault. A transient failure looks like this
+and is self-healing:
+
+```
+WRN broadcast: upload failed backend=openmhz-metro system=Metro-P25 tg=9001 attempt=1 of 4 err=...
+INF broadcast: call streamed backend=openmhz-metro system=Metro-P25 tg=9001 attempt=2
+```
+
+Only `ERR broadcast: giving up on call` means a call was lost to that feed —
+and even then only to that feed; the recording on disk and every other
+backend are unaffected.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `broadcast: upload failed … HTTP 401/403` on every call | wrong or revoked API key | Re-paste the key from the provider's dashboard; check you didn't swap two feeds' keys |
+| `broadcastify: metadata response rejected` | wrong `system_id`, or the talkgroup isn't in Broadcastify's DB for that node | Broadcastify validates metadata *before* issuing the upload URL — fix the node config on their side, then the ID here |
+| Uploads succeed but play as silence | historically, MP3 encoder bugs — three of them | Fixed and regression-pinned; the forensic story is [the silent-MP3 postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-15-silent-mp3/' | relative_url }}). If you see it on a current build, file an issue with the paired WAV |
+| Some talkgroups never appear on any feed | `stream: false` in the talkgroup CSV, or the call is shorter than `min_duration_ms` | Check the roster column and the duration gate before suspecting the backend |
+| One system uploads, another doesn't | `systems:` filter mismatch | The list must match `trunking.systems[].name` **exactly** — it's a name, not a pattern |
+| `broadcast: upload queue full, dropping call` | a backend is wedged or the network is down, and the queue chose dropping over stalling | Find which backend logs `upload failed`, fix or disable it; raise `workers` only if all backends are merely slow |
+| Encrypted calls missing from your webhook | `recordings.skip_encrypted: true` ends the call before the recorder lifecycle completes | Set it `false` to deliver them (issue [#897](https://github.com/MattCheramie/GopherTrunk/issues/897)) |
+| `broadcast: icecast source disconnected` repeating | wrong mount/password, or the server dropped the source | The backend reconnects on a fixed backoff forever; fix the credentials server-side and watch for `source connected` |
+
+One habit transfers from the decode side of this series: **read the log line
+before theorizing.** Every failure above names its backend and its attempt
+count — the difference between "OpenMHz rejected the key" and "my ISP dropped
+for a minute" is right there in `attempt=N of M`.
+
+## Variations
+
+- **Data-only rig.** Enable only `webhook` and `grant_webhook`: full call and
+  grant metadata to your own systems, zero audio leaves the box. The
+  [grant-webhook deep dive]({{ '/blog/deep-dives/running-it-for-real-11-grant-webhooks/' | relative_url }})
+  shows consumer patterns.
+- **Split routing.** Multiple entries per backend are legal — two
+  Broadcastify feeds with different `system_id`s and disjoint `systems:`
+  lists route a two-county rig to two nodes from one process.
+- **Louder everywhere.** `apply_to: both` normalizes the archive *and* the
+  MP3; `recording` normalizes only disk. Distributed-only is the recommended
+  start because it's reversible.
+- **Live-first rig.** Icecast alone, `min_duration_ms: 0`, and you've built a
+  classic streaming scanner; add
+  [`audio.enabled: true`]({{ '/blog/deep-dives/recording-streaming-12-live-listening/' | relative_url }})
+  if the box should also play to local speakers.
+
+## Where this goes next
+
+Everything you just shared also lands on your own disk, and disks fill.
+[Part 10]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }})
+builds the archival rig: first-class FLAC recordings at half the size, IQ
+taps that archive the *radio* signal too, the SQLite call log, and the
+retention math that says how many days actually fit.
+
+## FAQ
+
+**How do I stream GopherTrunk calls to Broadcastify?**
+Sign up to provide a Broadcastify Calls feed, take the Calls API key and
+system ID they assign, and paste both into a `broadcast.broadcastify` entry
+as above. GopherTrunk does the two-step Calls protocol itself — a metadata
+POST that returns a one-time upload URL, then an MP3 PUT — so there's no
+external uploader script to run.
+
+**What bitrate and format are the uploads?**
+Per-call MP3, encoded in pure Go from the finished recording. At the
+vocoder-native 8 kHz mono that recordings use, the encoder selects the
+MPEG-2.5 family at 32 kbps CBR — small enough that a full day of busy-system
+calls is tens of megabytes of upload.
+
+**Can I upload the same system to Broadcastify and OpenMHz at once?**
+Yes — that's the default behavior. Every enabled feed whose `systems:` list
+(or absence of one) accepts the call gets its own upload, from one shared
+MP3 encode. Backends fail independently: an OpenMHz outage never costs you a
+Broadcastify call.
+
+**Why do my uploads sound quieter than other feeds?**
+Faithful decode is conservative, and aggregator players do no gain riding.
+Enable `recordings.normalize` with `apply_to: distributed` for −16 LUFS
+loudness-normalized MP3s while keeping the on-disk archive untouched — or
+`recordings.enhance` from Part 1's table if you want the whole chain louder.
+
+**Does the Icecast feed go silent between calls?**
+It plays encoded silence, which is correct source behavior — the mount stays
+up, listeners stay connected, and the next call starts immediately. If the
+mount itself drops, look for `icecast source disconnected` lines; the backend
+redials on a fixed backoff until the server takes the source again.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: Radios Far Away — SoapyRemote, rtl_tcp & ka9q]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+· Next →
+[Part 10: The Archival Rig — FLAC, Retention & the Call Log]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }})

--- a/docs/_posts/2026-09-11-operator-cookbook-09-sharing-the-feed.md
+++ b/docs/_posts/2026-09-11-operator-cookbook-09-sharing-the-feed.md
@@ -331,10 +331,9 @@ MPEG-2.5 family at 32 kbps CBR — small enough that a full day of busy-system
 calls is tens of megabytes of upload.
 
 **Can I upload the same system to Broadcastify and OpenMHz at once?**
-Yes — that's the default behavior. Every enabled feed whose `systems:` list
-(or absence of one) accepts the call gets its own upload, from one shared
-MP3 encode. Backends fail independently: an OpenMHz outage never costs you a
-Broadcastify call.
+Yes — that's the default. Every enabled feed whose `systems:` list accepts
+the call gets its own upload from one shared MP3 encode, and backends fail
+independently: an OpenMHz outage never costs you a Broadcastify call.
 
 **Why do my uploads sound quieter than other feeds?**
 Faithful decode is conservative, and aggregator players do no gain riding.

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -14,19 +14,18 @@ series_part: 9
 America's dominant trunking protocol through GopherTrunk — from a raw C4FM
 carrier to recorded, named, multi-site voice.
 [Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }})
-followed an IMBE voice call from LDU superframes to a WAV on disk. This part
-is about the calls that never should make that trip: where "encrypted"
-actually lives on a P25 carrier — a single bit on the grant, and a 96-bit
-Encryption Sync buried inside the voice stream — and the policy machinery
-that decides what a scarce voice tuner, and your disk, should do about a
-call no scanner can decode.*
+followed an IMBE voice call from LDU superframes to a WAV on disk. This
+part is about the calls that should never make that trip: where
+"encrypted" actually lives on a P25 carrier — one bit on the grant, and a
+96-bit Encryption Sync buried inside the voice stream — and the policy
+machinery that decides what a scarce voice tuner, and your disk, should do
+about a call no scanner can decode.*
 
 > **TL;DR:** P25 signals encryption in two places GopherTrunk reads. The
 > grant's Service Options octet carries a **protected bit**
-> (`ServiceOptions.Encrypted`, `internal/radio/p25/phase1/opcodes.go`) —
-> one bit, known before voice even starts. The *metadata* arrives only
-> in-call: the **Encryption Sync** — a 72-bit Message Indicator, an
-> Algorithm ID and a Key ID — rides every LDU2, protected by a
+> (`ServiceOptions.Encrypted`) — one bit, known before voice starts. The
+> *metadata* arrives only in-call: the **Encryption Sync** — a 72-bit
+> Message Indicator, Algorithm ID and Key ID — rides every LDU2 under a
 > Hamming(10,6,3) inner FEC and an outer RS(24,16,9)
 > (`phase1.ParseEncryptionSync`). ALGID `0x80` means clear; anything else
 > names a cipher (`0x84` = AES-256, `0xAA` = ADP/RC4). On Phase 2 the same
@@ -189,7 +188,7 @@ zero" instead of failing silently.
 Here is the full path a discovered-encrypted call takes through the daemon:
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 258" width="680" height="258" role="img" aria-label="The two paths an encryption signal takes through GopherTrunk. Left column, control channel: the grant TSBK's protected bit sets Grant.Encrypted before a tuner is allocated. Right column, traffic channel: the LDU2 Encryption Sync is parsed by the composer, gated by the algorithm registry, and published as a KindCallEncryption bus event. Both converge on the trunking engine, which backfills the live grant and applies the per-system follow, metadata, or ignore policy, which in turn drives the recorder's skip-encrypted guard and the call log's algorithm and key columns.">
+<svg viewBox="0 0 680 258" width="680" height="258" role="img" aria-label="Two paths converge on the trunking engine: the grant's protected bit from the control channel, and the LDU2 Encryption Sync parsed and gated by the composer, published as a KindCallEncryption event; the engine backfills the live grant and applies the follow, metadata, or ignore policy that drives the recorder guard and the call log.">
   <text x="130" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">control channel (early)</text>
   <text x="480" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">traffic channel (mid-call)</text>
   <rect x="40" y="30" width="180" height="34" rx="6" fill="none" stroke="currentColor"/>
@@ -287,14 +286,13 @@ series.
 - **Events backfill instead of blocking.** The grant publishes immediately
   with what the control channel knows; `KindCallEncryption` and
   `KindCallSourceUpdate` patch the live call as the traffic channel fills
-  the gap — no consumer ever waits for metadata that may never come.
-- **Gates prefer omission to plausible garbage.** `AlgorithmKnown`,
-  `ErrEncryptionSyncUncorrectable` and the dedup check all drop
-  low-confidence values rather than surface them — a wrong key label sends
-  an operator chasing the wrong thing (the same reasoning as the TETRA DMO
-  colour-confidence gate).
+  the gap — no consumer waits for metadata that may never come.
+- **Gates prefer omission to plausible garbage.** `AlgorithmKnown` and
+  `ErrEncryptionSyncUncorrectable` drop low-confidence values rather than
+  surface them — a wrong key label sends an operator chasing the wrong
+  thing.
 - **Policy state lives in one enum with a safe zero.** `EncryptedFollow` is
-  the zero value and the parse fallback, so a config typo can never
+  the zero value *and* the parse fallback, so a config typo can never
   silently stop following calls.
 
 ## Where this goes next
@@ -311,32 +309,31 @@ frames and accumulates a neighbour map you can roam by.
 **How does GopherTrunk know a P25 call is encrypted?**
 Twice over: the voice grant's Service Options octet carries a protected bit
 (known before the call is even followed), and the traffic channel repeats
-the full Encryption Sync — Message Indicator, Algorithm ID, Key ID — in
-every LDU2 on Phase 1 or in the MAC_PTT key-up message on Phase 2. ALGID
-`0x80` is the clear value; anything else names a cipher.
+the full Encryption Sync — MI, Algorithm ID, Key ID — in every LDU2 on
+Phase 1 or in the MAC_PTT key-up message on Phase 2. ALGID `0x80` is the
+clear value; anything else names a cipher.
 
 **Can GopherTrunk decrypt encrypted P25 calls?**
 No. It surfaces which algorithm and key a call uses — the same
 identify-don't-decrypt model as SDRtrunk and OP25 — and performs no key
-recovery. Known-key decryption is currently implemented for DMR ARC4 only;
-on P25 a configured key exempts the call from the encrypted-call policy but
-the audio is not decrypted.
+recovery. Known-key decryption exists for DMR ARC4 only; on P25 a
+configured key exempts the call from the encrypted-call policy but the
+audio is not decrypted.
 
 **Why do some encrypted calls show no algorithm or key?**
 Either the call was torn down before an LDU2/MAC_PTT landed (the grant flag
-alone carries no metadata), or the ES word failed its FEC gates. GopherTrunk
+alone carries no metadata), or the ES word failed its gates. GopherTrunk
 deliberately omits ALGID/KID it cannot trust: an RS layer that
-"successfully" corrects to an Algorithm ID outside the TIA-102 registry is a
-known mis-decode signature (issue #924), and publishing it would be
-indistinguishable from a real key downstream.
+"successfully" corrects to an out-of-registry Algorithm ID is a known
+mis-decode signature (issue #924).
 
 **What does `encrypted_calls: metadata` actually buy me?**
 Alias, source and key intelligence without the tuner cost. The engine
 follows an encrypted call just long enough (default 1500 ms, or until the
 Phase 2 talker alias completes) to capture the traffic channel's metadata,
-then releases the voice SDR with end reason `encrypted`. On a busy system
-where a third of the traffic is encrypted, that's the difference between
-clear calls queueing for tuners and not.
+then releases the voice SDR with end reason `encrypted`. On a system where
+a third of the traffic is encrypted, that's the difference between clear
+calls queueing for tuners and not.
 
 **Should I set `recordings.skip_encrypted: true`?**
 If you never hold keys, probably: it keeps unplayable audio off the disk

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -41,11 +41,10 @@ about a call no scanner can decode.*
   *that* a call is protected, before allocation; only the traffic channel
   says *how*. Everything downstream is built around that gap: events that
   backfill, policies that re-evaluate, recordings that abort.
-- **The metadata is FEC'd like it matters — and gated like it lies.** Two
-  FEC layers protect the ES word, and an Algorithm ID that survives both
-  but lands outside the TIA-102 registry is *provably* a mis-decode
-  (`p25.AlgorithmKnown`, issue #924). A plausible-but-wrong key label is
-  worse than none.
+- **The metadata is FEC'd like it matters — and gated like it lies.** An
+  Algorithm ID that survives both FEC layers but lands outside the TIA-102
+  registry is *provably* a mis-decode (`p25.AlgorithmKnown`, issue #924); a
+  plausible-but-wrong key label is worse than none.
 - **Policy is per system, and configured keys trump policy.** `follow` /
   `metadata` / `ignore` are set per `trunking.systems[]` entry; a call
   whose Key ID matches a configured `encryption_keys` entry is always
@@ -69,40 +68,38 @@ about a call no scanner can decode.*
 ## In this post
 
 - **Two flags, two layers** — the one-bit grant flag vs the 96-bit in-call word.
-- **The Encryption Sync word** — MI, ALGID, KID and the two FEC layers under them.
-- **Phase 2: four layers between a flag and its metadata** — the postmortem this design came from.
-- **From burst to policy** — the event path, and what follow/metadata/ignore actually do.
+- **The Encryption Sync word** — MI, ALGID, KID and the FEC under them.
+- **Phase 2: four layers between a flag and its metadata** — the postmortem behind the design.
+- **From burst to policy** — the event path, and what follow/metadata/ignore do.
 - **What GopherTrunk won't do** — identification vs decryption vs key recovery.
 
 ## Two flags, two layers
 
 A P25 voice grant
 ([Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }}))
-carries an 8-bit Service Options octet, and bit `0x40` of it is the
-*protected* flag:
+carries an 8-bit Service Options octet; bit `0x40` is the *protected* flag:
 
-| Signal | Where | When you learn it | What it tells you |
+| Signal | Where | When | What it tells you |
 |---|---|---|---|
-| Service Options bit `0x40` | grant TSBK / MAC grant, control channel | before the voice SDR is allocated | encrypted: yes/no — nothing else |
+| Service Options bit `0x40` | grant TSBK / MAC grant, control channel | before the voice SDR is allocated | encrypted yes/no — nothing else |
 | Encryption Sync (Phase 1) | every LDU2 on the traffic channel | mid-call, repeating | MI (72 bits) + ALGID + KID |
-| MAC_PTT ES (Phase 2) | key-up message on the traffic channel | at each talk spurt | the same triple (issue #813) |
+| MAC_PTT ES (Phase 2) | key-up message on the traffic channel | each talk spurt | the same triple (issue #813) |
 
 The protected bit is the early warning: `Grant.Encrypted` is set before the
 [voice pool]({{ '/blog/deep-dives/trunking-engine-04-voice-pool/' | relative_url }})
 ever binds a tuner, which is what lets the `ignore` policy drop a grant
 without spending anything on it. But one bit is all it is — no algorithm,
-no key, and on compressed Phase 2 grants not even the bit, until the
-traffic channel says otherwise.
+no key, and on compressed Phase 2 grants not even the bit.
 
 The spec also front-loads the full MI/ALGID/KID triple into the
 [**Header Data Unit**]({{ '/reference/p25-header-data-unit/' | relative_url }})
 at key-up. GopherTrunk names the HDU in its DUID zoo (`DUIDHeader`,
 [Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }}))
-and deliberately leaves it undecoded: a trunked tune-in routinely arrives
-*after* key-up — grant, retune, DDC settle and frame lock all cost time — so
-a one-shot header at call start is exactly the frame a scanner is most
-likely to miss. The same triple repeats in **every LDU2**, one per 360 ms
-superframe, and that repeating copy is the one the pipeline is built on.
+and deliberately leaves it undecoded: a trunked tune-in arrives *after*
+key-up — grant, retune, DDC settle, frame lock — so a one-shot header at
+call start is exactly the frame a scanner misses. The same triple repeats
+in **every LDU2**, one per 360 ms superframe, and that repeating copy is
+the one the pipeline is built on.
 
 ## The Encryption Sync word
 
@@ -137,20 +134,18 @@ Note what the clear value is *not*: zero. A clear call advertises ALGID
 bitten every decoder that treated the field as a boolean. The IDs come from
 the TIA-102.AACE-A registry, mirrored in `internal/radio/p25/algorithm.go`:
 `0x81` DES-OFB, `0x84` AES-256, `0x85` AES-128, `0xAA` ADP/RC4 (the "cheap
-encryption" you meet most often), `0x9F` DES-XL among others — the
-[p25-algorithm-id]({{ '/reference/p25-algorithm-id/' | relative_url }})
-page keeps the full table.
+encryption" you meet most often), `0x9F` DES-XL among others
+([full table]({{ '/reference/p25-algorithm-id/' | relative_url }})).
 
 The two FEC layers earn their keep under marginal SNR, but they hide a
 trap: an RS decode can *report success* while "correcting" to garbage when
 more errors survive the inner layer than t=4 can honestly fix. A bit-error
-smears the Algorithm ID roughly uniformly across 0x00–0xFF with a
-near-distinct Key ID per call — surfaced, that's indistinguishable from a
-real key downstream. So both phases gate on the registry
-(`p25.AlgorithmKnown`, issue #924): an out-of-set ALGID is dropped with a
-debug line (`composer: p25p1 dropping out-of-set encryption sync`) rather
-than published. The set tracks `AlgorithmName`, so a genuinely new
-algorithm is admitted the moment it gets a name.
+smears the Algorithm ID roughly uniformly across 0x00–0xFF — surfaced,
+that's indistinguishable from a real key downstream. So both phases gate on
+the registry (`p25.AlgorithmKnown`, issue #924): an out-of-set ALGID is
+dropped with a debug line (`composer: p25p1 dropping out-of-set encryption
+sync`) rather than published. The set tracks `AlgorithmName`, so a
+genuinely new algorithm is admitted the moment it gets a name.
 
 ## Phase 2: four layers between a flag and its metadata
 
@@ -160,15 +155,15 @@ tells the same two-layer story with MAC PDUs. The protected bit rides the
 grant's Service Options as on Phase 1 — and also the in-call
 `GROUP_VOICE_CHANNEL_USER` PDU, which matters because Phase 2 grants often
 arrive *compressed*, with no source and no service options; the traffic
-channel resolves both mid-call via a `KindCallSourceUpdate` the engine
-folds back onto the live call.
+channel resolves both mid-call via a `KindCallSourceUpdate` the engine folds
+onto the live call.
 
 The metadata took longer to find. GopherTrunk's first model put ALGID/KID/MI
 in a standalone Encryption Sync MAC opcode (`AsEncryptionSync`) — and on
 real systems the triple doesn't ride there. It rides the **MAC_PTT** message
 at key-up, identified by its *slot type* rather than any opcode byte
-(`AsPushToTalk`, issue #813, field offsets cross-checked against SDRtrunk's
-PushToTalk structure). Getting to that answer was the subject of
+(`AsPushToTalk`, issue #813, offsets cross-checked against SDRtrunk).
+Getting to that answer was the subject of
 [From the Issue Tracker Part 3]({{ '/blog/solution-postmortem/from-the-issue-tracker-03-phase2-encryption-metadata/' | relative_url }}):
 a system that flagged every encrypted call correctly but never named an
 algorithm or key, because a fictional MAC opcode, a missing carrier loop, a
@@ -183,10 +178,10 @@ zero" instead of failing silently.
 
 ## From burst to policy
 
-Here is the full path a discovered-encrypted call takes through the daemon:
+The full path a discovered-encrypted call takes through the daemon:
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 258" width="680" height="258" role="img" aria-label="Two paths converge on the trunking engine: the grant's protected bit from the control channel, and the LDU2 Encryption Sync parsed and gated by the composer, published as a KindCallEncryption event; the engine backfills the live grant and applies the follow, metadata, or ignore policy that drives the recorder guard and the call log.">
+<svg viewBox="0 0 680 258" width="680" height="258" role="img" aria-label="Two paths converge on the trunking engine: the grant's protected bit from the control channel, and the composer-parsed LDU2 Encryption Sync published as a bus event; the engine backfills the live grant and applies the follow, metadata, or ignore policy driving the recorder guard and call log.">
   <text x="130" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">control channel (early)</text>
   <text x="480" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">traffic channel (mid-call)</text>
   <rect x="40" y="30" width="180" height="34" rx="6" fill="none" stroke="currentColor"/>
@@ -215,22 +210,21 @@ Here is the full path a discovered-encrypted call takes through the daemon:
   <text x="320" y="232" text-anchor="middle" fill="currentColor" font-size="10">call log + SSE/API</text>
   <text x="320" y="245" text-anchor="middle" fill="var(--fg-muted)" font-size="9">alg/key columns, E(alg=…,key=…) flag</text>
   <rect x="440" y="176" width="220" height="66" rx="6" fill="none" stroke="var(--fg-muted)"/>
-  <text x="550" y="192" text-anchor="middle" fill="currentColor" font-size="10">encrypted_calls policy</text>
-  <text x="550" y="206" text-anchor="middle" fill="var(--fg-muted)" font-size="9">follow · metadata (1.5 s) · ignore</text>
-  <text x="550" y="220" text-anchor="middle" fill="var(--fg-muted)" font-size="9">configured key ⇒ always follow</text>
-  <text x="550" y="234" text-anchor="middle" fill="var(--fg-muted)" font-size="9">teardown reason: "encrypted"</text>
+  <text x="550" y="196" text-anchor="middle" fill="currentColor" font-size="10">encrypted_calls policy</text>
+  <text x="550" y="212" text-anchor="middle" fill="var(--fg-muted)" font-size="9">follow · metadata (1.5 s) · ignore</text>
+  <text x="550" y="228" text-anchor="middle" fill="var(--fg-muted)" font-size="9">configured key ⇒ always follow</text>
 </svg>
-<figcaption>Two signals — one early and thin, one late and rich — converge on the engine, which owns the single policy decision everything downstream inherits.</figcaption>
+<figcaption>Two signals — one early and thin, one late and rich — converge on the engine, which owns the policy decision everything downstream inherits.</figcaption>
 </figure>
 
 The Phase 1 composer publishes a `KindCallEncryption` event when an LDU2's
 ES survives both FEC layers and the registry gate — deduplicated, since
 ALGID/KID rarely change within a call. The engine backfills the bound
-`ActiveCall.Grant` and republishes with the call's identity, which is why a
-grant log line grows a suffix mid-call: `E(alg=0x84,key=0x01A3)`. ALGID and
-KID persist into the call log, so an operator can see *which* key a
-recorded call would need. What the engine then does is the per-system
-`encrypted_calls` policy (issue #711),
+`ActiveCall.Grant` and republishes with the call's identity — why a grant
+log line grows a suffix mid-call: `E(alg=0x84,key=0x01A3)` — and both
+values persist into the call log, naming *which* key a recorded call would
+need. What the engine then does is the per-system `encrypted_calls` policy
+(issue #711),
 [Trunking Engine Part 11]({{ '/blog/deep-dives/trunking-engine-11-encrypted-mode/' | relative_url }})'s
 subject:
 
@@ -238,45 +232,41 @@ subject:
   no change): hold the voice SDR for the full call, like a clear one.
 - **`metadata`**: follow just long enough to harvest what the traffic
   channel gives away — talker alias, source RID, the ES itself — then
-  release the tuner. The window is `metadata_follow_ms` (default 1500 ms),
-  and on Phase 2 the release short-circuits the moment the talker alias
-  completes.
-- **`ignore`**: never spend a tuner. A grant already flagged encrypted is
-  dropped before allocation (`dropping encrypted grant (encrypted_calls
-  mode: ignore)`); encryption discovered mid-call tears the call down with
-  the dedicated end reason `encrypted` — a tuner freed by policy, not a
-  decode failure. Emergency grants bypass the policy entirely.
+  release. The window is `metadata_follow_ms` (default 1500 ms); on Phase 2
+  the release short-circuits the moment the talker alias completes.
+- **`ignore`**: never spend a tuner. A flagged grant is dropped before
+  allocation (`dropping encrypted grant (encrypted_calls mode: ignore)`);
+  encryption discovered mid-call tears the call down with the dedicated end
+  reason `encrypted` — a tuner freed by policy, not a decode failure.
+  Emergency grants bypass the policy entirely.
 
 Two exemptions cut across all modes. A call whose Key ID matches a
 configured `trunking.systems[].encryption_keys` entry is always followed
 (`Engine.keyConfigured` disarms any pending release). And the recorder has
-its own independent guard: `recordings.skip_encrypted` (issue #607) refuses
-to open a session for a flagged grant, and when encryption only surfaces
-mid-stream it closes and **deletes** the in-progress WAV/raw files and
-suppresses the CallComplete event, so upload feeds and webhooks never see
-the partial —
+its own guard: `recordings.skip_encrypted` (issue #607) refuses to open a
+session for a flagged grant, and when encryption surfaces mid-stream it
+closes and **deletes** the in-progress WAV/raw files and suppresses the
+CallComplete event, so upload feeds and webhooks never see the partial —
 [Recording & Streaming Part 7]({{ '/blog/deep-dives/recording-streaming-07-correctness-guards/' | relative_url }})
 walks that abort machinery.
 
 ## What GopherTrunk won't do
 
-The honest boundary, stated plainly. GopherTrunk **identifies** encryption
-— algorithm, key ID, message indicator — exactly as SDRtrunk does, and
-performs **no key recovery of any kind**. Known-key decryption exists today
-only for DMR ARC4 "Enhanced Privacy", where an operator authorized to hold
-a key configures it under `encryption_keys`; on P25, a configured key
-currently buys the policy exemption (the call is followed and recorded),
-not decryption.
+The honest boundary: GopherTrunk **identifies** encryption — algorithm,
+key ID, message indicator — exactly as SDRtrunk does, and performs **no key
+recovery of any kind**. Known-key decryption exists today only for DMR ARC4
+"Enhanced Privacy", configured under `encryption_keys` by an operator
+authorized to hold the key; on P25 a configured key buys the policy
+exemption (the call is followed and recorded), not decryption.
 
 What the identification path *does* feed is analysis of the signalling
 itself: every encrypted LDU2's MI (the IV) and its still-encrypted IMBE
 frames can be handed to the crypto-frame capture sink
 (`internal/voice/cryptocap`) for offline keystream-reuse analysis — the
-workflow the
-[Crypto Lab series]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }})
-builds on. The bridge captures every encrypted superframe, not one per call
-(distinct ciphertexts matter even when ALGID/KID never change), and it is
-off by default — the same opt-in discipline as every diagnostic tap in this
+[Crypto Lab]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }})
+workflow. The bridge captures every encrypted superframe, not one per call
+— distinct ciphertexts matter even when ALGID/KID never change — and it is
+off by default, the same opt-in discipline as every diagnostic tap in this
 series.
 
 ### How the gap shaped the Go code
@@ -286,30 +276,29 @@ series.
   `KindCallSourceUpdate` patch the live call as the traffic channel fills
   the gap — no consumer waits for metadata that may never come.
 - **Gates prefer omission to plausible garbage.** `AlgorithmKnown` and
-  `ErrEncryptionSyncUncorrectable` drop low-confidence values rather than
-  surface them — a wrong key label sends an operator chasing the wrong
-  thing.
+  `ErrEncryptionSyncUncorrectable` drop low-confidence values — a wrong key
+  label sends an operator chasing the wrong thing.
 - **Policy state lives in one enum with a safe zero.** `EncryptedFollow` is
   the zero value *and* the parse fallback, so a config typo can never
   silently stop following calls.
 
 ## Where this goes next
 
-Encryption was the last per-call layer. 
+Encryption was the last per-call layer.
 [Part 10]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})
 climbs above the call entirely: the WACN / System / RFSS / Site identity
-ladder, the status broadcasts that carry it — in both TSBK and multi-block
-AMBT forms — and how GopherTrunk votes a system's identity out of noisy
-frames and accumulates a neighbour map you can roam by.
+ladder, the broadcasts that carry it in TSBK and multi-block AMBT forms,
+and how GopherTrunk votes a system's identity out of noisy frames into a
+neighbour map you can roam by.
 
 ## FAQ
 
 **How does GopherTrunk know a P25 call is encrypted?**
-Twice over: the voice grant's Service Options octet carries a protected bit
+Twice over: the grant's Service Options octet carries a protected bit
 (known before the call is even followed), and the traffic channel repeats
 the full Encryption Sync — MI, Algorithm ID, Key ID — in every LDU2 on
-Phase 1 or in the MAC_PTT key-up message on Phase 2. ALGID `0x80` is the
-clear value; anything else names a cipher.
+Phase 1, or in the MAC_PTT key-up message on Phase 2. ALGID `0x80` is
+clear; anything else names a cipher.
 
 **Can GopherTrunk decrypt encrypted P25 calls?**
 No. It surfaces which algorithm and key a call uses — the same
@@ -319,27 +308,25 @@ configured key exempts the call from the encrypted-call policy but the
 audio is not decrypted.
 
 **Why do some encrypted calls show no algorithm or key?**
-Either the call was torn down before an LDU2/MAC_PTT landed (the grant flag
-alone carries no metadata), or the ES word failed its gates. GopherTrunk
-deliberately omits ALGID/KID it cannot trust: an RS layer that
-"successfully" corrects to an out-of-registry Algorithm ID is a known
-mis-decode signature (issue #924).
+Either the call ended before an LDU2/MAC_PTT landed (the grant flag alone
+carries no metadata), or the ES word failed its gates — GopherTrunk omits
+ALGID/KID it cannot trust, because an RS layer that "successfully" corrects
+to an out-of-registry Algorithm ID is a known mis-decode signature (issue
+#924).
 
 **What does `encrypted_calls: metadata` actually buy me?**
-Alias, source and key intelligence without the tuner cost. The engine
-follows an encrypted call just long enough (default 1500 ms, or until the
-Phase 2 talker alias completes) to capture the traffic channel's metadata,
-then releases the voice SDR with end reason `encrypted`. On a system where
-a third of the traffic is encrypted, that's the difference between clear
-calls queueing for tuners and not.
+Alias, source and key intelligence without the tuner cost: the engine
+follows an encrypted call just long enough to capture the traffic channel's
+metadata, then releases the voice SDR. On a system where a third of the
+traffic is encrypted, that's the difference between clear calls queueing
+for tuners and not.
 
 **Should I set `recordings.skip_encrypted: true`?**
 If you never hold keys, probably: it keeps unplayable audio off the disk
-and out of your upload feeds, gating both at grant time and mid-call (the
-in-progress file is deleted, not truncated). Leave it `false` if a
-downstream consumer wants the call events regardless — the suppressed
-CallComplete also suppresses call webhooks (issue #897) — or if you archive
-ciphertext deliberately for cryptolab-style analysis.
+and out of your upload feeds, gating at grant time and mid-call. Leave it
+`false` if a downstream consumer wants the call events regardless — the
+suppressed CallComplete also suppresses call webhooks (issue #897) — or if
+you deliberately archive ciphertext for cryptolab-style analysis.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -1,0 +1,357 @@
+---
+title: "P25 End to End, Part 9: Encryption Signalling — Flags, Metadata & Policy"
+description: Where a P25 call's encryption actually lives on the air — the grant's protected bit, the LDU2 Encryption Sync carrying the Message Indicator, Algorithm ID and Key ID, and Phase 2's MAC_PTT — and how GopherTrunk turns those signals into per-system tuner and recording policy.
+category: deep-dives
+keywords: p25 encryption sync, p25 algid key id, p25 message indicator, ldu2 encryption sync, encrypted p25 calls scanner, p25 aes 256 adp rc4, skip encrypted recordings, encrypted call policy, gophertrunk p25
+tags: [p25-end-to-end, p25, encryption, trunking, policy, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 9
+---
+
+*Part 9 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
+[Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }})
+followed an IMBE voice call from LDU superframes to a WAV on disk. This part
+is about the calls that never should make that trip: where "encrypted"
+actually lives on a P25 carrier — a single bit on the grant, and a 96-bit
+Encryption Sync buried inside the voice stream — and the policy machinery
+that decides what a scarce voice tuner, and your disk, should do about a
+call no scanner can decode.*
+
+> **TL;DR:** P25 signals encryption in two places GopherTrunk reads. The
+> grant's Service Options octet carries a **protected bit**
+> (`ServiceOptions.Encrypted`, `internal/radio/p25/phase1/opcodes.go`) —
+> one bit, known before voice even starts. The *metadata* arrives only
+> in-call: the **Encryption Sync** — a 72-bit Message Indicator, an
+> Algorithm ID and a Key ID — rides every LDU2, protected by a
+> Hamming(10,6,3) inner FEC and an outer RS(24,16,9)
+> (`phase1.ParseEncryptionSync`). ALGID `0x80` means clear; anything else
+> names a cipher (`0x84` = AES-256, `0xAA` = ADP/RC4). On Phase 2 the same
+> triple rides the **MAC_PTT** message at key-up (issue #813). Per-system
+> `encrypted_calls` policy — **follow / metadata / ignore** (issue #711) —
+> decides whether an encrypted call keeps its voice SDR, and
+> `recordings.skip_encrypted` (issue #607) keeps undecodable audio off the
+> disk. GopherTrunk identifies encryption; it does not break it.
+
+**Key takeaways**
+
+- **Encryption is signalled twice, at different layers.** The grant says
+  *that* a call is protected, before allocation; only the traffic channel
+  says *how* — algorithm and key arrive mid-call. Everything downstream is
+  built around that gap: events that backfill, policies that re-evaluate,
+  recordings that abort.
+- **The metadata is FEC'd like it matters — and gated like it lies.** Two
+  FEC layers protect the ES word, and an Algorithm ID that survives both but
+  lands outside the TIA-102 registry is *provably* a mis-decode
+  (`p25.AlgorithmKnown`, issue #924). A plausible-but-wrong key label is
+  worse than none.
+- **Policy is per system, and configured keys trump policy.** `follow` /
+  `metadata` / `ignore` are set per `trunking.systems[]` entry, and a call
+  whose Key ID matches a configured `encryption_keys` entry is always
+  followed regardless of mode.
+- **Identify, never decrypt.** GopherTrunk surfaces ALGID/KID/MI the way
+  SDRtrunk and OP25 do. Known-key decode exists only for DMR ARC4; on P25
+  there is no decryption and — everywhere — no key recovery of any kind.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Grant protected bit | "this call is encrypted", known at grant time | `phase1.ServiceOptions.Encrypted` (`opcodes.go`) |
+| LDU2 Encryption Sync | MI + ALGID + KID; Hamming(10,6,3) + RS(24,16,9) | `internal/radio/p25/phase1/encryption_sync.go` (`ParseEncryptionSync`) |
+| Phase 2 key-up sync | the ES triple riding MAC_PTT (slot type, not opcode) | `internal/radio/p25/phase2/mac_standard.go` (`AsPushToTalk`) |
+| Algorithm registry | ALGID → mnemonic + the out-of-set gate | `internal/radio/p25/algorithm.go` (`AlgorithmName`, `AlgorithmKnown`) |
+| In-call event path | composer → bus → engine backfills the live Grant | `events.KindCallEncryption` (`trunking.CallEncryption`) |
+| Tuner policy | follow / metadata / ignore, per system | `internal/trunking/encryptedmode.go` (`EncryptedMode`) |
+| Recording guard | never write, or abort-and-delete mid-call | `internal/voice/recorder.go` (`Options.SkipEncrypted`) |
+
+## In this post
+
+- **Two flags, two layers** — the one-bit grant flag vs the 96-bit in-call word.
+- **The Encryption Sync word** — MI, ALGID, KID and the two FEC layers under them.
+- **Phase 2: four layers between a flag and its metadata** — the postmortem this design came from.
+- **From burst to policy** — the event path, and what follow/metadata/ignore actually do.
+- **What GopherTrunk won't do** — identification vs decryption vs key recovery.
+
+## Two flags, two layers
+
+A P25 voice grant
+([Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }}))
+carries an 8-bit Service Options octet, and bit `0x40` of it is the
+*protected* flag:
+
+| Signal | Where | When you learn it | What it tells you |
+|---|---|---|---|
+| Service Options bit `0x40` | grant TSBK / MAC grant, control channel | before the voice SDR is allocated | encrypted: yes/no — nothing else |
+| Encryption Sync (Phase 1) | every LDU2 on the traffic channel | mid-call, repeating | MI (72 bits) + ALGID + KID |
+| MAC_PTT ES (Phase 2) | key-up message on the traffic channel | at each talk spurt | the same triple (issue #813) |
+
+The protected bit is the early warning: `Grant.Encrypted` is set before the
+[voice pool]({{ '/blog/deep-dives/trunking-engine-04-voice-pool/' | relative_url }})
+ever binds a tuner, which is what lets the `ignore` policy drop a grant
+without spending anything on it. But one bit is all it is — no algorithm, no
+key, and on some systems it's simply wrong or absent until the traffic
+channel says otherwise.
+
+The spec also front-loads the full MI/ALGID/KID triple into the
+[**Header Data Unit**]({{ '/reference/p25-header-data-unit/' | relative_url }})
+at key-up. GopherTrunk names the HDU in its DUID zoo (`DUIDHeader`,
+[Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }}))
+and deliberately leaves it undecoded: a trunked tune-in routinely arrives
+*after* key-up — grant, retune, DDC settle and frame lock all cost time — so
+a one-shot header at call start is exactly the frame a scanner is most
+likely to miss. The same triple repeats in **every LDU2**, one per 360 ms
+superframe, and that repeating copy is the one the pipeline is built on.
+
+## The Encryption Sync word
+
+The LDU2 donates the same six 40-bit slots an LDU1 spends on Link Control
+([Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }}))
+to an Encryption Sync word, under the identical inner FEC — 24 codewords of
+shortened Hamming(10,6,3). Above that sits an outer Reed-Solomon layer:
+
+```go
+// internal/radio/p25/phase1/encryption_sync.go (shape)
+type EncryptionSync struct {
+    MessageIndicator [9]byte // 72-bit per-call crypto sync vector (the IV)
+    AlgorithmID      uint8   // 0x80 = clear; 0x81 DES-OFB, 0x84 AES-256, …
+    KeyID            uint16  // which key in the radio's keyset
+}
+
+const AlgorithmClear uint8 = 0x80
+
+func (e EncryptionSync) Encrypted() bool { return e.AlgorithmID != AlgorithmClear }
+
+func ParseEncryptionSync(blocks [LDULCESBlockCount][]byte) (EncryptionSync, int, error) {
+    data, innerErrs, err := lcInnerDecode(blocks) // 24 × Hamming(10,6,3)
+    /* … */
+    info, rsErrs, rerr := framing.DecodeRS24_16(cw[:]) // outer RS(24,16,9), t=4
+    if rerr != nil {
+        return EncryptionSync{}, innerErrs, ErrEncryptionSyncUncorrectable
+    }
+    /* … octets 0-8 → MI, octet 9 → ALGID, octets 10-11 → KID … */
+}
+```
+
+Note what the clear value is *not*: zero. A clear call advertises ALGID
+`0x80`, so "encrypted" means `AlgorithmID != 0x80` — a detail that has
+bitten every decoder that treated the field as a boolean. The IDs come from
+the TIA-102.AACE-A registry, mirrored in `internal/radio/p25/algorithm.go`:
+`0x81` DES-OFB, `0x84` AES-256, `0x85` AES-128, `0xAA` ADP/RC4 (the "cheap
+encryption" you meet most often), `0x9F` DES-XL among others — the
+[p25-algorithm-id]({{ '/reference/p25-algorithm-id/' | relative_url }})
+page keeps the full table.
+
+The two FEC layers earn their keep under marginal SNR, but they hide a
+trap: an RS decode can *report success* while "correcting" to garbage when
+more errors survive the inner layer than t=4 can honestly fix. A bit-error
+smears the Algorithm ID roughly uniformly across 0x00–0xFF with a
+near-distinct Key ID per call — surfaced, that's indistinguishable from a
+real key downstream. So both phases gate on the registry
+(`p25.AlgorithmKnown`, issue #924): an out-of-set ALGID is dropped with a
+debug line (`composer: p25p1 dropping out-of-set encryption sync`) rather
+than published. The set tracks `AlgorithmName`, so a genuinely new
+algorithm is admitted the moment it gets a name.
+
+## Phase 2: four layers between a flag and its metadata
+
+Phase 2
+([Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }}))
+signals the same two-layer story with MAC PDUs. The protected bit rides the
+grant's Service Options exactly as on Phase 1 — and also on the in-call
+`GROUP_VOICE_CHANNEL_USER` PDU, which matters because Phase 2 grants often
+arrive in a *compressed* form with no source and no service options; the
+traffic channel resolves both mid-call, published as a
+`KindCallSourceUpdate` the engine folds back onto the live call.
+
+The metadata took longer to find. GopherTrunk's first model put ALGID/KID/MI
+in a standalone Encryption Sync MAC opcode (`AsEncryptionSync`) — and on
+real systems the triple doesn't ride there. It rides the **MAC_PTT** message
+at key-up, identified by its *slot type* rather than any opcode byte
+(`AsPushToTalk`, issue #813, field offsets cross-checked against SDRtrunk's
+PushToTalk structure). Getting to that answer was the subject of
+[From the Issue Tracker Part 3]({{ '/blog/solution-postmortem/from-the-issue-tracker-03-phase2-encryption-metadata/' | relative_url }}):
+a system that flagged every encrypted call correctly but never named an
+algorithm or key, because a fictional MAC opcode, a missing carrier loop, a
+48-bit sync constant in a 40-bit field and a swapped dibit map were stacked
+on top of each other — four layers between a flag and its metadata.
+
+Two design rules survive from that postmortem: the working-model layouts
+are **confined to one file each**, so a spec correction is a one-file
+change; and the protected bit **flags encryption independently** of the
+metadata parse, so a wrong layout degrades to "encrypted true, alg/key
+zero" instead of failing silently.
+
+## From burst to policy
+
+Here is the full path a discovered-encrypted call takes through the daemon:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 258" width="680" height="258" role="img" aria-label="The two paths an encryption signal takes through GopherTrunk. Left column, control channel: the grant TSBK's protected bit sets Grant.Encrypted before a tuner is allocated. Right column, traffic channel: the LDU2 Encryption Sync is parsed by the composer, gated by the algorithm registry, and published as a KindCallEncryption bus event. Both converge on the trunking engine, which backfills the live grant and applies the per-system follow, metadata, or ignore policy, which in turn drives the recorder's skip-encrypted guard and the call log's algorithm and key columns.">
+  <text x="130" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">control channel (early)</text>
+  <text x="480" y="20" text-anchor="middle" fill="currentColor" font-size="11" font-weight="bold">traffic channel (mid-call)</text>
+  <rect x="40" y="30" width="180" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="130" y="44" text-anchor="middle" fill="currentColor" font-size="10">grant TSBK / MAC grant</text>
+  <text x="130" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">SVC options bit 0x40 → Grant.Encrypted</text>
+  <rect x="380" y="30" width="200" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="480" y="44" text-anchor="middle" fill="currentColor" font-size="10">LDU2 ES / Phase 2 MAC_PTT</text>
+  <text x="480" y="57" text-anchor="middle" fill="var(--fg-muted)" font-size="9">MI + ALGID + KID, Hamming + RS</text>
+  <line x1="480" y1="64" x2="480" y2="82" stroke="currentColor"/><polygon points="476,80 480,88 484,80" fill="currentColor"/>
+  <rect x="380" y="88" width="200" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="480" y="102" text-anchor="middle" fill="currentColor" font-size="10">composer: ParseEncryptionSync</text>
+  <text x="480" y="115" text-anchor="middle" fill="var(--fg-muted)" font-size="9">AlgorithmKnown gate (#924) → bus event</text>
+  <line x1="130" y1="64" x2="130" y2="146" stroke="currentColor"/><polygon points="126,144 130,152 134,144" fill="currentColor"/>
+  <line x1="480" y1="122" x2="480" y2="134" stroke="currentColor"/>
+  <line x1="480" y1="134" x2="240" y2="158" stroke="currentColor"/><polygon points="247,159 232,159 242,151" fill="currentColor"/>
+  <text x="500" y="140" fill="var(--accent)" font-size="9">KindCallEncryption</text>
+  <rect x="40" y="152" width="290" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="185" y="168" text-anchor="middle" fill="var(--accent)" font-size="10" font-weight="bold">trunking engine</text>
+  <text x="185" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="9">backfills ALGID/KID onto the live Grant · applies policy</text>
+  <line x1="120" y1="192" x2="120" y2="212" stroke="currentColor"/><polygon points="116,210 120,218 124,210" fill="currentColor"/>
+  <line x1="250" y1="192" x2="250" y2="212" stroke="currentColor"/><polygon points="246,210 250,218 254,210" fill="currentColor"/>
+  <rect x="30" y="218" width="180" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="120" y="232" text-anchor="middle" fill="currentColor" font-size="10">recorder: skip_encrypted</text>
+  <text x="120" y="245" text-anchor="middle" fill="var(--fg-muted)" font-size="9">never open, or abort-and-delete</text>
+  <rect x="230" y="218" width="180" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="320" y="232" text-anchor="middle" fill="currentColor" font-size="10">call log + SSE/API</text>
+  <text x="320" y="245" text-anchor="middle" fill="var(--fg-muted)" font-size="9">alg/key columns, E(alg=…,key=…) flag</text>
+  <rect x="440" y="176" width="220" height="66" rx="6" fill="none" stroke="var(--fg-muted)"/>
+  <text x="550" y="192" text-anchor="middle" fill="currentColor" font-size="10">encrypted_calls policy</text>
+  <text x="550" y="206" text-anchor="middle" fill="var(--fg-muted)" font-size="9">follow · metadata (1.5 s) · ignore</text>
+  <text x="550" y="220" text-anchor="middle" fill="var(--fg-muted)" font-size="9">configured key ⇒ always follow</text>
+  <text x="550" y="234" text-anchor="middle" fill="var(--fg-muted)" font-size="9">teardown reason: "encrypted"</text>
+</svg>
+<figcaption>Two signals — one early and thin, one late and rich — converge on the engine, which owns the single policy decision everything downstream inherits.</figcaption>
+</figure>
+
+The Phase 1 composer publishes a `KindCallEncryption` event when an LDU2's
+ES survives both FEC layers and the registry gate — deduplicated, since
+ALGID/KID rarely change within a call. The engine backfills the bound
+`ActiveCall.Grant` and republishes with the call's identity, which is why a
+grant log line grows a suffix mid-call: `E(alg=0x84,key=0x01A3)`. The
+Algorithm ID and Key ID persist into the call log, so an operator can see
+*which* key a recorded call would need.
+
+What the engine then does is the per-system `encrypted_calls` policy
+(issue #711),
+[Trunking Engine Part 11]({{ '/blog/deep-dives/trunking-engine-11-encrypted-mode/' | relative_url }})'s
+subject:
+
+- **`follow`** (the default and the zero value — pre-existing configs see
+  no change): hold the voice SDR for the full call, like a clear one.
+- **`metadata`**: follow just long enough to harvest what the traffic
+  channel gives away — talker alias, source RID, the ES itself — then
+  release the tuner. The window is `metadata_follow_ms` (default 1500 ms),
+  and on Phase 2 the release short-circuits the moment the talker alias
+  completes.
+- **`ignore`**: never spend a tuner. A grant already flagged encrypted is
+  dropped before allocation (`dropping encrypted grant (encrypted_calls
+  mode: ignore)`); encryption discovered mid-call tears the call down with
+  the dedicated end reason `encrypted` — a tuner freed by policy, not a
+  decode failure. Emergency grants bypass the policy entirely.
+
+Two exemptions cut across all modes. A call whose Key ID matches a
+configured `trunking.systems[].encryption_keys` entry is always followed
+(`Engine.keyConfigured` disarms any pending release). And the recorder has
+its own independent guard: `recordings.skip_encrypted` (issue #607) refuses
+to open a session for a flagged grant, and when encryption only surfaces
+mid-stream it closes and **deletes** the in-progress WAV/raw files and
+suppresses the CallComplete event, so upload feeds and webhooks never see
+the partial —
+[Recording & Streaming Part 7]({{ '/blog/deep-dives/recording-streaming-07-correctness-guards/' | relative_url }})
+walks that abort machinery.
+
+## What GopherTrunk won't do
+
+The honest boundary, stated plainly. GopherTrunk **identifies** encryption
+— algorithm, key ID, message indicator — exactly as SDRtrunk does, and
+performs **no key recovery of any kind**. Known-key decryption exists today
+only for DMR ARC4 "Enhanced Privacy", where an operator authorized to hold
+a key configures it under `encryption_keys`; on P25, a configured key
+currently buys the policy exemption (the call is followed and recorded),
+not decryption.
+
+What the identification path *does* feed is analysis of the signalling
+itself: every encrypted LDU2's MI (the IV) and its still-encrypted IMBE
+frames can be handed to the crypto-frame capture sink
+(`internal/voice/cryptocap`) for offline keystream-reuse analysis — the
+workflow the
+[Crypto Lab series]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }})
+builds on. The bridge captures every encrypted superframe, not one per call
+(distinct ciphertexts matter even when ALGID/KID never change), and it is
+off by default — the same opt-in discipline as every diagnostic tap in this
+series.
+
+### How the gap shaped the Go code
+
+- **Events backfill instead of blocking.** The grant publishes immediately
+  with what the control channel knows; `KindCallEncryption` and
+  `KindCallSourceUpdate` patch the live call as the traffic channel fills
+  the gap — no consumer ever waits for metadata that may never come.
+- **Gates prefer omission to plausible garbage.** `AlgorithmKnown`,
+  `ErrEncryptionSyncUncorrectable` and the dedup check all drop
+  low-confidence values rather than surface them — a wrong key label sends
+  an operator chasing the wrong thing (the same reasoning as the TETRA DMO
+  colour-confidence gate).
+- **Policy state lives in one enum with a safe zero.** `EncryptedFollow` is
+  the zero value and the parse fallback, so a config typo can never
+  silently stop following calls.
+
+## Where this goes next
+
+Encryption was the last per-call layer. 
+[Part 10]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})
+climbs above the call entirely: the WACN / System / RFSS / Site identity
+ladder, the status broadcasts that carry it — in both TSBK and multi-block
+AMBT forms — and how GopherTrunk votes a system's identity out of noisy
+frames and accumulates a neighbour map you can roam by.
+
+## FAQ
+
+**How does GopherTrunk know a P25 call is encrypted?**
+Twice over: the voice grant's Service Options octet carries a protected bit
+(known before the call is even followed), and the traffic channel repeats
+the full Encryption Sync — Message Indicator, Algorithm ID, Key ID — in
+every LDU2 on Phase 1 or in the MAC_PTT key-up message on Phase 2. ALGID
+`0x80` is the clear value; anything else names a cipher.
+
+**Can GopherTrunk decrypt encrypted P25 calls?**
+No. It surfaces which algorithm and key a call uses — the same
+identify-don't-decrypt model as SDRtrunk and OP25 — and performs no key
+recovery. Known-key decryption is currently implemented for DMR ARC4 only;
+on P25 a configured key exempts the call from the encrypted-call policy but
+the audio is not decrypted.
+
+**Why do some encrypted calls show no algorithm or key?**
+Either the call was torn down before an LDU2/MAC_PTT landed (the grant flag
+alone carries no metadata), or the ES word failed its FEC gates. GopherTrunk
+deliberately omits ALGID/KID it cannot trust: an RS layer that
+"successfully" corrects to an Algorithm ID outside the TIA-102 registry is a
+known mis-decode signature (issue #924), and publishing it would be
+indistinguishable from a real key downstream.
+
+**What does `encrypted_calls: metadata` actually buy me?**
+Alias, source and key intelligence without the tuner cost. The engine
+follows an encrypted call just long enough (default 1500 ms, or until the
+Phase 2 talker alias completes) to capture the traffic channel's metadata,
+then releases the voice SDR with end reason `encrypted`. On a busy system
+where a third of the traffic is encrypted, that's the difference between
+clear calls queueing for tuners and not.
+
+**Should I set `recordings.skip_encrypted: true`?**
+If you never hold keys, probably: it keeps unplayable audio off the disk
+and out of your upload feeds, gating both at grant time and mid-call (the
+in-progress file is deleted, not truncated). Leave it `false` if a
+downstream consumer wants the call events regardless — the suppressed
+CallComplete also suppresses call webhooks (issue #897) — or if you archive
+ciphertext deliberately for cryptolab-style analysis.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8: IMBE Voice — From LDU to WAV]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }})
+· Next →
+[Part 10: Sites, WACNs & Roaming a Multi-Site System]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -103,10 +103,10 @@ the one the pipeline is built on.
 
 ## The Encryption Sync word
 
-The LDU2 donates the same six 40-bit slots an LDU1 spends on Link Control
+The LDU2 donates the six 40-bit slots an LDU1 spends on Link Control
 ([Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }}))
 to an Encryption Sync word, under the identical inner FEC — 24 codewords of
-shortened Hamming(10,6,3) — with an outer Reed-Solomon layer above it:
+shortened Hamming(10,6,3) — plus an outer Reed-Solomon layer:
 
 ```go
 // internal/radio/p25/phase1/encryption_sync.go (shape)
@@ -271,10 +271,10 @@ series.
 
 ### How the gap shaped the Go code
 
-- **Events backfill instead of blocking.** The grant publishes immediately
-  with what the control channel knows; `KindCallEncryption` and
-  `KindCallSourceUpdate` patch the live call as the traffic channel fills
-  the gap — no consumer waits for metadata that may never come.
+- **Events backfill instead of blocking.** The grant publishes immediately;
+  `KindCallEncryption` and `KindCallSourceUpdate` patch the live call as
+  the traffic channel fills the gap — no consumer waits for metadata that
+  may never come.
 - **Gates prefer omission to plausible garbage.** `AlgorithmKnown` and
   `ErrEncryptionSyncUncorrectable` drop low-confidence values — a wrong key
   label sends an operator chasing the wrong thing.

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -109,7 +109,7 @@ superframe, and that repeating copy is the one the pipeline is built on.
 The LDU2 donates the same six 40-bit slots an LDU1 spends on Link Control
 ([Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }}))
 to an Encryption Sync word, under the identical inner FEC — 24 codewords of
-shortened Hamming(10,6,3). Above that sits an outer Reed-Solomon layer:
+shortened Hamming(10,6,3) — with an outer Reed-Solomon layer above it:
 
 ```go
 // internal/radio/p25/phase1/encryption_sync.go (shape)
@@ -118,8 +118,6 @@ type EncryptionSync struct {
     AlgorithmID      uint8   // 0x80 = clear; 0x81 DES-OFB, 0x84 AES-256, …
     KeyID            uint16  // which key in the radio's keyset
 }
-
-const AlgorithmClear uint8 = 0x80
 
 func (e EncryptionSync) Encrypted() bool { return e.AlgorithmID != AlgorithmClear }
 
@@ -158,12 +156,12 @@ algorithm is admitted the moment it gets a name.
 
 Phase 2
 ([Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }}))
-signals the same two-layer story with MAC PDUs. The protected bit rides the
-grant's Service Options exactly as on Phase 1 — and also on the in-call
+tells the same two-layer story with MAC PDUs. The protected bit rides the
+grant's Service Options as on Phase 1 — and also the in-call
 `GROUP_VOICE_CHANNEL_USER` PDU, which matters because Phase 2 grants often
-arrive in a *compressed* form with no source and no service options; the
-traffic channel resolves both mid-call, published as a
-`KindCallSourceUpdate` the engine folds back onto the live call.
+arrive *compressed*, with no source and no service options; the traffic
+channel resolves both mid-call via a `KindCallSourceUpdate` the engine
+folds back onto the live call.
 
 The metadata took longer to find. GopherTrunk's first model put ALGID/KID/MI
 in a standalone Encryption Sync MAC opcode (`AsEncryptionSync`) — and on

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -130,8 +130,8 @@ func ParseEncryptionSync(blocks [LDULCESBlockCount][]byte) (EncryptionSync, int,
 ```
 
 Note what the clear value is *not*: zero. A clear call advertises ALGID
-`0x80`, so "encrypted" means `AlgorithmID != 0x80` — a detail that has
-bitten every decoder that treated the field as a boolean. The IDs come from
+`0x80`, so "encrypted" means `AlgorithmID != 0x80` — a detail that bites
+any decoder treating the field as a boolean. The IDs come from
 the TIA-102.AACE-A registry, mirrored in `internal/radio/p25/algorithm.go`:
 `0x81` DES-OFB, `0x84` AES-256, `0x85` AES-128, `0xAA` ADP/RC4 (the "cheap
 encryption" you meet most often), `0x9F` DES-XL among others
@@ -301,8 +301,7 @@ Phase 1, or in the MAC_PTT key-up message on Phase 2. ALGID `0x80` is
 clear; anything else names a cipher.
 
 **Can GopherTrunk decrypt encrypted P25 calls?**
-No. It surfaces which algorithm and key a call uses — the same
-identify-don't-decrypt model as SDRtrunk and OP25 — and performs no key
+No. It surfaces which algorithm and key a call uses, and performs no key
 recovery. Known-key decryption exists for DMR ARC4 only; on P25 a
 configured key exempts the call from the encrypted-call policy but the
 audio is not decrypted.
@@ -310,9 +309,8 @@ audio is not decrypted.
 **Why do some encrypted calls show no algorithm or key?**
 Either the call ended before an LDU2/MAC_PTT landed (the grant flag alone
 carries no metadata), or the ES word failed its gates — GopherTrunk omits
-ALGID/KID it cannot trust, because an RS layer that "successfully" corrects
-to an out-of-registry Algorithm ID is a known mis-decode signature (issue
-#924).
+ALGID/KID it cannot trust, because an RS layer "successfully" correcting to
+an out-of-registry Algorithm ID is a known mis-decode signature (#924).
 
 **What does `encrypted_calls: metadata` actually buy me?**
 Alias, source and key intelligence without the tuner cost: the engine

--- a/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
+++ b/docs/_posts/2026-09-11-p25-end-to-end-09-encryption.md
@@ -40,18 +40,17 @@ call no scanner can decode.*
 
 - **Encryption is signalled twice, at different layers.** The grant says
   *that* a call is protected, before allocation; only the traffic channel
-  says *how* — algorithm and key arrive mid-call. Everything downstream is
-  built around that gap: events that backfill, policies that re-evaluate,
-  recordings that abort.
+  says *how*. Everything downstream is built around that gap: events that
+  backfill, policies that re-evaluate, recordings that abort.
 - **The metadata is FEC'd like it matters — and gated like it lies.** Two
-  FEC layers protect the ES word, and an Algorithm ID that survives both but
-  lands outside the TIA-102 registry is *provably* a mis-decode
+  FEC layers protect the ES word, and an Algorithm ID that survives both
+  but lands outside the TIA-102 registry is *provably* a mis-decode
   (`p25.AlgorithmKnown`, issue #924). A plausible-but-wrong key label is
   worse than none.
 - **Policy is per system, and configured keys trump policy.** `follow` /
-  `metadata` / `ignore` are set per `trunking.systems[]` entry, and a call
+  `metadata` / `ignore` are set per `trunking.systems[]` entry; a call
   whose Key ID matches a configured `encryption_keys` entry is always
-  followed regardless of mode.
+  followed.
 - **Identify, never decrypt.** GopherTrunk surfaces ALGID/KID/MI the way
   SDRtrunk and OP25 do. Known-key decode exists only for DMR ARC4; on P25
   there is no decryption and — everywhere — no key recovery of any kind.
@@ -92,9 +91,9 @@ carries an 8-bit Service Options octet, and bit `0x40` of it is the
 The protected bit is the early warning: `Grant.Encrypted` is set before the
 [voice pool]({{ '/blog/deep-dives/trunking-engine-04-voice-pool/' | relative_url }})
 ever binds a tuner, which is what lets the `ignore` policy drop a grant
-without spending anything on it. But one bit is all it is — no algorithm, no
-key, and on some systems it's simply wrong or absent until the traffic
-channel says otherwise.
+without spending anything on it. But one bit is all it is — no algorithm,
+no key, and on compressed Phase 2 grants not even the bit, until the
+traffic channel says otherwise.
 
 The spec also front-loads the full MI/ALGID/KID triple into the
 [**Header Data Unit**]({{ '/reference/p25-header-data-unit/' | relative_url }})
@@ -231,12 +230,10 @@ The Phase 1 composer publishes a `KindCallEncryption` event when an LDU2's
 ES survives both FEC layers and the registry gate — deduplicated, since
 ALGID/KID rarely change within a call. The engine backfills the bound
 `ActiveCall.Grant` and republishes with the call's identity, which is why a
-grant log line grows a suffix mid-call: `E(alg=0x84,key=0x01A3)`. The
-Algorithm ID and Key ID persist into the call log, so an operator can see
-*which* key a recorded call would need.
-
-What the engine then does is the per-system `encrypted_calls` policy
-(issue #711),
+grant log line grows a suffix mid-call: `E(alg=0x84,key=0x01A3)`. ALGID and
+KID persist into the call log, so an operator can see *which* key a
+recorded call would need. What the engine then does is the per-system
+`encrypted_calls` policy (issue #711),
 [Trunking Engine Part 11]({{ '/blog/deep-dives/trunking-engine-11-encrypted-mode/' | relative_url }})'s
 subject:
 

--- a/docs/_posts/2026-09-12-from-spec-to-shipping-10-the-on-air-gate.md
+++ b/docs/_posts/2026-09-12-from-spec-to-shipping-10-the-on-air-gate.md
@@ -1,0 +1,350 @@
+---
+title: "From Spec to Shipping, Part 10: The On-Air Gate — Green Synthetics Prove Nothing"
+description: Why every decoder claim in GopherTrunk carries a verification status — synthetic-green, capture-verified, or on-air-verified — and how the TETRA DMO "encrypted" misdiagnosis was overturned three times by three successive operator captures before the real causes surfaced.
+category: deep-dives
+keywords: on-air verification, synthetic test vs real capture, tetra dmo encrypted misdiagnosis, dm colour code recovery, iq replay test workflow, crc chance floor, decoder verification levels, issue closing discipline, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, tetra, dmo, verification, testing, methodology]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 10
+---
+
+*Part 10 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 9]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})
+built four nets around a schemaless RPC wire — and ended on the admission
+that passing all four proves nothing about a real system. This part makes
+that boundary a formal gate: three levels of evidence, three kinds of
+claims each level licenses, and the cautionary tale of a DMO decoder that
+was "encrypted," then "clear but colour 3," then "no dominant colour" —
+each verdict overturned by the **next** operator capture.*
+
+> **TL;DR:** Every decoder claim in GopherTrunk carries one of three
+> statuses: **synthetic-green** (our tests pass), **capture-verified**
+> (a real recording decodes), **on-air-verified** (the operator confirms
+> on the live system). The gate exists because
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was
+> closed twice on a synthetic-green "fix" while the symptom stayed live
+> ([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)). The
+> TETRA DMO saga
+> ([#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003)) shows
+> why: a chance-floor TCH/S CRC was read as encryption, the radios were
+> TEA0-clear, and the real causes — a colour-0 descramble skip, a wrong
+> colour code, an MNI-0 search blind spot — surfaced one capture at a
+> time, through env-gated replay tests (`TestTETRADMOReplay`,
+> `GT_TETRA_DMO_*`) whose **verdict lines are written for the person
+> holding the antenna**.
+
+**Key takeaways**
+
+- **"The tests pass" and "it works" are different claims with different
+  evidence.** A synthetic fixture shares assumptions with the code it
+  tests; a capture carries only the transmitter's assumptions; the air
+  carries nobody's. Each rung falsifies things the rung below cannot.
+- **A chance floor is a measurement, not a diagnosis.** TCH/S CRC at
+  ~1/256 is consistent with encryption, a wrong descramble seed, wrong
+  burst geometry, *and* a weak signal. The DMO investigation read it as
+  encryption and was wrong — the discriminating fact (TEA0-clear radios)
+  had to come from outside the code.
+- **Build the operator loop as a product.** When the person with RF
+  access isn't the person with the debugger, the test harness *is* the
+  interface: env-var replay tests, verdict lines that state the
+  conclusion and the next step, and a flag (`GT_TETRA_DMO_CLEAR`) that
+  folds the operator's ground truth into the verdict.
+- **A gate that refuses to answer is working.** `RecoverDMColourCode`
+  demands its winner beat the runner-up 3× — and on the one capture where
+  no colour dominated, that refusal was the correct output. The temptation
+  to hardcode the 33%-yield "winner" was the self-consistent trap again.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The gate's origin | issue closed twice on an unverified fix, symptom live | [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) / [#771](https://github.com/MattCheramie/GopherTrunk/issues/771); `CLAUDE.md` issue-closing policy |
+| DMO replay harness | operator-run capture replay with verdict lines | `cmd/gophertrunk/tetra_dmo_replay_test.go` (`TestTETRADMOReplay`) |
+| Ground-truth flag | operator asserts the call is clear → verdict flips | `GT_TETRA_DMO_CLEAR=1` |
+| Colour diagnostics | 64-colour CRC-yield sweep, prints the full map | `TestTETRADMOColourScan` (`GT_TETRA_DMO_SCAN=1`) |
+| Empirical colour recovery | pick the colour that maximizes CRC yield, with a dominance gate | `internal/radio/tetra/dmo_decode.go` (`RecoverDMColourCode`) |
+| Signal-vs-DSP referee | independent resampler proves a deficit lives in the samples | `internal/scanner/ccdecoder/ddc_highrate_test.go`, [Weak-Signal Part 12]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }}) |
+
+## In this post
+
+- **The three-rung ladder** — what each level of evidence can and cannot
+  falsify.
+- **The "encrypted" verdict that wasn't** — the DMO saga, capture by
+  capture.
+- **The operator loop** — env-gated replay tests as a user interface.
+- **The gate that refused** — why a non-answer was the right answer.
+- **Writing the status down** — institutional notes, `Refs` vs `Closes`,
+  and the close that needs a human.
+
+## The three-rung ladder
+
+The workflow this series has been building implies a hierarchy of claims,
+and it is worth making explicit, because each rung is defined by what it
+**cannot** rule out:
+
+**Synthetic-green.** Every unit test, round-trip, literal vector and
+conformance harness passes. This falsifies internal inconsistency and —
+with [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})'s
+literal vectors — disagreement with a reference. It cannot falsify a
+wrong model of the transmitter: the
+[self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
+lives entirely inside this rung, and GopherTrunk's fabricated SmartNet
+framing ([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143))
+sat synthetic-green for its whole wrong life.
+
+**Capture-verified.** A recording of a real transmitter decodes. This
+falsifies the wrong-model class — the bits in the file were arranged by
+somebody else's radio. It cannot falsify problems the capture doesn't
+contain: the wrong RF conditions, the wrong network parameters, a
+different vendor's option. As the DMO saga below shows, *each capture
+verifies exactly one point in configuration space*, and generalizing from
+it is a fresh assumption.
+
+**On-air-verified.** The operator runs the shipped path on the live
+system and confirms the original symptom is gone. Only this rung closes
+an issue, because only this rung tests the claim the issue actually made.
+The policy has a scar behind it: **#764 was closed twice** on a fix green
+in every test while the reported symptom was still live (#771). The
+issue-closing policy now requires a failing-first regression *plus*
+reporter confirmation — or a reproduced symptom shown resolved — before
+any close-as-completed.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Three gates in a row from left to right. First box: synthetic-green, licensed claim is the code agrees with itself and with references; below it, cannot see a wrong model of the transmitter. Arrow through a gate labelled real capture decodes into the second box: capture-verified, licensed claim is a real transmitter's bits decode; below it, cannot see conditions the capture lacks. Arrow through a gate labelled operator confirms on the live system into the third box: on-air-verified, licensed claim is the reported symptom is gone, and only this rung closes an issue. Beneath the row, a note that the DMO saga crossed the middle gate three times, each capture overturning the previous conclusion.">
+  <rect x="16" y="40" width="180" height="76" rx="6" fill="none" stroke="currentColor"/>
+  <text x="106" y="60" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">synthetic-green</text>
+  <text x="106" y="78" text-anchor="middle" fill="currentColor" font-size="9">claim: agrees with itself</text>
+  <text x="106" y="91" text-anchor="middle" fill="currentColor" font-size="9">and with references</text>
+  <text x="106" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="9">blind to: a wrong model</text>
+  <rect x="250" y="40" width="180" height="76" rx="6" fill="none" stroke="currentColor"/>
+  <text x="340" y="60" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">capture-verified</text>
+  <text x="340" y="78" text-anchor="middle" fill="currentColor" font-size="9">claim: a real transmitter's</text>
+  <text x="340" y="91" text-anchor="middle" fill="currentColor" font-size="9">bits decode</text>
+  <text x="340" y="108" text-anchor="middle" fill="var(--fg-muted)" font-size="9">blind to: what the capture lacks</text>
+  <rect x="484" y="40" width="180" height="76" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="574" y="60" text-anchor="middle" fill="var(--accent)" font-size="10" font-weight="bold">on-air-verified</text>
+  <text x="574" y="78" text-anchor="middle" fill="var(--accent)" font-size="9">claim: the reported</text>
+  <text x="574" y="91" text-anchor="middle" fill="var(--accent)" font-size="9">symptom is gone</text>
+  <text x="574" y="108" text-anchor="middle" fill="var(--accent)" font-size="9">only this rung closes an issue</text>
+  <line x1="196" y1="78" x2="250" y2="78" stroke="var(--fg-muted)"/><polygon points="246,74 254,78 246,82" fill="var(--fg-muted)"/>
+  <line x1="223" y1="58" x2="223" y2="98" stroke="var(--accent)"/>
+  <text x="223" y="140" text-anchor="middle" fill="var(--fg-muted)" font-size="9">gate: a real capture decodes</text>
+  <line x1="430" y1="78" x2="484" y2="78" stroke="var(--fg-muted)"/><polygon points="480,74 488,78 480,82" fill="var(--fg-muted)"/>
+  <line x1="457" y1="58" x2="457" y2="98" stroke="var(--accent)"/>
+  <text x="457" y="158" text-anchor="middle" fill="var(--fg-muted)" font-size="9">gate: operator confirms live</text>
+  <text x="340" y="196" text-anchor="middle" fill="currentColor" font-size="10">the DMO saga crossed the middle gate three times —</text>
+  <text x="340" y="212" text-anchor="middle" fill="currentColor" font-size="10">each new capture overturned the previous capture's conclusion</text>
+</svg>
+<figcaption>Three rungs of evidence, each defined by what it cannot falsify — and an issue closes only at the last one.</figcaption>
+</figure>
+
+## The "encrypted" verdict that wasn't
+
+The DMO direct-mode investigation
+([#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003), told
+at protocol depth in
+[TETRA End to End Parts 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
+[and 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }}))
+is the cleanest demonstration this project owns of why the middle rung
+must be crossed repeatedly. Compressed to its verdicts:
+
+| Round | Evidence | Conclusion drawn | Overturned by |
+|---|---|---|---|
+| 1 | first capture: signalling decodes, TCH/S at the ~1/256 CRC chance floor | "air-interface encrypted voice" | the reporter's codeplug: radios are **TEA0, clear**, colour 0 |
+| 2 | code audit with the clear fact in hand | the voice path **skipped descrambling at colour 0** — TETRA scrambling is non-identity even at colour 0 | — (a real fix, but not yet the whole story) |
+| 3 | 10aug capture: signalling 44/45, TCH/S still floored at colour 0 | colour sweep: **colour 3** → 35/269 CRC-valid, 70 speech frames, 2.1 s of PCM | nothing — but only for *this* capture |
+| 4 | 15aug capture: ~90% signalling, **no colour dominates** (best 140 vs runner-up 74 of 831) | "marginal signal, partial keystream artifacts" | the radios' identity: Motorola MTP8500Ex running **MCC 250 / MNC 1** |
+| 5 | the MNI fact | the colour search only ever tried MNI 0 — the true seed `ExtendedColourCode(250, 1, colour)` was **unreachable** by construction | still open: the MNI-folded fix is synthetic-pinned, awaiting the operator's A/B |
+
+Three things to take from that table. First, **every round's conclusion
+was reasonable on its evidence** — a chance-floor CRC really is what
+encryption looks like. The failure wasn't sloppy reasoning; it was
+treating one capture's worth of evidence as more general than it was.
+Second, the facts that broke each deadlock — TEA0-clear, the colour, the
+MNI — all came **from the operator's side of the gate**: a codeplug
+screen, a radio model number. No amount of staring at the decoder could
+have produced them. Third, round 2's fix was *real and necessary* and
+still didn't make voice decode; rounds 3–5 each peeled another layer. A
+gate you cross once is a gate you'll cross again.
+
+The empirical answer that came out of round 3 is worth showing, because
+it encodes the discipline in two constants:
+
+```go
+// internal/radio/tetra/dmo_decode.go (shape)
+// Confidence gate for RecoverDMColourCode: the winning colour must clear
+// this many CRC-valid TCH/S bursts AND beat the runner-up by this factor.
+// The correct colour descrambles the class-2 protected speech while every
+// wrong colour sits at the ~1/256 chance floor (measured ≈35 vs ≤3 on the
+// #1003 10aug capture) — while an encrypted or unreceivable call clears
+// neither.
+const (
+    dmColourMinCRC    = 6
+    dmColourDominance = 3
+)
+```
+
+The DM colour code is *not recoverable from the signalling* (the SCH/S is
+always colour-0 scrambled), and pinning its exact bit offset in the
+DM-SYNC SYSINFO from one capture — where colour 3 lights only two bits —
+would have been the self-consistent trap in a new spot. So GopherTrunk
+recovers it the way
+[Part 6]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }})
+resolved the DNB geometry: **design a measurement where the right answer
+wins by a wide margin, and refuse to answer when it doesn't.** On the
+15aug capture the gate refused — 140 is not 3 × 74 — and that refusal,
+initially read as "the colour guesser is broken," was the harness
+correctly reporting that its hypothesis space didn't contain the truth.
+The truth (a non-zero MNI) enlarged the space; the gate stands unchanged.
+
+## The operator loop as a user interface
+
+Crossing the middle gate repeatedly only works if crossing is cheap for
+the person who has the RF. GopherTrunk's answer is a family of env-gated
+replay tests: they **skip cleanly** with a one-line instruction when their
+capture is absent, and become field instruments when it's present. The
+reproduce line for the DMO harness is a single command:
+
+```
+GT_TETRA_DMO_IQ=<capture.raw> GT_TETRA_DMO_RATE=144000 \
+GT_TETRA_DMO_MCC=250 GT_TETRA_DMO_MNC=1 \
+go test ./cmd/gophertrunk -run TestTETRADMOReplay -v
+```
+
+The part that makes it a *loop* rather than a log dump is that the output
+speaks in verdicts, and the operator's ground truth changes what the
+verdict says:
+
+```go
+// cmd/gophertrunk/tetra_dmo_replay_test.go (shape)
+// GT_TETRA_DMO_CLEAR=1 asserts the capture is clear and flips the verdict.
+if os.Getenv("GT_TETRA_DMO_CLEAR") == "1" {
+    t.Logf("VERDICT: DMO SIGNALLING decodes (dsb_schs_crc=%d, distinct FN=%d) "+
+        "but TCH/S is at the chance floor (tch_crc=%d/%d) on a capture asserted "+
+        "CLEAR (TEA0) — this is a clear-voice DECODE defect to keep chasing "+
+        "(geometry/interleave/colour), NOT encryption. …", /* … */)
+} else {
+    t.Logf("VERDICT: … either air-interface ENCRYPTED voice or a remaining "+
+        "clear-voice decode defect. If the call is known CLEAR (TEA0), set "+
+        "GT_TETRA_DMO_CLEAR=1; otherwise validate against a known-CLEAR DMO call.")
+}
+```
+
+The same measurement, two different conclusions — because the operator
+holds a fact the harness cannot measure. This is round 1's mistake,
+engineered away: the harness will never again silently launder "chance
+floor" into "encrypted" when somebody on the other end *knows* the call
+is clear. And when the verdict says "keep chasing," the next instrument
+is one env var away: `GT_TETRA_DMO_SCAN=1` runs
+`TestTETRADMOColourScan`, the 64-colour CRC-yield sweep whose full
+colour→yield map is what made the 15aug "no dominant colour" signature —
+and therefore the MNI blind spot — visible at all.
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+covers the fixture machinery behind all of this; the design rule here is
+that **the test harness is an interface between two people who each hold
+half the evidence**.
+
+The gate cuts the other way too, and honestly. Sometimes the capture
+proves the *decoder* innocent: the #764 endgame decimated the operator's
+10 MS/s capture with an **independent resampler**, replayed it through
+the proven 2.5 MS/s path, and reproduced the identical ~9.5 dB deficit —
+the problem was baked into the samples, front-end phase noise, not DSP
+([the full method]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})).
+An on-air gate that can only ever indict your code is a ritual; one that
+can acquit it is a measurement.
+
+## Writing the status down
+
+A ladder nobody records is a ladder that gets skipped under deadline. The
+project's standing engineering notes mark every claim with its rung — the
+phrase **"still on-air-gated"** appears verbatim next to the DMO MNI fix,
+the conventional-DMR two-slot rebuild, and the SmartNet reconstruction,
+each with the exact command an operator runs to move it up a rung. Three
+concrete habits fall out:
+
+- **PRs say `Refs #N`, not `Closes #N`, until the fix is verified** — so
+  a merge cannot auto-close an issue whose symptom nobody has re-checked.
+- **A close-as-completed requires a human to confirm the verification**,
+  mechanically — the repo's tooling interposes the question, because
+  #764 proved good intentions don't.
+- **When you can't verify, you leave the issue open and say what's
+  blocking** — "needs the reporter's capture" is a status, not a failure,
+  and [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})
+  builds the whole definition of "done" on it.
+
+### How that principle shaped the Go code
+
+- **Verdict lines are code-reviewed prose.** The `t.Logf` strings in
+  `tetra_dmo_replay_test.go` state the conclusion, the alternative, and
+  the next command — they are written for the operator, and changing one
+  is a semantic change.
+- **Ground truth enters as input, not assumption.** `GT_TETRA_DMO_CLEAR`,
+  `GT_TETRA_DMO_MCC/MNC` and `GT_TETRA_DMO_COLOUR` let the operator
+  assert what they know; unset, the harness recovers what it can
+  (`RecoverDMColourCode`) and says so.
+- **Confidence gates return three values, not two.** `(colour, count,
+  confident)` — and every caller of a non-confident result keeps its
+  default rather than trusting a chance-floor winner.
+- **The rung is greppable.** "on-air-gated," "capture-verified," and the
+  reproduce commands live in the notes and test comments, so the next
+  investigation starts knowing exactly which claims are load-bearing.
+
+## Where this goes next
+
+Everything in this part assumes a capture exists to replay — and getting
+the *right* capture is its own discipline.
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+treats captures as first-class test fixtures: the `samples/` conventions
+and metadata sidecars, the env-gated harnesses, how to ask a reporter for
+the capture that can actually answer the question, and why you baseline
+the metrics *before* touching the code.
+
+## FAQ
+
+**Why isn't a passing test suite enough to close a bug?**
+Because the suite and the code can share the same wrong assumption — the
+recurring villain of this series. A test the author of the fix wrote can
+only check the author's model; the reported symptom lives on a system
+that doesn't care about the model. #764 was closed twice by exactly this
+overconfidence.
+
+**What does a "CRC chance floor" mean and why does it matter?**
+With random input, a CRC-gated decode still passes occasionally — for
+the TCH/S class-2 check, at roughly 1/256. Yield *at* that floor means
+the decoder is recovering nothing: encryption, a wrong descramble seed,
+wrong geometry, and severe RF damage all look identical there. The floor
+tells you something is wrong; it cannot tell you what — which is why
+GopherTrunk pairs it with ground-truth flags and sweep diagnostics.
+
+**How do I run GopherTrunk's DMO replay against my own capture?**
+Record cs16 IQ on the DMO carrier, then
+`GT_TETRA_DMO_IQ=<file> GT_TETRA_DMO_RATE=<hz> go test ./cmd/gophertrunk
+-run TestTETRADMOReplay -v`. Add `GT_TETRA_DMO_CLEAR=1` if you know the
+call is unencrypted, `GT_TETRA_DMO_MCC`/`GT_TETRA_DMO_MNC` if your
+network runs a non-zero MNI, and `GT_TETRA_DMO_SCAN=1` (with
+`TestTETRADMOColourScan`) to see the full colour-yield map.
+
+**Isn't demanding operator confirmation slow?**
+Slower than closing on green, faster than closing wrong. Every round of
+the DMO saga that shipped a premature conclusion cost a full
+capture-request cycle to unwind — and #764's two wrong closes cost more
+credibility than any delay would have. The gate converts "we think" into
+"we measured," and the loop is engineered to make measuring cheap.
+
+**Does the gate apply to features, or only bug fixes?**
+Both, with the same ladder. A new decoder path (the DMO production
+pipeline, the SmartNet rebuild) ships synthetic-green and
+capture-verified, is *documented* as on-air-gated, and its issue stays
+open until the live confirmation lands. Shipping staged-but-honest beats
+shipping "done."
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: Wire Protocols Without Schemas]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})
+· Next →
+[Part 11: Capture-Driven Development]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})

--- a/docs/_posts/2026-09-12-from-spec-to-shipping-10-the-on-air-gate.md
+++ b/docs/_posts/2026-09-12-from-spec-to-shipping-10-the-on-air-gate.md
@@ -162,14 +162,13 @@ must be crossed repeatedly. Compressed to its verdicts:
 
 Three things to take from that table. First, **every round's conclusion
 was reasonable on its evidence** — a chance-floor CRC really is what
-encryption looks like. The failure wasn't sloppy reasoning; it was
-treating one capture's worth of evidence as more general than it was.
-Second, the facts that broke each deadlock — TEA0-clear, the colour, the
-MNI — all came **from the operator's side of the gate**: a codeplug
-screen, a radio model number. No amount of staring at the decoder could
-have produced them. Third, round 2's fix was *real and necessary* and
-still didn't make voice decode; rounds 3–5 each peeled another layer. A
-gate you cross once is a gate you'll cross again.
+encryption looks like; the failure was treating one capture's evidence as
+more general than it was. Second, the facts that broke each deadlock —
+TEA0-clear, the colour, the MNI — all came **from the operator's side of
+the gate**: a codeplug screen, a radio model number. Third, round 2's fix
+was real and necessary and *still* didn't make voice decode; rounds 3–5
+each peeled another layer. A gate you cross once is a gate you'll cross
+again.
 
 The empirical answer that came out of round 3 is worth showing, because
 it encodes the discipline in two constants:
@@ -234,19 +233,16 @@ if os.Getenv("GT_TETRA_DMO_CLEAR") == "1" {
 }
 ```
 
-The same measurement, two different conclusions — because the operator
-holds a fact the harness cannot measure. This is round 1's mistake,
-engineered away: the harness will never again silently launder "chance
-floor" into "encrypted" when somebody on the other end *knows* the call
-is clear. And when the verdict says "keep chasing," the next instrument
-is one env var away: `GT_TETRA_DMO_SCAN=1` runs
-`TestTETRADMOColourScan`, the 64-colour CRC-yield sweep whose full
-colour→yield map is what made the 15aug "no dominant colour" signature —
-and therefore the MNI blind spot — visible at all.
-[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
-covers the fixture machinery behind all of this; the design rule here is
-that **the test harness is an interface between two people who each hold
-half the evidence**.
+The same measurement, two conclusions — because the operator holds a
+fact the harness cannot measure. Round 1's mistake, engineered away: the
+harness will never again launder "chance floor" into "encrypted" when
+somebody on the other end *knows* the call is clear. And when the verdict
+says "keep chasing," the next instrument is one env var away:
+`GT_TETRA_DMO_SCAN=1` runs `TestTETRADMOColourScan`, the 64-colour
+CRC-yield sweep whose full colour→yield map is what made the 15aug "no
+dominant colour" signature — and therefore the MNI blind spot — visible
+at all. The design rule: **the test harness is an interface between two
+people who each hold half the evidence**.
 
 The gate cuts the other way too, and honestly. Sometimes the capture
 proves the *decoder* innocent: the #764 endgame decimated the operator's
@@ -306,19 +302,17 @@ the metrics *before* touching the code.
 ## FAQ
 
 **Why isn't a passing test suite enough to close a bug?**
-Because the suite and the code can share the same wrong assumption — the
-recurring villain of this series. A test the author of the fix wrote can
-only check the author's model; the reported symptom lives on a system
-that doesn't care about the model. #764 was closed twice by exactly this
-overconfidence.
+Because the suite and the code can share the same wrong assumption — this
+series' recurring villain. A test the fix's author wrote checks the
+author's model; the reported symptom lives on a system that doesn't care
+about the model. #764 was closed twice by exactly this overconfidence.
 
 **What does a "CRC chance floor" mean and why does it matter?**
-With random input, a CRC-gated decode still passes occasionally — for
-the TCH/S class-2 check, at roughly 1/256. Yield *at* that floor means
-the decoder is recovering nothing: encryption, a wrong descramble seed,
+With random input, a CRC-gated decode still passes occasionally — for the
+TCH/S class-2 check, at roughly 1/256. Yield *at* that floor means the
+decoder is recovering nothing — but encryption, a wrong descramble seed,
 wrong geometry, and severe RF damage all look identical there. The floor
-tells you something is wrong; it cannot tell you what — which is why
-GopherTrunk pairs it with ground-truth flags and sweep diagnostics.
+says something is wrong; it cannot say what.
 
 **How do I run GopherTrunk's DMO replay against my own capture?**
 Record cs16 IQ on the DMO carrier, then

--- a/docs/_posts/2026-09-12-from-spec-to-shipping-10-the-on-air-gate.md
+++ b/docs/_posts/2026-09-12-from-spec-to-shipping-10-the-on-air-gate.md
@@ -14,12 +14,12 @@ series_part: 10
 decoder actually gets written — from standards documents and independent
 references to code you can trust on air.
 [Part 9]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})
-built four nets around a schemaless RPC wire — and ended on the admission
-that passing all four proves nothing about a real system. This part makes
-that boundary a formal gate: three levels of evidence, three kinds of
-claims each level licenses, and the cautionary tale of a DMO decoder that
-was "encrypted," then "clear but colour 3," then "no dominant colour" —
-each verdict overturned by the **next** operator capture.*
+built four nets around a schemaless RPC wire — and admitted that passing
+all four proves nothing about a real system. This part makes that
+boundary a formal gate: three levels of evidence, the claims each
+licenses, and the cautionary tale of a DMO decoder that was "encrypted,"
+then "clear but colour 3," then "no dominant colour" — each verdict
+overturned by the **next** operator capture.*
 
 > **TL;DR:** Every decoder claim in GopherTrunk carries one of three
 > statuses: **synthetic-green** (our tests pass), **capture-verified**
@@ -49,14 +49,14 @@ each verdict overturned by the **next** operator capture.*
   encryption and was wrong — the discriminating fact (TEA0-clear radios)
   had to come from outside the code.
 - **Build the operator loop as a product.** When the person with RF
-  access isn't the person with the debugger, the test harness *is* the
-  interface: env-var replay tests, verdict lines that state the
-  conclusion and the next step, and a flag (`GT_TETRA_DMO_CLEAR`) that
-  folds the operator's ground truth into the verdict.
+  access isn't the person with the debugger, the harness *is* the
+  interface: env-var replay tests, verdict lines stating the conclusion
+  and the next step, a flag (`GT_TETRA_DMO_CLEAR`) folding the operator's
+  ground truth into the verdict.
 - **A gate that refuses to answer is working.** `RecoverDMColourCode`
   demands its winner beat the runner-up 3× — and on the one capture where
-  no colour dominated, that refusal was the correct output. The temptation
-  to hardcode the 33%-yield "winner" was the self-consistent trap again.
+  no colour dominated, that refusal was the correct output. Hardcoding
+  the 33%-yield "winner" would have been the self-consistent trap again.
 
 ## Cheat sheet
 
@@ -82,9 +82,8 @@ each verdict overturned by the **next** operator capture.*
 
 ## The three-rung ladder
 
-The workflow this series has been building implies a hierarchy of claims,
-and it is worth making explicit, because each rung is defined by what it
-**cannot** rule out:
+The workflow this series has been building implies a hierarchy of claims.
+Each rung is defined by what it **cannot** rule out:
 
 **Synthetic-green.** Every unit test, round-trip, literal vector and
 conformance harness passes. This falsifies internal inconsistency and —
@@ -92,17 +91,16 @@ with [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | 
 literal vectors — disagreement with a reference. It cannot falsify a
 wrong model of the transmitter: the
 [self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }})
-lives entirely inside this rung, and GopherTrunk's fabricated SmartNet
-framing ([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143))
-sat synthetic-green for its whole wrong life.
+lives entirely inside this rung, and the fabricated SmartNet framing
+([#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)) sat
+synthetic-green for its whole wrong life.
 
 **Capture-verified.** A recording of a real transmitter decodes. This
 falsifies the wrong-model class — the bits in the file were arranged by
 somebody else's radio. It cannot falsify problems the capture doesn't
 contain: the wrong RF conditions, the wrong network parameters, a
-different vendor's option. As the DMO saga below shows, *each capture
-verifies exactly one point in configuration space*, and generalizing from
-it is a fresh assumption.
+different vendor's option. *Each capture verifies exactly one point in
+configuration space*, and generalizing from it is a fresh assumption.
 
 **On-air-verified.** The operator runs the shipped path on the live
 system and confirms the original symptom is gone. Only this rung closes
@@ -114,7 +112,7 @@ reporter confirmation — or a reproduced symptom shown resolved — before
 any close-as-completed.
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Three gates in a row from left to right. First box: synthetic-green, licensed claim is the code agrees with itself and with references; below it, cannot see a wrong model of the transmitter. Arrow through a gate labelled real capture decodes into the second box: capture-verified, licensed claim is a real transmitter's bits decode; below it, cannot see conditions the capture lacks. Arrow through a gate labelled operator confirms on the live system into the third box: on-air-verified, licensed claim is the reported symptom is gone, and only this rung closes an issue. Beneath the row, a note that the DMO saga crossed the middle gate three times, each capture overturning the previous conclusion.">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Three boxes in a row: synthetic-green, capture-verified, and on-air-verified, each listing the claim it licenses and what it is blind to, joined by two gates — a real capture decodes, and the operator confirms live — with a note that the DMO saga crossed the middle gate three times, each capture overturning the previous conclusion.">
   <rect x="16" y="40" width="180" height="76" rx="6" fill="none" stroke="currentColor"/>
   <text x="106" y="60" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">synthetic-green</text>
   <text x="106" y="78" text-anchor="middle" fill="currentColor" font-size="9">claim: agrees with itself</text>
@@ -149,8 +147,8 @@ The DMO direct-mode investigation
 at protocol depth in
 [TETRA End to End Parts 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }})
 [and 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }}))
-is the cleanest demonstration this project owns of why the middle rung
-must be crossed repeatedly. Compressed to its verdicts:
+is this project's cleanest demonstration of why the middle rung must be
+crossed repeatedly. Compressed to its verdicts:
 
 | Round | Evidence | Conclusion drawn | Overturned by |
 |---|---|---|---|
@@ -197,16 +195,16 @@ resolved the DNB geometry: **design a measurement where the right answer
 wins by a wide margin, and refuse to answer when it doesn't.** On the
 15aug capture the gate refused — 140 is not 3 × 74 — and that refusal,
 initially read as "the colour guesser is broken," was the harness
-correctly reporting that its hypothesis space didn't contain the truth.
-The truth (a non-zero MNI) enlarged the space; the gate stands unchanged.
+correctly reporting that the truth wasn't in its hypothesis space. The
+truth (a non-zero MNI) enlarged the space; the gate stands unchanged.
 
 ## The operator loop as a user interface
 
 Crossing the middle gate repeatedly only works if crossing is cheap for
-the person who has the RF. GopherTrunk's answer is a family of env-gated
-replay tests: they **skip cleanly** with a one-line instruction when their
-capture is absent, and become field instruments when it's present. The
-reproduce line for the DMO harness is a single command:
+the person with the RF. GopherTrunk's answer is env-gated replay tests
+that **skip cleanly** with a one-line instruction when their capture is
+absent and become field instruments when it's present. The DMO harness
+reproduces in a single command:
 
 ```
 GT_TETRA_DMO_IQ=<capture.raw> GT_TETRA_DMO_RATE=144000 \
@@ -244,50 +242,48 @@ dominant colour" signature — and therefore the MNI blind spot — visible
 at all. The design rule: **the test harness is an interface between two
 people who each hold half the evidence**.
 
-The gate cuts the other way too, and honestly. Sometimes the capture
-proves the *decoder* innocent: the #764 endgame decimated the operator's
-10 MS/s capture with an **independent resampler**, replayed it through
-the proven 2.5 MS/s path, and reproduced the identical ~9.5 dB deficit —
-the problem was baked into the samples, front-end phase noise, not DSP
+The gate cuts the other way too. Sometimes the capture proves the
+*decoder* innocent: the #764 endgame decimated the operator's 10 MS/s
+capture with an **independent resampler**, replayed it through the proven
+2.5 MS/s path, and reproduced the identical ~9.5 dB deficit — baked into
+the samples, front-end phase noise, not DSP
 ([the full method]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }})).
-An on-air gate that can only ever indict your code is a ritual; one that
-can acquit it is a measurement.
+A gate that can only indict your code is a ritual; one that can acquit it
+is a measurement.
 
 ## Writing the status down
 
 A ladder nobody records is a ladder that gets skipped under deadline. The
-project's standing engineering notes mark every claim with its rung — the
-phrase **"still on-air-gated"** appears verbatim next to the DMO MNI fix,
-the conventional-DMR two-slot rebuild, and the SmartNet reconstruction,
-each with the exact command an operator runs to move it up a rung. Three
-concrete habits fall out:
+project's standing engineering notes mark every claim with its rung —
+**"still on-air-gated"** appears verbatim next to the DMO MNI fix, the
+conventional-DMR two-slot rebuild, and the SmartNet reconstruction, each
+with the exact command an operator runs to move it up a rung. Three
+habits fall out:
 
 - **PRs say `Refs #N`, not `Closes #N`, until the fix is verified** — so
   a merge cannot auto-close an issue whose symptom nobody has re-checked.
 - **A close-as-completed requires a human to confirm the verification**,
-  mechanically — the repo's tooling interposes the question, because
-  #764 proved good intentions don't.
-- **When you can't verify, you leave the issue open and say what's
-  blocking** — "needs the reporter's capture" is a status, not a failure,
-  and [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})
+  mechanically — because #764 proved good intentions don't.
+- **When you can't verify, leave the issue open and say what's
+  blocking** — "needs the reporter's capture" is a status, not a failure;
+  [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})
   builds the whole definition of "done" on it.
 
 ### How that principle shaped the Go code
 
 - **Verdict lines are code-reviewed prose.** The `t.Logf` strings in
   `tetra_dmo_replay_test.go` state the conclusion, the alternative, and
-  the next command — they are written for the operator, and changing one
-  is a semantic change.
+  the next command; changing one is a semantic change.
 - **Ground truth enters as input, not assumption.** `GT_TETRA_DMO_CLEAR`,
   `GT_TETRA_DMO_MCC/MNC` and `GT_TETRA_DMO_COLOUR` let the operator
   assert what they know; unset, the harness recovers what it can
   (`RecoverDMColourCode`) and says so.
 - **Confidence gates return three values, not two.** `(colour, count,
-  confident)` — and every caller of a non-confident result keeps its
+  confident)` — and a caller handed a non-confident result keeps its
   default rather than trusting a chance-floor winner.
 - **The rung is greppable.** "on-air-gated," "capture-verified," and the
   reproduce commands live in the notes and test comments, so the next
-  investigation starts knowing exactly which claims are load-bearing.
+  investigation starts knowing which claims are load-bearing.
 
 ## Where this goes next
 
@@ -295,9 +291,9 @@ Everything in this part assumes a capture exists to replay — and getting
 the *right* capture is its own discipline.
 [Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
 treats captures as first-class test fixtures: the `samples/` conventions
-and metadata sidecars, the env-gated harnesses, how to ask a reporter for
-the capture that can actually answer the question, and why you baseline
-the metrics *before* touching the code.
+and metadata sidecars, the env-gated harnesses, asking a reporter for the
+capture that can actually answer the question, and baselining the metrics
+*before* touching the code.
 
 ## FAQ
 
@@ -318,23 +314,22 @@ says something is wrong; it cannot say what.
 Record cs16 IQ on the DMO carrier, then
 `GT_TETRA_DMO_IQ=<file> GT_TETRA_DMO_RATE=<hz> go test ./cmd/gophertrunk
 -run TestTETRADMOReplay -v`. Add `GT_TETRA_DMO_CLEAR=1` if you know the
-call is unencrypted, `GT_TETRA_DMO_MCC`/`GT_TETRA_DMO_MNC` if your
-network runs a non-zero MNI, and `GT_TETRA_DMO_SCAN=1` (with
-`TestTETRADMOColourScan`) to see the full colour-yield map.
+call is unencrypted, the MCC/MNC vars if your network runs a non-zero
+MNI, and `GT_TETRA_DMO_SCAN=1` (with `TestTETRADMOColourScan`) for the
+full colour-yield map.
 
 **Isn't demanding operator confirmation slow?**
-Slower than closing on green, faster than closing wrong. Every round of
-the DMO saga that shipped a premature conclusion cost a full
-capture-request cycle to unwind — and #764's two wrong closes cost more
-credibility than any delay would have. The gate converts "we think" into
-"we measured," and the loop is engineered to make measuring cheap.
+Slower than closing on green, faster than closing wrong. Every premature
+DMO conclusion cost a full capture-request cycle to unwind, and #764's
+two wrong closes cost more credibility than any delay would have. The
+gate converts "we think" into "we measured," and the loop is engineered
+to make measuring cheap.
 
 **Does the gate apply to features, or only bug fixes?**
-Both, with the same ladder. A new decoder path (the DMO production
-pipeline, the SmartNet rebuild) ships synthetic-green and
-capture-verified, is *documented* as on-air-gated, and its issue stays
-open until the live confirmation lands. Shipping staged-but-honest beats
-shipping "done."
+Both. A new decoder path (the DMO production pipeline, the SmartNet
+rebuild) ships synthetic-green and capture-verified, is *documented* as
+on-air-gated, and its issue stays open until the live confirmation lands.
+Staged-but-honest beats "done."
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
+++ b/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
@@ -14,12 +14,11 @@ series_part: 10
 copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
 [Part 9]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})
 sent your calls out into the world; this part is about keeping them. The
-archival rig is the build for operators who treat the recordings folder as a
-record, not a cache: lossless FLAC everywhere a container exists, a queryable
-SQLite call log, IQ taps that archive the radio signal itself, vocoder-frame
-sidecars for cross-decoder verification — and a retention policy that keeps
-all of it from eating the disk. The running thread: an archive you can't
-budget is an outage on a timer.*
+archival rig treats the recordings folder as a record, not a cache: lossless
+FLAC everywhere a container exists, a queryable SQLite call log, IQ taps
+that archive the radio signal itself, vocoder-frame sidecars for
+cross-decoder verification — and a retention policy that keeps all of it
+from eating the disk. An archive you can't budget is an outage on a timer.*
 
 > **TL;DR:** `recordings.format: flac` switches per-call voice recordings to
 > lossless FLAC at roughly **half the size** of WAV for speech, and the whole
@@ -36,9 +35,9 @@ budget is an outage on a timer.*
 **Key takeaways**
 
 - **FLAC is first-class now, not a transcode step.** Every recorder that had
-  a container at all grew a `flac` option — voice recordings, wideband and
-  DDC IQ taps, auto-record, voice IQ debug — and every reader sniffs the
-  content, so a mixed wav/flac archive Just Works.
+  a container at all grew a `flac` option — voice recordings, IQ taps,
+  auto-record, voice IQ debug — and every reader sniffs the content, so a
+  mixed wav/flac archive Just Works.
 - **Archive the samples, not just the audio.** A voice file answers "what was
   said"; a `tap: ddc` IQ file answers "what was received" and replays through
   `gophertrunk replay` when a decode looks wrong. The archival rig keeps both.
@@ -48,8 +47,7 @@ budget is an outage on a timer.*
   and it's configurable per axis.
 - **Retention math is arithmetic, not vibes.** 8 kHz 16-bit voice is
   16 KB/s of talk time; 2.4 MS/s wideband IQ is 9.6 MB/s of wall time. Do
-  the multiplication before the disk does it for you — the worked table is
-  below.
+  the multiplication before the disk does it for you.
 
 ## Cheat sheet
 
@@ -76,11 +74,10 @@ budget is an outage on a timer.*
 
 Any working rig from Parts 1–9, with its storage story made deliberate. Per
 call you keep up to four artifacts: the **audio** (`.flac`), the **JSON
-sidecar** with full metadata, the optional **raw vocoder frames**
-(`write_raw`), and the optional **DSD-FME-playable sidecar**
-(`mbe_files`: `.imb` for P25 Phase 1, `.amb` for DMR/NXDN/P25 Phase 2).
-Alongside them, one SQLite database indexes every call — the same store the
-History panel and `GET /api/v1/calls` query — and, if you choose, standing IQ
+sidecar**, optional **raw vocoder frames** (`write_raw`), and the optional
+**DSD-FME-playable sidecar** (`mbe_files`: `.imb` for P25 Phase 1, `.amb`
+for DMR/NXDN/P25 Phase 2). Alongside them, one SQLite database indexes every
+call — the store behind the History panel — and, if you choose, standing IQ
 taps archive the receiver's actual input for replay. The deep-dive series
 covers each layer's internals
 ([WAV on disk]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }}),
@@ -243,23 +240,20 @@ so even a misnamed file mounts correctly.
 | Disk filling despite `retention:` configured | the standing tap is `tap: wideband`, or `files_days: 0` | Wideband is ~34 GB/h — switch the standing tap to `ddc` and leave wideband to `auto_record` with a `seconds:` cap |
 | No `retention:` lines ever | all thresholds `0` (each `0` disables that sweep), or nothing is old enough yet | Set non-zero days; force a pass via `POST /api/v1/retention/sweep` and watch for the `deleted` lines |
 | `retention: file sweep failed` / `retention: rm failed` | permissions or a vanished mount under `recordings.dir` | The sweeper logs the path — fix ownership/mount; on the Part 11 systemd build check `ReadWritePaths` |
-| A player won't open the recordings | an old external tool that predates FLAC | Everything *inside* GopherTrunk (web player, normalize, MP3 uploads) sniffs content and reads either; for stubborn external tooling, set `format:` back to `wav` — the archive can mix containers freely |
-| History shows calls with no playable audio | working as designed: `call_log_days` > `files_days` | Rows outlive files on purpose; align the two values if you want them to expire together |
-| No `.imb`/`.amb` for some calls | TETRA / ProVoice / analog have no DSD-FME playback mode | Expected — those protocols produce no sidecar; the `.raw` frames still archive if `write_raw` is on |
-| DSD-FME plays a sidecar slow and low-pitched | DSD-FME's `-w` writer stamps 8 kHz on 12 kHz synthesis | Upstream quirk, [documented]({{ '/vocoders.html' | relative_url }}) — use its per-call mode or relabel the WAV to 12 kHz |
+| A player won't open the recordings | an old external tool that predates FLAC | Everything inside GopherTrunk sniffs content and reads either; for stubborn external tooling set `format:` back to `wav` — the archive can mix containers freely |
+| History shows calls with no playable audio | by design: `call_log_days` > `files_days` | Rows outlive files on purpose; align the two values to expire together |
+| No `.imb`/`.amb` for some calls | TETRA / ProVoice / analog have no DSD-FME playback mode | Expected — those protocols produce no sidecar; `.raw` frames still archive if `write_raw` is on |
 | Recording rate isn't what you set | digital voice forces vocoder-native output | `recorder: forcing WAV rate to vocoder-native 8000` — `recordings.sample_rate` applies to analog/NBFM only |
 
 ### How this recipe shapes operator practice
 
-- **Archive the evidence, not just the product.** Every hard bug this project
-  has chased ended with "get the raw capture" — the `ddc` tap means the
-  capture already exists when the bad decode happens.
+- **Archive the evidence, not just the product.** Every hard bug this
+  project has chased ended with "get the raw capture" — the `ddc` tap means
+  the capture already exists when the bad decode happens.
 - **Let the index outlive the payload.** Cheap rows, expensive files,
-  separate clocks: query 30 days, store 14, and nobody has to choose one
-  number for both.
-- **Verify with a second decoder.** `mbe_files` exists so your archive can be
-  cross-examined; a claim about audio quality backed by a paired `.amb` is
-  measurement, not opinion.
+  separate clocks.
+- **Verify with a second decoder.** A claim about audio quality backed by a
+  paired `.amb` is measurement, not opinion.
 
 ## Variations
 
@@ -278,12 +272,11 @@ so even a misnamed file mounts correctly.
 
 ## Where this goes next
 
-An archive this good deserves better than a laptop that gets rebooted for OS
-updates. [Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
-turns the rig into a closet appliance: a Pi or mini-PC under systemd with
-hardening that actually fits an SDR daemon, Docker USB pass-through for the
-container crowd, watchdogs for dongles that fall off the bus, and the
-graceful-shutdown work that made `systemctl restart` take milliseconds
+An archive this good deserves better than a laptop rebooted for OS updates.
+[Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
+turns the rig into a closet appliance: a Pi or mini-PC under systemd,
+Docker USB pass-through, watchdogs for dongles that fall off the bus, and
+the graceful-shutdown work that made `systemctl restart` take milliseconds
 instead of thirty silent seconds.
 
 ## FAQ
@@ -296,21 +289,21 @@ upload, retention) reads both containers transparently by content sniffing.
 
 **How much disk space do SDR call recordings use?**
 At the vocoder-native 8 kHz mono, WAV costs 16 KB per second of talk time
-and FLAC about half that — so ~29 MB per hour of actual talk as FLAC. Even
-busy systems accumulate slowly; it's IQ recording (192 KB/s for a DDC
-channel tap, 9.6 MB/s for a 2.4 MS/s wideband tap) that needs a real budget.
+and FLAC about half — ~29 MB per hour of actual talk. Busy systems
+accumulate slowly; it's IQ recording (192 KB/s for a DDC channel tap,
+9.6 MB/s for a 2.4 MS/s wideband tap) that needs a real budget.
 
 **Can I replay a FLAC IQ recording like a cs16 or WAV capture?**
 Yes — `baseband.replay` and `gophertrunk replay` mount a `.flac` IQ file as
 a virtual tuner exactly like a WAV, detecting the container from the `fLaC`
-marker in the file body rather than the extension. A DDC-tap recording
-replays through the same channel-rate decode path the live daemon used.
+marker rather than the extension. A DDC-tap recording replays through the
+same channel-rate decode path the live daemon used.
 
 **Why are old calls still in History after retention deleted the files?**
-Because the sweeps are independent: `files_days` ages out audio and sidecars
-on disk while `call_log_days` ages out SQLite rows, and the config above
-deliberately keeps rows longer. Set both to the same value if you want the
-searchable record and the playable record to expire together.
+Because the sweeps are independent: `files_days` ages out audio on disk
+while `call_log_days` ages out SQLite rows, and the config above
+deliberately keeps rows longer. Set both to one value to make the
+searchable record and the playable record expire together.
 
 **Do the .imb/.amb files replace the audio recording?**
 No — they're sidecars carrying the raw vocoder frames in DSD-FME's native

--- a/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
+++ b/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
@@ -167,18 +167,15 @@ baseband:
 ```
 
 Choices worth explaining. **`format: flac`** costs CPU only at call
-finalization and buys ~2× more days per gigabyte; there is no fidelity trade
-— it decodes bit-identical. **`path_template`** is taste, but a date tree
-keeps directory sizes sane at archive scale and matches how you'll actually
-browse (concurrent same-second calls still auto-suffix `-2`, so no
-disambiguator token is needed). **`tap: ddc`** is the archival sweet spot for
-IQ: it records the down-converted channel the decoder actually consumed
-(48 kHz for the C4FM family, 144 kHz for TETRA), directly replayable with
-`gophertrunk replay -in rec.flac -protocol p25` — where a wideband tap at the
-full SDR rate is for short diagnostic grabs, not standing archival. For
-event-driven IQ instead of a standing tap, `baseband.auto_record` fires
-captures on encrypted/emergency/concurrent-call triggers and takes
-`format: flac` too.
+finalization and buys ~2× more days per gigabyte, with no fidelity trade —
+it decodes bit-identical. **`path_template`** is taste, but a date tree keeps
+directory sizes sane at archive scale. **`tap: ddc`** is the archival sweet
+spot for IQ: it records the down-converted channel the decoder actually
+consumed (48 kHz for the C4FM family, 144 kHz for TETRA), directly
+replayable with `gophertrunk replay` — where a wideband tap at the full SDR
+rate is for short diagnostic grabs, not standing archival. For event-driven
+IQ instead of a standing tap, `baseband.auto_record` fires captures on
+encrypted/emergency/concurrent-call triggers and takes `format: flac` too.
 
 **`mbe_files`** is the cross-verification lever: each call gets a `.imb`
 (P25 Phase 1) or `.amb` (DMR/NXDN/P25 Phase 2) file in DSD-FME's native
@@ -273,12 +270,11 @@ so even a misnamed file mounts correctly.
   `files_days`: vocoder frames are a few hundred bytes per second, and the
   audio can be re-synthesized from them offline via `gophertrunk decode`.
 - **Forensic maximalist.** Add `auto_record` (event-triggered wideband
-  slices) and `voice_iq_debug` (per-call channelized voice IQ, `format: flac`,
-  512 MB per-call cap) — every questionable call arrives with its own
-  replayable IQ attached.
-- **Network storage.** `recordings.dir` and `baseband.record[].dir` take
-  absolute paths, so a NAS mount works — but keep `storage.path` (SQLite) on
-  a local disk; databases and network filesystems are old enemies.
+  slices) and `voice_iq_debug` (per-call channelized voice IQ, `format: flac`)
+  — every questionable call arrives with its own replayable IQ attached.
+- **Network storage.** The `dir` keys take absolute paths, so a NAS mount
+  works — but keep `storage.path` (SQLite) on local disk; databases and
+  network filesystems are old enemies.
 
 ## Where this goes next
 
@@ -317,11 +313,13 @@ deliberately keeps rows longer. Set both to the same value if you want the
 searchable record and the playable record to expire together.
 
 **Do the .imb/.amb files replace the audio recording?**
-No — they're sidecars containing the raw vocoder frames in DSD-FME's native
+No — they're sidecars carrying the raw vocoder frames in DSD-FME's native
 container, written alongside the normal recording when
-`recordings.mbe_files: true`. Their job is independent verification
-(`dsd-fme -r call.imb` re-decodes the same frames with a different vocoder)
-and very compact archival, not playback convenience.
+`recordings.mbe_files: true`. Their job is independent verification and very
+compact archival, not playback convenience. Note DSD-FME's own `-w` writer
+stamps an 8 kHz header on 12 kHz synthesis (plays ~1.5× slow) — an upstream
+quirk documented in the [vocoders guide]({{ '/vocoders.html' | relative_url }}),
+not a sidecar defect.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
+++ b/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
@@ -162,9 +162,9 @@ baseband:
       format: flac
 ```
 
-Choices worth explaining. **`format: flac`** costs CPU only at call
-finalization and buys ~2× more days per gigabyte, with no fidelity trade —
-it decodes bit-identical. **`path_template`** is taste, but a date tree keeps
+Choices worth explaining. **`format: flac`** costs a little CPU per call
+and buys ~2× more days per gigabyte, with no fidelity trade — it decodes
+bit-identical. **`path_template`** is taste, but a date tree keeps
 directory sizes sane at archive scale. **`tap: ddc`** is the archival sweet
 spot for IQ: it records the down-converted channel the decoder actually
 consumed (48 kHz for the C4FM family, 144 kHz for TETRA), directly

--- a/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
+++ b/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
@@ -1,0 +1,331 @@
+---
+title: "The Operator's Cookbook, Part 10: The Archival Rig — FLAC, Retention & the Call Log"
+description: The keep-everything GopherTrunk build — lossless FLAC voice recordings at roughly half the size of WAV, FLAC IQ taps, the SQLite call log, retention sweeps that actually run, DSD-FME-playable vocoder sidecars, and disk-budget math with real byte rates.
+category: tutorials
+keywords: scanner call recording archive, flac scanner recordings, sdr iq recording flac, sqlite call log scanner, recording retention policy sdr, dsd-fme imb amb files, disk space sdr recording, trunking call archive setup, gophertrunk cookbook
+tags: [operator-cookbook, flac, recordings, retention, sqlite, archiving]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 10
+---
+
+*Part 10 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 9]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})
+sent your calls out into the world; this part is about keeping them. The
+archival rig is the build for operators who treat the recordings folder as a
+record, not a cache: lossless FLAC everywhere a container exists, a queryable
+SQLite call log, IQ taps that archive the radio signal itself, vocoder-frame
+sidecars for cross-decoder verification — and a retention policy that keeps
+all of it from eating the disk. The running thread: an archive you can't
+budget is an outage on a timer.*
+
+> **TL;DR:** `recordings.format: flac` switches per-call voice recordings to
+> lossless FLAC at roughly **half the size** of WAV for speech, and the whole
+> downstream chain — web playback, loudness normalize (FLAC-in/FLAC-out),
+> MP3 uploads, the retention sweeper — reads either container by **content
+> sniffing**, never by extension. `baseband.record[].format: flac` does the
+> same for IQ taps (~30–50% smaller, mounts back as a virtual tuner
+> identically), and `tap: ddc` records the channelized stream at orders of
+> magnitude less than wideband. `storage.path` is the SQLite call log behind
+> the History panel; the `retention:` block sweeps rows (`call_log_days`),
+> decoder logs (`log_days`) and files (`files_days`) on an `interval`, logging
+> `retention: deleted recordings count=N` as it goes.
+
+**Key takeaways**
+
+- **FLAC is first-class now, not a transcode step.** Every recorder that had
+  a container at all grew a `flac` option — voice recordings, wideband and
+  DDC IQ taps, auto-record, voice IQ debug — and every reader sniffs the
+  content, so a mixed wav/flac archive Just Works.
+- **Archive the samples, not just the audio.** A voice file answers "what was
+  said"; a `tap: ddc` IQ file answers "what was received" and replays through
+  `gophertrunk replay` when a decode looks wrong. The archival rig keeps both.
+- **The call log is the index; files are the payload.** SQLite rows survive
+  after `files_days` sweeps the audio, so History can show a 30-day record of
+  a system while only 14 days of it is playable — that split is a feature,
+  and it's configurable per axis.
+- **Retention math is arithmetic, not vibes.** 8 kHz 16-bit voice is
+  16 KB/s of talk time; 2.4 MS/s wideband IQ is 9.6 MB/s of wall time. Do
+  the multiplication before the disk does it for you — the worked table is
+  below.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| FLAC voice recordings | lossless, ~half of WAV for speech | `recordings.format: flac` |
+| FLAC IQ taps | ~30–50% smaller, replays identically | `baseband.record[].format: flac` (also `auto_record.format`, `voice_iq_debug.format`) |
+| Small IQ archives | channelized stream, not the whole band | `baseband.record[].tap: ddc` |
+| Call log database | SQLite behind History + `/api/v1/calls` | `storage.path`, [call-log deep dive]({{ '/blog/deep-dives/recording-streaming-10-call-log-sqlite/' | relative_url }}) |
+| Retention sweeps | rows, decoder logs, files — independent clocks | `retention.call_log_days`, `log_days`, `files_days`, `interval` |
+| Vocoder-frame sidecars | DSD-FME-playable `.imb`/`.amb` per call | `recordings.mbe_files`, [vocoders guide]({{ '/vocoders.html' | relative_url }}) |
+| Naming & layout | date trees, freq-in-filename | `recordings.filename_template`, `path_template` |
+
+## In this post
+
+- **What you're building** — a self-pruning archive of audio, metadata and IQ.
+- **The shopping list** — one real purchase: the disk.
+- **The config** — FLAC everywhere, retention clocks, sidecars.
+- **The disk budget** — real byte rates for every stream you can archive.
+- **First run — what healthy looks like** — sweep lines and FLAC files.
+- **When it doesn't work** — disks filling, sweeps not sweeping, players balking.
+
+## What you're building
+
+Any working rig from Parts 1–9, with its storage story made deliberate. Per
+call you keep up to four artifacts: the **audio** (`.flac`), the **JSON
+sidecar** with full metadata, the optional **raw vocoder frames**
+(`write_raw`), and the optional **DSD-FME-playable sidecar**
+(`mbe_files`: `.imb` for P25 Phase 1, `.amb` for DMR/NXDN/P25 Phase 2).
+Alongside them, one SQLite database indexes every call — the same store the
+History panel and `GET /api/v1/calls` query — and, if you choose, standing IQ
+taps archive the receiver's actual input for replay. The deep-dive series
+covers each layer's internals
+([WAV on disk]({{ '/blog/deep-dives/recording-streaming-05-wav-on-disk/' | relative_url }}),
+[sidecars & naming]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }}),
+[retention]({{ '/blog/deep-dives/recording-streaming-11-retention-housekeeping/' | relative_url }}));
+this recipe assembles them into one build.
+
+The FLAC support is new and worth a paragraph of trust-building: it isn't a
+post-processing transcode — the recorder writes FLAC natively through one
+shared encode core, and everything downstream identifies the container by
+sniffing the `fLaC` marker in the file. Loudness normalization rewrites
+FLAC-in/FLAC-out, the broadcast MP3 transcode from Part 9 reads it, the
+`/calls/{id}/audio` endpoint serves it as `audio/flac`, and the retention
+sweeper counts it. Duration and dead-key accounting use *uncompressed* PCM
+byte counts, so call bookkeeping is container-independent. Two deliberate
+exceptions stay raw: `diversity_capture` stays cs16 (its branch-alignment
+invariant depends on it) and the hunt's survey capture stays f32.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 252" width="680" height="252" role="img" aria-label="Storage map of the archival rig: one decoded call fans into four on-disk artifacts, a FLAC audio file, a JSON sidecar, raw vocoder frames and a DSD-FME sidecar, plus one row in the SQLite call log; separately the SDR IQ stream feeds a wideband or DDC baseband record tap writing FLAC IQ; a retention sweeper with three independent clocks, files at 14 days, call rows at 30 days and decoder logs at 30 days, prunes each store on its own schedule">
+  <rect x="10" y="30" width="96" height="36" rx="4" fill="none" stroke="currentColor"/>
+  <text x="58" y="52" text-anchor="middle" fill="currentColor" font-size="10">decoded call</text>
+  <rect x="10" y="150" width="96" height="36" rx="4" fill="none" stroke="currentColor"/>
+  <text x="58" y="166" text-anchor="middle" fill="currentColor" font-size="10">SDR IQ</text>
+  <text x="58" y="179" text-anchor="middle" fill="var(--fg-muted)" font-size="9">2.4 MS/s</text>
+  <line x1="106" y1="48" x2="150" y2="48" stroke="currentColor"/>
+  <rect x="150" y="16" width="230" height="104" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="265" y="32" text-anchor="middle" fill="var(--accent)" font-size="10">per call — recordings/&lt;system&gt;/&lt;tg&gt;/</text>
+  <text x="265" y="50" text-anchor="middle" fill="currentColor" font-size="10">audio .flac (~½ of WAV)</text>
+  <text x="265" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="9">.json sidecar · .raw frames</text>
+  <text x="265" y="82" text-anchor="middle" fill="var(--fg-muted)" font-size="9">.imb / .amb (mbe_files)</text>
+  <text x="265" y="104" text-anchor="middle" fill="currentColor" font-size="10">+ one row in calls.db (SQLite)</text>
+  <line x1="106" y1="168" x2="150" y2="168" stroke="currentColor"/>
+  <rect x="150" y="140" width="230" height="60" rx="6" fill="none" stroke="currentColor"/>
+  <text x="265" y="158" text-anchor="middle" fill="currentColor" font-size="10">baseband.record tap</text>
+  <text x="265" y="174" text-anchor="middle" fill="var(--fg-muted)" font-size="9">wideband: whole band, ~34 GB/h wav</text>
+  <text x="265" y="188" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ddc: one channel, ~0.7 GB/h — format: flac</text>
+  <rect x="440" y="52" width="226" height="130" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="553" y="72" text-anchor="middle" fill="var(--fg-muted)" font-size="10">retention sweeper (every interval)</text>
+  <text x="553" y="96" text-anchor="middle" fill="currentColor" font-size="10">files_days: 14 → audio + sidecars</text>
+  <text x="553" y="118" text-anchor="middle" fill="currentColor" font-size="10">call_log_days: 30 → calls.db rows</text>
+  <text x="553" y="140" text-anchor="middle" fill="currentColor" font-size="10">log_days: 30 → decoder log tables</text>
+  <text x="553" y="164" text-anchor="middle" fill="var(--fg-muted)" font-size="9">0 on any axis = that sweep disabled</text>
+  <line x1="380" y1="68" x2="440" y2="90" stroke="var(--fg-muted)"/>
+  <line x1="380" y1="104" x2="440" y2="115" stroke="var(--fg-muted)"/>
+  <text x="340" y="234" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the index outlives the payload: History still shows day-30 calls whose audio was swept at day 14</text>
+</svg>
+<figcaption>Three stores, three clocks: audio artifacts, database rows and decoder logs each age out on their own schedule, so the searchable record outlives the playable one.</figcaption>
+</figure>
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| Storage | ~$50+ | an SSD or spinning disk sized by the budget table below; for an [SBC build]({{ '/gophertrunk-sbc-build/' | relative_url }}), external — don't archive to the [SD card]({{ '/reference/sd-card/' | relative_url }}) that boots the box |
+| Everything else | $0 | any rig from Parts 1–9 |
+
+## The config
+
+```yaml
+storage:
+  path: "../data/calls.db"
+
+recordings:
+  dir: "../recordings"
+  format: flac                 # lossless, ~half the size of wav for speech
+  write_raw: true              # .raw vocoder-frame sidecar per call
+  mbe_files: true              # DSD-FME-playable .imb/.amb sidecars
+  filename_template: "{date}_{time}_{tg}_{freq}"
+  path_template: "{system}/{year}/{month}/{day}"   # date-tree layout
+
+retention:
+  files_days: 14               # audio + sidecars swept after 14 days
+  call_log_days: 30            # SQLite call rows kept twice as long
+  log_days: 30                 # pager/aprs/vessel/… decoder-log tables
+  interval: "1h"               # sweeper cadence; 0 on any *_days disables it
+
+baseband:
+  record:
+    - serial: "00000001"       # the control dongle from Part 1
+      dir: "../iq/"
+      tap: ddc                 # the channelized CC stream, not the whole band
+      format: flac
+```
+
+Choices worth explaining. **`format: flac`** costs CPU only at call
+finalization and buys ~2× more days per gigabyte; there is no fidelity trade
+— it decodes bit-identical. **`path_template`** is taste, but a date tree
+keeps directory sizes sane at archive scale and matches how you'll actually
+browse (concurrent same-second calls still auto-suffix `-2`, so no
+disambiguator token is needed). **`tap: ddc`** is the archival sweet spot for
+IQ: it records the down-converted channel the decoder actually consumed
+(48 kHz for the C4FM family, 144 kHz for TETRA), directly replayable with
+`gophertrunk replay -in rec.flac -protocol p25` — where a wideband tap at the
+full SDR rate is for short diagnostic grabs, not standing archival. For
+event-driven IQ instead of a standing tap, `baseband.auto_record` fires
+captures on encrypted/emergency/concurrent-call triggers and takes
+`format: flac` too.
+
+**`mbe_files`** is the cross-verification lever: each call gets a `.imb`
+(P25 Phase 1) or `.amb` (DMR/NXDN/P25 Phase 2) file in DSD-FME's native
+container, so `dsd-fme -f1 -w out.wav -r call.imb` re-decodes your call with
+an entirely independent vocoder — the workflow the
+[vocoders guide]({{ '/vocoders.html' | relative_url }}) documents, and the
+one that let us measure GopherTrunk's AMBE+2 high-band deficit against
+mbelib frame-for-frame. TETRA and ProVoice have no DSD-FME playback mode and
+produce none.
+
+## The disk budget
+
+The rates are exact; the durations are what they buy on a **1 TB** disk:
+
+| Stream | Rate | 1 TB holds |
+|---|---|---|
+| Voice WAV (8 kHz, 16-bit mono) | 16 KB/s of *talk time* | ~17,000 h of talk |
+| Voice FLAC | ~8 KB/s of talk time | ~35,000 h of talk |
+| DDC IQ tap, C4FM family (48 kHz cs16-in-container) | 192 KB/s wall time | ~60 days continuous (WAV); ~3–4 months FLAC |
+| DDC IQ tap, TETRA (144 kHz) | 576 KB/s wall time | ~20 days (WAV); ~1 month FLAC |
+| Wideband IQ tap (2.4 MS/s) | 9.6 MB/s wall time | ~29 h (WAV); ~40–60 h FLAC |
+
+Two readings. First, **voice archives are effectively free**: a busy system
+doing two hours of actual talk per day writes ~58 MB/day as FLAC —
+`files_days: 0` (never sweep audio) is legitimate on any modern disk, and
+the config above sweeps files mainly to bound the IQ tap. Second,
+**wideband IQ is a different regime entirely** — three orders of magnitude —
+which is why the standing tap is `ddc` and wideband belongs to the
+event-driven `auto_record` with its `seconds:` cap. The IQ FLAC savings are
+real but signal-dependent; budget on the WAV number and treat compression as
+margin — the [capture-discipline]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})
+habit.
+
+## First run — what healthy looks like
+
+Restart and let a few calls land. The recorder lines look exactly like
+Part 1's, with the extension telling you the container took:
+
+```
+INF recorder: call started device=... wav=../recordings/Metro-P25/2026/09/12/20260912_141212_9001_857262500.flac tg=9001 vocoder=imbe
+INF recorder: call ended device=... duration=6.42s reason=released
+```
+
+Play the call in the web History panel (served as `audio/flac`), and confirm
+the `.json`, `.raw` and `.imb`/`.amb` siblings landed next to it. Then, within
+the first `interval` (and every hour after), the sweeper reports — only when
+it deletes something:
+
+```
+INF retention: deleted recordings count=214
+INF retention: deleted call rows count=3120
+INF retention: deleted log rows table=pager_log count=87
+```
+
+Silence from the sweeper on a young archive is normal — nothing has aged
+past a threshold yet; `POST /api/v1/retention/sweep` forces a pass. Finally
+check the IQ tap: a growing `.flac` in `../iq/` that `gophertrunk replay`
+accepts — the replay driver sniffs the `fLaC` marker, never the extension,
+so even a misnamed file mounts correctly.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Disk filling despite `retention:` configured | the standing tap is `tap: wideband`, or `files_days: 0` | Wideband is ~34 GB/h — switch the standing tap to `ddc` and leave wideband to `auto_record` with a `seconds:` cap |
+| No `retention:` lines ever | all thresholds `0` (each `0` disables that sweep), or nothing is old enough yet | Set non-zero days; force a pass via `POST /api/v1/retention/sweep` and watch for the `deleted` lines |
+| `retention: file sweep failed` / `retention: rm failed` | permissions or a vanished mount under `recordings.dir` | The sweeper logs the path — fix ownership/mount; on the Part 11 systemd build check `ReadWritePaths` |
+| A player won't open the recordings | an old external tool that predates FLAC | Everything *inside* GopherTrunk (web player, normalize, MP3 uploads) sniffs content and reads either; for stubborn external tooling, set `format:` back to `wav` — the archive can mix containers freely |
+| History shows calls with no playable audio | working as designed: `call_log_days` > `files_days` | Rows outlive files on purpose; align the two values if you want them to expire together |
+| No `.imb`/`.amb` for some calls | TETRA / ProVoice / analog have no DSD-FME playback mode | Expected — those protocols produce no sidecar; the `.raw` frames still archive if `write_raw` is on |
+| DSD-FME plays a sidecar slow and low-pitched | DSD-FME's `-w` writer stamps 8 kHz on 12 kHz synthesis | Upstream quirk, [documented]({{ '/vocoders.html' | relative_url }}) — use its per-call mode or relabel the WAV to 12 kHz |
+| Recording rate isn't what you set | digital voice forces vocoder-native output | `recorder: forcing WAV rate to vocoder-native 8000` — `recordings.sample_rate` applies to analog/NBFM only |
+
+### How this recipe shapes operator practice
+
+- **Archive the evidence, not just the product.** Every hard bug this project
+  has chased ended with "get the raw capture" — the `ddc` tap means the
+  capture already exists when the bad decode happens.
+- **Let the index outlive the payload.** Cheap rows, expensive files,
+  separate clocks: query 30 days, store 14, and nobody has to choose one
+  number for both.
+- **Verify with a second decoder.** `mbe_files` exists so your archive can be
+  cross-examined; a claim about audio quality backed by a paired `.amb` is
+  measurement, not opinion.
+
+## Variations
+
+- **Maximum-compatibility archive.** `format: wav` everywhere and accept 2×
+  the bytes — every audio tool since the 1990s opens it. Mixing is fine:
+  readers sniff per file, so switching formats mid-archive breaks nothing.
+- **Frames-only cold storage.** `write_raw` + `mbe_files` with aggressive
+  `files_days`: vocoder frames are a few hundred bytes per second, and the
+  audio can be re-synthesized from them offline via `gophertrunk decode`.
+- **Forensic maximalist.** Add `auto_record` (event-triggered wideband
+  slices) and `voice_iq_debug` (per-call channelized voice IQ, `format: flac`,
+  512 MB per-call cap) — every questionable call arrives with its own
+  replayable IQ attached.
+- **Network storage.** `recordings.dir` and `baseband.record[].dir` take
+  absolute paths, so a NAS mount works — but keep `storage.path` (SQLite) on
+  a local disk; databases and network filesystems are old enemies.
+
+## Where this goes next
+
+An archive this good deserves better than a laptop that gets rebooted for OS
+updates. [Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
+turns the rig into a closet appliance: a Pi or mini-PC under systemd with
+hardening that actually fits an SDR daemon, Docker USB pass-through for the
+container crowd, watchdogs for dongles that fall off the bus, and the
+graceful-shutdown work that made `systemctl restart` take milliseconds
+instead of thirty silent seconds.
+
+## FAQ
+
+**Should I record scanner calls as FLAC or WAV?**
+FLAC, unless a specific external tool you depend on can't read it. It's
+lossless — bit-identical audio at roughly half the size for speech — and
+GopherTrunk's entire downstream chain (web playback, loudness normalize, MP3
+upload, retention) reads both containers transparently by content sniffing.
+
+**How much disk space do SDR call recordings use?**
+At the vocoder-native 8 kHz mono, WAV costs 16 KB per second of talk time
+and FLAC about half that — so ~29 MB per hour of actual talk as FLAC. Even
+busy systems accumulate slowly; it's IQ recording (192 KB/s for a DDC
+channel tap, 9.6 MB/s for a 2.4 MS/s wideband tap) that needs a real budget.
+
+**Can I replay a FLAC IQ recording like a cs16 or WAV capture?**
+Yes — `baseband.replay` and `gophertrunk replay` mount a `.flac` IQ file as
+a virtual tuner exactly like a WAV, detecting the container from the `fLaC`
+marker in the file body rather than the extension. A DDC-tap recording
+replays through the same channel-rate decode path the live daemon used.
+
+**Why are old calls still in History after retention deleted the files?**
+Because the sweeps are independent: `files_days` ages out audio and sidecars
+on disk while `call_log_days` ages out SQLite rows, and the config above
+deliberately keeps rows longer. Set both to the same value if you want the
+searchable record and the playable record to expire together.
+
+**Do the .imb/.amb files replace the audio recording?**
+No — they're sidecars containing the raw vocoder frames in DSD-FME's native
+container, written alongside the normal recording when
+`recordings.mbe_files: true`. Their job is independent verification
+(`dsd-fme -r call.imb` re-decodes the same frames with a different vocoder)
+and very compact archival, not playback convenience.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: Sharing the Feed — Broadcastify, OpenMHz & Friends]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})
+· Next →
+[Part 11: The Closet Appliance — Pi, systemd & Docker]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})

--- a/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
+++ b/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
@@ -42,9 +42,8 @@ from eating the disk. An archive you can't budget is an outage on a timer.*
   said"; a `tap: ddc` IQ file answers "what was received" and replays through
   `gophertrunk replay` when a decode looks wrong. The archival rig keeps both.
 - **The call log is the index; files are the payload.** SQLite rows survive
-  after `files_days` sweeps the audio, so History can show a 30-day record of
-  a system while only 14 days of it is playable — that split is a feature,
-  and it's configurable per axis.
+  after `files_days` sweeps the audio, so History can show a 30-day record
+  while only 14 days of it stays playable — a feature, configurable per axis.
 - **Retention math is arithmetic, not vibes.** 8 kHz 16-bit voice is
   16 KB/s of talk time; 2.4 MS/s wideband IQ is 9.6 MB/s of wall time. Do
   the multiplication before the disk does it for you.
@@ -208,8 +207,8 @@ habit.
 
 ## First run — what healthy looks like
 
-Restart and let a few calls land. The recorder lines look exactly like
-Part 1's, with the extension telling you the container took:
+Restart and let a few calls land. The recorder lines look like Part 1's,
+the extension telling you the container took:
 
 ```
 INF recorder: call started device=... wav=../recordings/Metro-P25/2026/09/12/20260912_141212_9001_857262500.flac tg=9001 vocoder=imbe
@@ -284,8 +283,7 @@ instead of thirty silent seconds.
 **Should I record scanner calls as FLAC or WAV?**
 FLAC, unless a specific external tool you depend on can't read it. It's
 lossless — bit-identical audio at roughly half the size for speech — and
-GopherTrunk's entire downstream chain (web playback, loudness normalize, MP3
-upload, retention) reads both containers transparently by content sniffing.
+GopherTrunk's entire downstream chain reads both containers transparently.
 
 **How much disk space do SDR call recordings use?**
 At the vocoder-native 8 kHz mono, WAV costs 16 KB per second of talk time

--- a/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
+++ b/docs/_posts/2026-09-12-operator-cookbook-10-archival-rig.md
@@ -25,11 +25,11 @@ from eating the disk. An archive you can't budget is an outage on a timer.*
 > downstream chain — web playback, loudness normalize (FLAC-in/FLAC-out),
 > MP3 uploads, the retention sweeper — reads either container by **content
 > sniffing**, never by extension. `baseband.record[].format: flac` does the
-> same for IQ taps (~30–50% smaller, mounts back as a virtual tuner
-> identically), and `tap: ddc` records the channelized stream at orders of
-> magnitude less than wideband. `storage.path` is the SQLite call log behind
-> the History panel; the `retention:` block sweeps rows (`call_log_days`),
-> decoder logs (`log_days`) and files (`files_days`) on an `interval`, logging
+> same for IQ taps (~30–50% smaller, mounts back as a virtual tuner), and
+> `tap: ddc` records the channelized stream at orders of magnitude less than
+> wideband. `storage.path` is the SQLite call log behind History; the
+> `retention:` block sweeps rows (`call_log_days`), decoder logs (`log_days`)
+> and files (`files_days`) on an `interval`, logging
 > `retention: deleted recordings count=N` as it goes.
 
 **Key takeaways**
@@ -38,9 +38,9 @@ from eating the disk. An archive you can't budget is an outage on a timer.*
   a container at all grew a `flac` option — voice recordings, IQ taps,
   auto-record, voice IQ debug — and every reader sniffs the content, so a
   mixed wav/flac archive Just Works.
-- **Archive the samples, not just the audio.** A voice file answers "what was
-  said"; a `tap: ddc` IQ file answers "what was received" and replays through
-  `gophertrunk replay` when a decode looks wrong. The archival rig keeps both.
+- **Archive the samples, not just the audio.** A voice file answers "what
+  was said"; a `tap: ddc` IQ file answers "what was received" and replays
+  when a decode looks wrong. This rig keeps both.
 - **The call log is the index; files are the payload.** SQLite rows survive
   after `files_days` sweeps the audio, so History can show a 30-day record
   while only 14 days of it stays playable — a feature, configurable per axis.
@@ -131,7 +131,7 @@ invariant depends on it) and the hunt's survey capture stays f32.
 
 | Item | Price (rough) | Notes |
 |---|---|---|
-| Storage | ~$50+ | an SSD or spinning disk sized by the budget table below; for an [SBC build]({{ '/gophertrunk-sbc-build/' | relative_url }}), external — don't archive to the [SD card]({{ '/reference/sd-card/' | relative_url }}) that boots the box |
+| Storage | ~$50+ | an SSD or spinning disk sized by the budget table below; on an [SBC build]({{ '/gophertrunk-sbc-build/' | relative_url }}), external — never the boot [SD card]({{ '/reference/sd-card/' | relative_url }}) |
 | Everything else | $0 | any rig from Parts 1–9 |
 
 ## The config
@@ -215,10 +215,9 @@ INF recorder: call started device=... wav=../recordings/Metro-P25/2026/09/12/202
 INF recorder: call ended device=... duration=6.42s reason=released
 ```
 
-Play the call in the web History panel (served as `audio/flac`), and confirm
-the `.json`, `.raw` and `.imb`/`.amb` siblings landed next to it. Then, within
-the first `interval` (and every hour after), the sweeper reports — only when
-it deletes something:
+Play the call in the web History panel (served as `audio/flac`) and confirm
+the `.json`, `.raw` and `.imb`/`.amb` siblings landed next to it. Then, each
+`interval`, the sweeper reports — only when it deletes something:
 
 ```
 INF retention: deleted recordings count=214
@@ -260,8 +259,8 @@ so even a misnamed file mounts correctly.
   the bytes — every audio tool since the 1990s opens it. Mixing is fine:
   readers sniff per file, so switching formats mid-archive breaks nothing.
 - **Frames-only cold storage.** `write_raw` + `mbe_files` with aggressive
-  `files_days`: vocoder frames are a few hundred bytes per second, and the
-  audio can be re-synthesized from them offline via `gophertrunk decode`.
+  `files_days`: vocoder frames cost a few hundred bytes per second, and
+  `gophertrunk decode` re-synthesizes audio from them offline.
 - **Forensic maximalist.** Add `auto_record` (event-triggered wideband
   slices) and `voice_iq_debug` (per-call channelized voice IQ, `format: flac`)
   — every questionable call arrives with its own replayable IQ attached.

--- a/docs/_posts/2026-09-12-p25-end-to-end-10-sites-roaming.md
+++ b/docs/_posts/2026-09-12-p25-end-to-end-10-sites-roaming.md
@@ -1,0 +1,346 @@
+---
+title: "P25 End to End, Part 10: Sites, WACNs & Roaming a Multi-Site System"
+description: The P25 identity ladder — a 20-bit WACN, 12-bit System ID, RFSS and Site — and the status broadcasts that carry it in TSBK and multi-block AMBT forms. How GopherTrunk votes a system's identity out of noisy frames, accumulates a neighbour map, and roams by hunting control channels.
+category: deep-dives
+keywords: p25 wacn system id, rfss status broadcast, p25 adjacent site status, p25 neighbor sites, multi-site p25 scanner, p25 network status broadcast, p25 control channel hunting, p25 site roaming, gophertrunk p25
+tags: [p25-end-to-end, p25, trunking, multi-site, topology, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 10
+---
+
+*Part 10 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
+[Part 9]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }})
+pinned down where "encrypted" lives on the air and what policy does about
+it. This part climbs above any single call, to the question a P25 network
+answers continuously on its control channel: *who am I, and who are my
+neighbours?* The identity ladder from WACN down to Site, the broadcasts
+that carry it in two different frame formats, and how GopherTrunk turns a
+stream of individually untrustworthy frames into a site map an operator can
+roam by.*
+
+> **TL;DR:** A P25 site names itself with a ladder of identifiers — a
+> 20-bit **WACN**, 12-bit **System ID**, 8-bit **RFSS** and **Site** — and
+> repeats them in four status broadcasts: Network Status (0x3B), RFSS
+> Status (0x3A), Secondary Control Channel (0x39), Adjacent Site Status
+> (0x3C). Each also exists in a multi-block **AMBT** form
+> ([Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})),
+> and some systems broadcast their richest data — the WACN, most of the
+> neighbour list — *only* that way. `phase1.NetworkModel`
+> (`internal/radio/p25/phase1/network.go`) accumulates them with a
+> **majority vote** on identity scalars, because a corrupt-but-CRC-passing
+> TSBK must not poison the reported identity. Above it,
+> `trunking.SiteTracker` folds every `KindSiteUpdate` into a per-system
+> site roster (`GET /api/v1/sites`, issue #698) — and roaming falls out of
+> control-channel hunting (`System.HuntOrder`), not a feature anyone
+> built.
+
+**Key takeaways**
+
+- **Identity arrives in fragments, on a schedule the system chooses.** No
+  single frame carries the whole ladder: 0x3B has the WACN but no
+  RFSS/Site, 0x3A the reverse. A decoder that waits for one authoritative
+  message reports blanks forever.
+- **The same broadcast wears two frames, and one may be missing.** Every
+  status message has a TSBK and an AMBT form with complementary fields.
+  GopherTrunk once decoded only the TSBK form — and showed one neighbour
+  where SDRtrunk listed twelve.
+- **CRC-clean is not true.** Identity scalars are resolved by majority
+  vote, zeros never get a vote, and a neighbour merge keeps whichever half
+  a new observation lacks — corroboration, not last-write-wins.
+- **Roaming is a fold, not a feature.** The site tracker accumulates every
+  site the hunter ever locks; hopping the configured control channels *is*
+  the roam, biased toward the last-known-good frequency.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Identity + neighbour accumulator | votes WACN/SysID/RFSS/Site, merges neighbours | `internal/radio/p25/phase1/network.go` (`NetworkModel`) |
+| Status broadcast parsers | TSBK 0x3B/0x3A/0x39/0x3C + AMBT twins | `phase1/tsbk.go`, `phase1/mbt.go` (`ApplyMBT*` folds) |
+| Protocol-neutral snapshot | identity + neighbours + band plan, per system | `internal/trunking/topology.go` (`TopologySnapshot`) |
+| Live site roster | every site seen, keyed (system, RFSS, site) | `internal/trunking/site_tracker.go` (`SiteTracker`, `GET /api/v1/sites`) |
+| Network report | SDRtrunk-style rendered topology | `internal/trunking/network_report.go` (`RenderNeighborLines`) |
+| CC hunting order | last-known-good CC first, then configured order | `internal/trunking/site.go` (`System.HuntOrder`), `trunking.Hunter` |
+| Wrong-site instrument | carrier offset of the locked CC vs tuned centre | `SiteInfo.ControlChannelCarrierOffsetHz` (issue #815) |
+
+## In this post
+
+- **The identity ladder** — WACN, System, RFSS, Site, and what each scopes.
+- **Four broadcasts, two frame formats** — and the systems that only send one.
+- **Votes, not last-write-wins** — surviving corrupt-but-CRC-passing frames.
+- **The neighbour map** — merging complementary halves of the same site.
+- **Roaming is a fold** — the site tracker, the hunter, and the #815 instrument.
+
+## The identity ladder
+
+Four numbers, nested like postal geography:
+
+| Field | Width | Scopes | Carried by |
+|---|---|---|---|
+| WACN | 20 bits | a wide-area network (one licensee's whole P25 world) | Network Status (0x3B) |
+| System ID | 12 bits | one trunked system inside the WACN | 0x3B, 0x3A, and every 0x3C neighbour |
+| RFSS | 8 bits | an RF sub-system — a cluster of sites | RFSS Status (0x3A) |
+| Site | 8 bits | one physical site inside the RFSS | 0x3A, plus 0x3C for neighbours |
+
+A radio's fully-qualified home is WACN + System ID; RFSS + Site say *where
+in the network* it currently is. None of this is the NAC from
+[Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }})
+— the NAC is a 12-bit per-frame access colour code that gates which frames
+a receiver accepts, and while operators often align it with the site, it
+identifies nothing beyond "this transmission belongs here." The
+[wacn]({{ '/reference/wacn/' | relative_url }}) and
+[rfss]({{ '/reference/rfss/' | relative_url }}) reference pages carry the
+field-guide versions;
+[Trunking Engine Part 10]({{ '/blog/deep-dives/trunking-engine-10-sites-topology-roaming/' | relative_url }})
+covers the engine-side machinery this part grounds in the P25 bits.
+
+The point of the ladder is roaming: a radio camped on a fading site needs
+to know which *adjacent* sites carry the same system, on which control
+channels — exactly the information a scanner wants for the same reason.
+
+## Four broadcasts, two frame formats
+
+A P25 control channel repeats a rotation of status broadcasts between
+grants
+([Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})):
+
+| Broadcast | TSBK opcode | What it contributes |
+|---|---|---|
+| Network Status | 0x3B | WACN, System ID, primary CC channel |
+| RFSS Status | 0x3A | System ID, RFSS, Site, primary CC |
+| Secondary CC | 0x39 (+ 0x29 explicit) | additional control channels of this site |
+| Adjacent Site Status | 0x3C | one neighbour: RFSS, Site, its CC, CFVA flags |
+
+Every one of them also exists in the **AMBT** form — the same semantic
+message carried in a multi-block PDU
+([Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }}))
+— and the two forms are not redundant copies. The AMBT Adjacent Site
+Status is the only form that names the neighbour's **explicit uplink
+channel**; the TSBK form is the only one carrying the CFVA flags and
+service class. And many systems, notably Motorola, broadcast most or all
+of their neighbour list — and sometimes the WACN itself — **only** in AMBT
+form.
+
+That asymmetry is the war story this series keeps returning to. GopherTrunk
+originally decoded only the TSBK forms and logged every control-channel PDU
+as `non-control DUID duid=PDU` — so an operator watched SDRtrunk list
+**twelve neighbours with uplinks in fifteen seconds** while GT showed one
+neighbour and "No Network Status Broadcast yet" on the same carrier. The
+frames carrying everything they were missing were being counted as spam.
+The fix is `mbt.go`'s AMBT decoder, validated against OP25's `process_PDU`
+and SDRtrunk's AMBTC message classes, feeding the same accumulator through
+the `ApplyMBT*` folds. One detail worth repeating from Part 4 because it
+decides real frequencies: an explicit uplink channel resolves as plain
+base + spacing with **no transmit offset** — the uplink channel number
+already encodes the uplink frequency
+([Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})
+owns that arithmetic).
+
+## Votes, not last-write-wins
+
+Every frame reaching the accumulator has already survived trellis decode
+and CRC
+([Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})).
+That is not enough. A CRC-CCITT16 occasionally passes on corrupted payload,
+and the control-channel state machine evaluates a grid of NID/TSBK
+alignment hypotheses per frame, multiplying the exposure. A single
+corrupt-but-CRC-passing frame must not rewrite the reported WACN or inject
+a phantom neighbour. So identity scalars are **voted**:
+
+```go
+// internal/radio/p25/phase1/network.go (shape)
+func (m *NetworkModel) ApplyNetworkStatus(n NetworkStatusBroadcast) {
+    /* … lock, ensure maps … */
+    // WACN/SysID are meaningless at zero (absent), so a zero never gets
+    // a vote — it cannot out-rank a real value seen the same number of times.
+    if n.WACN != 0 {
+        m.wacnVotes[n.WACN]++
+    }
+    if n.SystemID != 0 {
+        m.sysidVotes[n.SystemID]++
+    }
+    m.votePrimary(n.ChannelID, n.ChannelNumber)
+}
+
+// Snapshot reports the most-observed value per field.
+func majority[K ~uint8 | ~uint16 | ~uint32](votes map[K]int) K { /* … */ }
+```
+
+The asymmetries are deliberate. A lone observation is still surfaced —
+latency matters on a fresh lock — but a repeated correct value out-votes a
+one-shot wrong one. Zero never votes for WACN/SysID/LRA (zero means
+"absent" there) while **RFSS 0 and Site 0 always count**, because RFSS 0 is
+a real, common value. Neighbours and band-plan slots surface on first
+sighting, de-duplicated, matching OP25's latency — the identity vote
+already absorbs the one-shot corruption that actually hurts.
+
+Two quieter tricks fill gaps real systems leave. An Adjacent Site broadcast
+votes the *neighbour's* System ID into our own tally — every site of a P25
+system shares one System ID, so a neighbour names us, and on systems that
+emit 0x3C but never 0x3B/0x3A this is the **only** System ID source (OP25
+and SDRtrunk corroborate the same way). And an *accepted* Location
+Registration Response (0x2B) votes RFSS/Site, since it names the camped
+site — but only response value 0: a denied registration may name a
+different site.
+
+## The neighbour map
+
+Neighbours are keyed by (RFSS, Site) and **merged**, not overwritten,
+because the two frame forms carry complementary halves:
+
+```go
+// internal/radio/p25/phase1/network.go (shape) — upsertNeighbor
+if old, ok := m.neighborData[key]; ok {
+    if n.UplinkID == 0 && n.UplinkNumber == 0 { // AMBT-only field
+        n.UplinkID, n.UplinkNumber = old.UplinkID, old.UplinkNumber
+    }
+    if !n.CFVAKnown { // TSBK-only fields
+        n.CFVA, n.CFVAKnown, n.ServiceClass = old.CFVA, old.CFVAKnown, old.ServiceClass
+    }
+    /* … keep old LRA / SystemID when the new observation lacks them … */
+}
+m.neighborData[key] = n
+```
+
+`CFVAKnown` exists because "flags all zero" and "never seen" are different
+facts — the same discipline as the voted zeros above. The snapshot of all
+this (`NetworkConfig`) crosses into the protocol-neutral
+`trunking.TopologySnapshot`, which is what the
+[network configuration report]({{ '/blog/deep-dives/trunking-engine-10-sites-topology-roaming/' | relative_url }})
+renders and the hunt accumulator folds into discovered systems.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 236" width="680" height="236" role="img" aria-label="The P25 identity tree: a 20-bit WACN contains a 12-bit System ID, which contains RF sub-systems, which contain sites. Three sites are drawn under RFSS 1; the camped site is highlighted and double-headed adjacency arrows labelled with the 0x3C broadcast connect it to its two neighbours, one annotated as AMBT-only with an explicit uplink.">
+  <rect x="240" y="10" width="200" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="340" y="29" text-anchor="middle" fill="currentColor" font-size="10">WACN (20 bits) — e.g. 0xBEE00</text>
+  <line x1="340" y1="40" x2="340" y2="56" stroke="var(--fg-muted)"/>
+  <rect x="240" y="56" width="200" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="340" y="75" text-anchor="middle" fill="currentColor" font-size="10">System ID (12 bits) — shared by all sites</text>
+  <line x1="340" y1="86" x2="340" y2="102" stroke="var(--fg-muted)"/>
+  <rect x="255" y="102" width="170" height="28" rx="6" fill="none" stroke="currentColor"/>
+  <text x="340" y="120" text-anchor="middle" fill="currentColor" font-size="10">RFSS 1 (8 bits)</text>
+  <line x1="300" y1="130" x2="150" y2="160" stroke="var(--fg-muted)"/>
+  <line x1="340" y1="130" x2="340" y2="160" stroke="var(--fg-muted)"/>
+  <line x1="380" y1="130" x2="530" y2="160" stroke="var(--fg-muted)"/>
+  <rect x="80" y="160" width="140" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="150" y="176" text-anchor="middle" fill="currentColor" font-size="10">Site 1</text>
+  <text x="150" y="191" text-anchor="middle" fill="var(--fg-muted)" font-size="9">CC 851.0125 MHz</text>
+  <rect x="270" y="160" width="140" height="40" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="340" y="176" text-anchor="middle" fill="var(--accent)" font-size="10">Site 2 — camped</text>
+  <text x="340" y="191" text-anchor="middle" fill="var(--fg-muted)" font-size="9">0x3A votes RFSS/Site</text>
+  <rect x="460" y="160" width="140" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="530" y="176" text-anchor="middle" fill="currentColor" font-size="10">Site 3</text>
+  <text x="530" y="191" text-anchor="middle" fill="var(--fg-muted)" font-size="9">AMBT-only: explicit uplink</text>
+  <line x1="222" y1="180" x2="268" y2="180" stroke="var(--accent)"/>
+  <polygon points="226,176 218,180 226,184" fill="var(--accent)"/><polygon points="264,176 272,180 264,184" fill="var(--accent)"/>
+  <line x1="412" y1="180" x2="458" y2="180" stroke="var(--accent)"/>
+  <polygon points="416,176 408,180 416,184" fill="var(--accent)"/><polygon points="454,176 462,180 454,184" fill="var(--accent)"/>
+  <text x="340" y="222" text-anchor="middle" fill="var(--fg-muted)" font-size="9">0x3C Adjacent Site Status, TSBK + AMBT forms merged per (RFSS, Site) — each neighbour also names our System ID</text>
+</svg>
+<figcaption>The identity tree GopherTrunk assembles from broadcasts: identity scalars voted, neighbours merged from two frame forms that each carry half the picture.</figcaption>
+</figure>
+
+## Roaming is a fold, not a feature
+
+Above the decoder, `trunking.SiteTracker` subscribes to the bus and folds
+every `KindSiteUpdate` — published when the control channel decodes an RFSS
+Status Broadcast — into a live table keyed (system, RFSS, site). Where the
+`NetworkModel` only knows the *currently camped* site, the tracker
+remembers **every site the decoder has ever locked**, and entries never
+expire: a site roster is small and stable, and operators want the full
+list even for sites gone quiet. That table backs `GET /api/v1/sites`
+(issue #698), with operator names merged on from the system config.
+
+Roaming, then, is not a subsystem — it is what falls out when the
+[cchunt supervisor]({{ '/blog/deep-dives/the-hunt-06-control-channel-hunting/' | relative_url }})
+hops control channels over a session. The candidate list is the system's
+configured `control_channels`; `System.HuntOrder` moves the last-locked
+frequency (persisted in the hunt cache) to the front, so a daemon restart
+or a brief fade goes straight back to the site that was working. When a
+locked CC goes silent, the decoder publishes `cc.lost` and the supervisor
+re-hunts —
+[Trunking Engine Part 12]({{ '/blog/deep-dives/trunking-engine-12-cc-hunting-watchdog-testing/' | relative_url }})
+covers the watchdog and backoff, and
+[The Hunt Part 7]({{ '/blog/deep-dives/the-hunt-07-locking-a-p25-system/' | relative_url }})
+what "locked" demands on P25. Each site the hunter lands on contributes its
+broadcasts and the roster grows — the fold *is* the roam. (Watching several
+sites *simultaneously* instead of serially is Part 11's subject.)
+
+One instrument earns special mention because it catches the multi-site
+failure mode nothing else sees: each `SiteInfo` row carries
+`ControlChannelCarrierOffsetHz`, the demod's measured carrier offset of the
+locked CC against the tuned centre. A lock sitting well off the configured
+frequency is the signature of an **adjacent site bleeding through** — you
+are decoding a different tower than you tuned (issue #815, and the
+[carrier-offset-adjacent-lock]({{ '/reference/carrier-offset-adjacent-lock/' | relative_url }})
+reference). The companion WARN requires the offset to *persist* before
+firing, because a per-chunk estimator blip is not a site change.
+
+### How the fragment problem shaped the Go code
+
+- **Accumulate in the decoder, snapshot at the boundary.** Identity is not
+  on any per-event payload — `TopologySnapshot` exists precisely because a
+  consumer cannot reconstruct WACN/SysID/RFSS/Site from the event stream.
+- **Distinguish absent from zero, everywhere.** Zero-vote guards, `CFVAKnown`,
+  and the 0x2B accepted-only rule all encode the same idea: a field you
+  never saw is not a field that equals zero.
+- **Two frame forms, one fold.** The AMBT `Apply*` methods normalise into
+  the TSBK structures and share the merge — so a fix to the accumulator
+  lands on both forms, the standing
+  [twin-path rule]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }})
+  applied at the message layer.
+
+## Where this goes next
+
+Hunting visits sites one at a time.
+[Part 11]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }})
+removes the "one at a time": pin a single SDR across a band and channelize
+every control channel out of one capture — the `DDCBank` tuner bank, voice
+taps that follow grants without retuning, and the twin down-converter paths
+whose drift taught this project its most expensive lesson.
+
+## FAQ
+
+**What is a WACN and do I need to configure it?**
+The Wide Area Communication Network ID — a 20-bit number identifying the
+licensee's whole P25 network, above the System ID. You don't configure it;
+GopherTrunk decodes it from Network Status broadcasts (TSBK or AMBT form)
+and reports it in the site table and network report — how you confirm two
+configured systems are actually the same network.
+
+**Why did GopherTrunk show one neighbour site when SDRtrunk showed twelve?**
+Because those neighbours were broadcast only in the multi-block AMBT form,
+which early GopherTrunk logged as `non-control DUID duid=PDU` and dropped.
+Since the `mbt.go` decoder landed, both forms feed one accumulator — and
+the AMBT form contributes fields the TSBK form doesn't carry, like the
+neighbour's explicit uplink channel.
+
+**Does GopherTrunk automatically roam between P25 sites?**
+Effectively, yes — one site at a time. The hunter locks the best candidate
+from your `control_channels` list, biased toward the last-known-good
+frequency, re-hunts on `cc.lost`, and the tracker accumulates every site it
+visits. It does not (yet) auto-add decoded neighbour frequencies to the
+candidate list; the network report tells you which are worth adding.
+
+**Is the NAC the same thing as the System ID?**
+No. The NAC is a 12-bit access code in every frame's NID — a colour code
+that gates frame acceptance. The System ID is a 12-bit network identity
+carried in status broadcasts. Many systems set memorable NACs per site,
+but nothing requires the two to relate.
+
+**My site shows RFSS 0 — is that a decode failure?**
+No. RFSS 0 is a real, common value, which is why the accumulator counts
+RFSS/Site votes even at zero, unlike WACN/System ID where zero means
+"absent." A genuinely undecoded identity shows as no row at all, or blank
+WACN/SysID awaiting status broadcasts.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9: Encryption Signalling — Flags, Metadata & Policy]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }})
+· Next →
+[Part 11: Wideband P25 — Watching the Whole System at Once]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }})

--- a/docs/_posts/2026-09-12-p25-end-to-end-10-sites-roaming.md
+++ b/docs/_posts/2026-09-12-p25-end-to-end-10-sites-roaming.md
@@ -40,10 +40,10 @@ roam by.*
 
 **Key takeaways**
 
-- **Identity arrives in fragments, on a schedule the system chooses.** No
-  single frame carries the whole ladder: 0x3B has the WACN but no
-  RFSS/Site, 0x3A the reverse. A decoder that waits for one authoritative
-  message reports blanks forever.
+- **Identity arrives in fragments, on the system's schedule.** No single
+  frame carries the whole ladder: 0x3B has the WACN but no RFSS/Site, 0x3A
+  the reverse. A decoder waiting for one authoritative message reports
+  blanks forever.
 - **The same broadcast wears two frames, and one may be missing.** Every
   status message has a TSBK and an AMBT form with complementary fields.
   GopherTrunk once decoded only the TSBK form — and showed one neighbour
@@ -115,15 +115,14 @@ grants
 | Secondary CC | 0x39 (+ 0x29 explicit) | additional control channels of this site |
 | Adjacent Site Status | 0x3C | one neighbour: RFSS, Site, its CC, CFVA flags |
 
-Every one of them also exists in the **AMBT** form — the same semantic
-message carried in a multi-block PDU
+Every one also exists in the **AMBT** form — the same semantic message
+carried in a multi-block PDU
 ([Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }}))
 — and the two forms are not redundant copies. The AMBT Adjacent Site
-Status is the only form that names the neighbour's **explicit uplink
-channel**; the TSBK form is the only one carrying the CFVA flags and
-service class. And many systems, notably Motorola, broadcast most or all
-of their neighbour list — and sometimes the WACN itself — **only** in AMBT
-form.
+Status alone names the neighbour's **explicit uplink channel**; the TSBK
+form alone carries the CFVA flags and service class. And many systems,
+notably Motorola, broadcast most of their neighbour list — sometimes the
+WACN itself — **only** in AMBT form.
 
 That asymmetry is the war story this series keeps returning to. GopherTrunk
 originally decoded only the TSBK forms and logged every control-channel PDU
@@ -207,9 +206,9 @@ m.neighborData[key] = n
 ```
 
 `CFVAKnown` exists because "flags all zero" and "never seen" are different
-facts — the same discipline as the voted zeros above. The snapshot of all
-this (`NetworkConfig`) crosses into the protocol-neutral
-`trunking.TopologySnapshot`, which is what the
+facts — the same discipline as the voted zeros. The snapshot of all this
+(`NetworkConfig`) crosses into the protocol-neutral
+`trunking.TopologySnapshot`, which the
 [network configuration report]({{ '/blog/deep-dives/trunking-engine-10-sites-topology-roaming/' | relative_url }})
 renders and the hunt accumulator folds into discovered systems.
 
@@ -298,9 +297,9 @@ firing, because a per-chunk estimator blip is not a site change.
 
 Hunting visits sites one at a time.
 [Part 11]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }})
-removes the "one at a time": pin a single SDR across a band and channelize
-every control channel out of one capture — the `DDCBank` tuner bank, voice
-taps that follow grants without retuning, and the twin down-converter paths
+removes the "one at a time": pin one SDR across a band and channelize every
+control channel out of one capture — the `DDCBank` tuner bank, voice taps
+that follow grants without retuning, and the twin down-converter paths
 whose drift taught this project its most expensive lesson.
 
 ## FAQ

--- a/docs/_posts/2026-09-13-from-spec-to-shipping-11-capture-driven-development.md
+++ b/docs/_posts/2026-09-13-from-spec-to-shipping-11-capture-driven-development.md
@@ -217,7 +217,9 @@ now written into the harness notes: **known colour code (from the
 codeplug), actually talking, single antenna, combiner off**. Similarly,
 `samples/p25/README.md`'s priority ask is not another clean control
 channel — it is a *marginal voice-channel* call, because a strong capture
-cannot exercise the missing equalizer it exists to justify.
+cannot exercise the
+[missing equalizer]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }})
+it exists to justify.
 
 **Right physics.** IQ or nothing, for phase protocols: an FM-demodulated
 audio recording of TETRA has already destroyed the phase the decoder
@@ -248,7 +250,9 @@ before," which is how wishful DSP ships.
 
 This is also why the harnesses print yields rather than verdicts wherever
 a number will do: CRC-valid counts on the same capture are comparable
-across months and branches. The
+across months and branches — the fixture side of the
+[testing discipline]({{ '/learn/testing/' | relative_url }}) this whole
+series leans on. The
 [ten-megasamples investigation]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
 ([#764](https://github.com/MattCheramie/GopherTrunk/issues/764)) was
 settled exactly this way: the same capture, decimated by an independent

--- a/docs/_posts/2026-09-13-from-spec-to-shipping-11-capture-driven-development.md
+++ b/docs/_posts/2026-09-13-from-spec-to-shipping-11-capture-driven-development.md
@@ -1,0 +1,330 @@
+---
+title: "From Spec to Shipping, Part 11: Capture-Driven Development"
+description: How GopherTrunk turns operator IQ recordings into first-class test fixtures — the samples/ conventions, .metadata.json sidecars whose bounds turn log lines into pass/fail gates, env-gated replay harnesses that skip in CI and become field instruments, and the discipline of baselining before fixing.
+category: deep-dives
+keywords: iq capture test fixture, sdr capture metadata sidecar, replay test harness, env gated integration test, capture driven development, sample rate honesty, pre-combine diversity capture, regression fixture from capture, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, captures, testing, fixtures, replay, methodology]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 11
+---
+
+*Part 11 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+made the verification ladder explicit — and every rung above
+synthetic-green stands on a recording of a real transmitter. This part is
+about treating those recordings as what they are: **test fixtures with
+provenance**. The `samples/` conventions, the metadata sidecars, the
+env-gated harnesses that skip in CI and become instruments in the field,
+and the two habits that decide whether a capture answers anything:
+asking for the right one, and baselining before you fix.*
+
+> **TL;DR:** A capture in GopherTrunk is a binary plus a committed
+> `*.metadata.json` sidecar carrying provenance and **expected** bounds —
+> absent bounds are reported, present bounds are asserted, so a fresh
+> capture *measures* the decoder before anyone commits to a threshold
+> (`samples/p25/README.md`; `TestReplayP25RealCaptureMetrics` in
+> `cmd/gophertrunk/p25_realcapture_metrics_test.go`). Bigger captures
+> drive **env-gated harnesses** — `GT_TETRA_DMO_IQ`/`RATE`/`MCC`/`MNC`,
+> `GT_DIVERSITY_CAPTURE`, `GT_TETRA_LMS` — that skip cleanly with a
+> one-line instruction and turn into field instruments when the file
+> exists. The committed P25 control-channel fixture graded a live NAC
+> 0x2C1 site at EVM 12.7% / SNR 14.5 dB / TSBK 36 decoded, 0 CRC-failed;
+> those numbers are now floors. The rule underneath:
+> **record the baseline before touching the code.**
+
+**Key takeaways**
+
+- **A capture without metadata is a smoke test; with metadata it's a
+  regression gate.** The sidecar carries what the decoder *should* find —
+  NAC, colour code, yield floors — and `gophertrunk test` grades against
+  it with a CI-ready exit code.
+- **Report first, assert later.** Every bound in the schema is optional:
+  a new capture logs its metrics without failing anything, the measured
+  numbers become the committed floors, and the floors tighten as the
+  decoder improves — never the other way.
+- **The harness must cost nothing when the capture is absent.** Skip-gated
+  tests keep CI green with no fixture installed, while the skip message
+  itself documents how to run them — the same file is a unit test in CI
+  and an instrument on an operator's bench.
+- **Most capture failures happen before recording starts.** Wrong tap
+  (post-combine when the question is the combiner), wrong content (a
+  silent PTT when the question is voice), wrong rate honesty — the
+  asking-for-a-capture checklist is engineering, not admin.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Drop-zone conventions | per-protocol folders, format + acceptance criteria per README | `samples/README.md`, `samples/<proto>/README.md` |
+| Sidecar schema | provenance + `expected` bounds; hex-tolerant field matching | `samples/README.md` (unified metadata schema) |
+| P25 field-truth harness | replays `samples/p25/*.cfile`, reports/asserts EVM, SNR, sync margin, NID/TSBK yield | `cmd/gophertrunk/p25_realcapture_metrics_test.go` (`TestReplayP25RealCaptureMetrics`) |
+| DMO capture harness | replay + colour recovery + verdict lines | `cmd/gophertrunk/tetra_dmo_replay_test.go` (`GT_TETRA_DMO_*`) |
+| Pre-combine diversity tap | one cs16 file per branch + `<prefix>.diversity.json`, alignment-guaranteed | `sdr.soapy_remote[].diversity_capture` → `TestDiversityCombinerReplay` (`GT_DIVERSITY_CAPTURE`) |
+| Capture / grade tooling | `gophertrunk capture` writes IQ + sidecar; `gen` synthesizes; `test` grades, exit 0/1 | `samples/README.md` (Signal Lab section) |
+
+## In this post
+
+- **A fixture with provenance** — the `samples/` layout and what gets
+  committed.
+- **The sidecar schema** — bounds that report until you're ready to
+  assert.
+- **Env-gated harnesses** — one file, two lives: CI test and field
+  instrument.
+- **Asking for the right capture** — the checklist written in scar
+  tissue.
+- **Baseline before fix** — the habit that makes an A/B possible at all.
+
+## A fixture with provenance
+
+`samples/` is GopherTrunk's capture drop-zone: one folder per protocol
+(`p25/`, `tetra/`, `nxdn/`, `dmr-tier2/`, `mpt1327/`, …), each with a
+README stating the capture format the loader expects, the metadata needed
+to validate a decode, and **numerical acceptance criteria** — the
+explicit thresholds a contributor with hardware can run a capture against
+to close a follow-up. The binaries themselves are deliberately
+gitignored (multi-megabyte IQ does not belong in source control; anything
+under ~1 MB may be committed directly); what *is* committed is the
+sidecar, and the sidecar is where the value lives.
+
+The committed `samples/p25/p25-450875-cc.metadata.json` shows the shape:
+a live UHF C4FM control channel at 449.875 MHz, NAC `0x2C1`, channelised
+to 48 kHz — and, in its `notes`, the measured grades: **EVM 12.7%, SNR
+14.5 dB, sync-margin min=3/median=5, NID trusted=31/failed=0, TSBK
+decoded=36/CRC-failed=0**. The `.cfile` never entered git; the fixture is
+reproducible from the raw 2 MSPS recording via `TestGenerateP25Fixture`,
+and the sidecar's bounds are set *below* the measured values — floors,
+not targets, tightened as the demod improves. A capture handled this way
+is not a debugging aid that evaporates when the issue closes; it is a
+regression fixture with a birth certificate.
+
+## The sidecar schema: report until you can assert
+
+The harness side of that contract is `TestReplayP25RealCaptureMetrics`,
+and its expected-payload struct encodes the discipline directly:
+
+```go
+// cmd/gophertrunk/p25_realcapture_metrics_test.go (shape)
+// p25MetricsExpected is the "expected" payload for samples/p25/*.metadata.json.
+// Every bound is optional: a zero/absent field is reported but not asserted,
+// so a capture can be dropped in to *measure* the demod before anyone
+// commits to a pass/fail threshold.
+type p25MetricsExpected struct {
+    DemodMode     string  `json:"demod_mode"` // "c4fm" (default) or "cqpsk"
+    NAC           string  `json:"nac"`        // hex, e.g. "0x167"
+    MinNIDTrusted int     `json:"min_nid_trusted"`
+    MinTSBK       int     `json:"min_tsbk"`
+    MaxEVMPct     float64 `json:"max_evm_pct"`
+    MinSNRdB      float64 `json:"min_snr_db"`
+    MinSyncMargin int     `json:"min_sync_margin"`
+}
+```
+
+**Every bound optional** is the load-bearing design choice. Day one, an
+operator drops a capture with only `demod_mode` and `nac` filled in; the
+harness logs pre-FEC EVM, estimated SNR, FSW sync margin and NID/TSBK
+yields without failing anything. Those logged numbers *are* the baseline.
+Once trusted, they go into the sidecar as floors, and from that commit on
+the capture bites: any regression in the demod fails a named test against
+a named recording. The same pattern generalizes across the tree — the
+unified schema in `samples/README.md` adds `lock`, `lock_latency_max_sec`
+and hex-tolerant `lock_fields`, and `gophertrunk test -capture x.cfile`
+grades any capture against its auto-discovered sidecar with a CI-ready
+exit code. `gophertrunk capture` and `gen` both *write* a sidecar
+alongside every file they produce, so a capture is never born naked.
+
+## Env-gated harnesses: one file, two lives
+
+Committed fixtures cover the small, stable end. The investigations that
+drive this series run on captures too big, too private, or too
+operator-specific to commit — and for those, GopherTrunk uses
+**env-gated harnesses**: ordinary `go test` functions that skip with a
+one-line instruction when their variable is unset.
+
+| Variable(s) | Harness | The question it answers |
+|---|---|---|
+| `GT_TETRA_DMO_IQ`, `GT_TETRA_DMO_RATE` | `TestTETRADMOReplay` | does a real DMO transmission decode to speech? |
+| `GT_TETRA_DMO_MCC`/`MNC`, `GT_TETRA_DMO_COLOUR`, `GT_TETRA_DMO_CLEAR` | same | fold in the operator's ground truth ([Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})) |
+| `GT_TETRA_DMO_SCAN=1` | `TestTETRADMOColourScan` | the full 64-colour CRC-yield map |
+| `GT_TETRA_LMS=1` | `TestTETRAMultiSlotReplay` | does the trained equalizer beat CMA on this capture? |
+| `GT_DIVERSITY_CAPTURE` | `TestDiversityCombinerReplay` | is MRC helping, hurting, or irrelevant on this rig? |
+
+The skip messages are documentation: `set GT_TETRA_DMO_IQ (cs16 IQ) +
+GT_TETRA_DMO_RATE to run the DMO replay`. CI never sees the captures and
+stays green; an operator with a `.raw` file is one env var from the full
+instrument — windowed traces, decode arms, verdict lines. One source
+file, two lives, and the two can never drift apart because they are the
+same code.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 220" width="680" height="220" role="img" aria-label="The capture lifecycle as five stages joined by arrows: an issue report saying voice does not decode; a capture request specifying tap, content and rate; the recording plus its metadata sidecar, with only the sidecar committed to git; the env-gated replay harness reporting a baseline; and finally a regression fixture whose measured numbers become asserted floors. A return arrow labelled next investigation starts here loops from the fixture back toward the issue stage.">
+  <rect x="12" y="60" width="118" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="71" y="82" text-anchor="middle" fill="currentColor" font-size="10">issue report</text>
+  <text x="71" y="97" text-anchor="middle" fill="var(--fg-muted)" font-size="9">"voice doesn't decode"</text>
+  <line x1="130" y1="86" x2="148" y2="86" stroke="var(--fg-muted)"/><polygon points="146,82 154,86 146,90" fill="var(--fg-muted)"/>
+  <rect x="154" y="60" width="118" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="213" y="78" text-anchor="middle" fill="currentColor" font-size="10">capture request</text>
+  <text x="213" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="9">right tap, content,</text>
+  <text x="213" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">honest rate</text>
+  <line x1="272" y1="86" x2="290" y2="86" stroke="var(--fg-muted)"/><polygon points="288,82 296,86 288,90" fill="var(--fg-muted)"/>
+  <rect x="296" y="60" width="118" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="355" y="78" text-anchor="middle" fill="currentColor" font-size="10">IQ + sidecar</text>
+  <text x="355" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="9">binary gitignored,</text>
+  <text x="355" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">.metadata.json committed</text>
+  <line x1="414" y1="86" x2="432" y2="86" stroke="var(--fg-muted)"/><polygon points="430,82 438,86 430,90" fill="var(--fg-muted)"/>
+  <rect x="438" y="60" width="118" height="52" rx="6" fill="none" stroke="currentColor"/>
+  <text x="497" y="78" text-anchor="middle" fill="currentColor" font-size="10">gated harness</text>
+  <text x="497" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="9">skips in CI, reports</text>
+  <text x="497" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">the baseline in the field</text>
+  <line x1="556" y1="86" x2="574" y2="86" stroke="var(--fg-muted)"/><polygon points="572,82 580,86 572,90" fill="var(--fg-muted)"/>
+  <rect x="580" y="60" width="92" height="52" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="626" y="82" text-anchor="middle" fill="var(--accent)" font-size="10">regression</text>
+  <text x="626" y="97" text-anchor="middle" fill="var(--accent)" font-size="10">fixture</text>
+  <path d="M 626 112 L 626 160 L 71 160 L 71 118" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <polygon points="67,122 71,114 75,122" fill="var(--accent)"/>
+  <text x="348" y="152" text-anchor="middle" fill="var(--accent)" font-size="10">measured numbers become asserted floors — the next investigation starts ahead</text>
+  <text x="340" y="200" text-anchor="middle" fill="currentColor" font-size="10">every stage leaves an artifact; the capture outlives the bug that requested it</text>
+</svg>
+<figcaption>The capture lifecycle: an issue buys a capture, the capture buys a baseline, and the baseline becomes a permanent floor under the decoder.</figcaption>
+</figure>
+
+## Asking for the right capture
+
+The expensive failures in this workflow happen before a single sample is
+recorded, and GopherTrunk's DMO and diversity investigations paid for the
+checklist the hard way:
+
+**Right tap.** The MRC combiner lives inside the SoapyRemote driver, so
+every ordinary recording path — `baseband.auto_record`, the scope taps —
+sits *downstream* of it: a capture from any of them has one combiner
+already baked in and can never A/B another.
+`sdr.soapy_remote[].diversity_capture` exists solely to tap the branches
+before the combine, writing one headerless cs16 file per branch plus a
+`.diversity.json` sidecar — and a datagram that didn't carry every branch
+is dropped from **both** files and counted, never written short, because
+one short write silently desynchronises the branches and poisons every
+later conclusion.
+
+**Right content.** A 25-second *silent* PTT looked like the perfect
+clean DMO vector and turned out to be a poor one — largely comfort-noise
+and discontinuous-transmission frames, exactly wrong for grading a speech
+descramble. A later run had MRC enabled, a single antenna and no cavity
+filter, which contaminated both decode paths at once. The standing ask is
+now written into the harness notes: **known colour code (from the
+codeplug), actually talking, single antenna, combiner off**. Similarly,
+`samples/p25/README.md`'s priority ask is not another clean control
+channel — it is a *marginal voice-channel* call, because a strong capture
+cannot exercise the missing equalizer it exists to justify.
+
+**Right physics.** IQ or nothing, for phase protocols: an FM-demodulated
+audio recording of TETRA has already destroyed the phase the decoder
+needs, and 128 kbps MP3 collapses a 4-FSK constellation's levels —
+`samples/README.md` documents both empirically, from files contributors
+actually uploaded. And rate honesty: a 48 kHz TETRA capture gives 2.67
+samples/symbol and can never lock, however real the signal. The full
+operator-side treatment — formats, sidecars, SigMF, rates — is
+[The Analog Edge Part 10]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }})'s
+territory; this series' concern is what the engineering side must
+*specify* when it asks.
+
+The request itself is part of the diagnostic loop from
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }}):
+each DMO round ended with a sharper ask, and the sharper ask is what made
+the next round decisive.
+
+## Baseline before fix
+
+The last habit is the one that turns a capture into an experiment:
+**run the metrics harness and record its output before touching the
+code.** The P25 weak-signal plan in `samples/p25/README.md` spells the
+order out — baseline the capture with `TestReplayP25RealCaptureMetrics`
+(pre-FEC EVM, SNR, FSW margin, LDU yield), *then* port the equalizer or
+add soft decisions, then A/B against the same file. Without the recorded
+baseline there is no A/B — only a vague memory of "it seemed worse
+before," which is how wishful DSP ships.
+
+This is also why the harnesses print yields rather than verdicts wherever
+a number will do: CRC-valid counts on the same capture are comparable
+across months and branches. The
+[ten-megasamples investigation]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
+([#764](https://github.com/MattCheramie/GopherTrunk/issues/764)) was
+settled exactly this way: the same capture, decimated by an independent
+resampler, replayed through the proven path — deficit unchanged,
+therefore in the samples, not the DSP. The capture was the experiment's
+control group, and it could be, because nothing about it changed between
+runs.
+
+### How that principle shaped the Go code
+
+- **Fixtures load through the production pipeline, not a shortcut.** The
+  replay harnesses build the same down-converters and receivers the
+  daemon runs, so a capture grades the shipping code path.
+- **Sidecar bounds are floors with provenance.** Committed thresholds sit
+  below measured values, with the measurement date and numbers in
+  `notes` — so a failing gate points at a regression, not an optimistic
+  guess.
+- **Skip messages are the manual.** Every gated test's `t.Skip` string
+  names the variables and the file format it wants; discovering how to
+  run the instrument *is* running the test suite.
+- **Capture tools emit metadata by default.** `gophertrunk capture` and
+  `gen` write the sidecar with the file, so provenance exists from the
+  moment the samples do.
+
+## Where this goes next
+
+A capture tells you what the decoder does; it doesn't yet force you to
+fix it honestly.
+[Part 12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})
+is the rule that governs every fix in this repo: one narrow commit plus a
+regression test that **fails without the fix and passes with it** — and
+if you can't write the failing test, you haven't reproduced the bug,
+whether or not you think you understand it.
+
+## FAQ
+
+**How do I contribute a capture to GopherTrunk?**
+Read the protocol folder's README in `samples/`, record IQ in the
+documented format (cfile/cs16 at an honest sample rate), and write the
+`*.metadata.json` sidecar — protocol, rates, and whatever ground truth
+you have (NAC, colour code, talkgroups). Commit the sidecar; link or
+attach the binary per the README. A capture with expected values
+validates a decoder; one without is only a does-it-crash smoke test.
+
+**Why aren't the capture binaries committed to the repo?**
+Size and churn — multi-megabyte opaque binaries bloat every clone
+forever. The committed sidecar preserves the provenance and the measured
+grades; small (≤ ~1 MB) representative slices are committed directly
+when a regression test needs to run everywhere, like the
+`mmr-s9-cc.cfile`-style fixtures under `cmd/gophertrunk/testdata/`.
+
+**What belongs in a capture's metadata sidecar?**
+Provenance (source, center frequency, sample rate, format), the receiver
+configuration it implies (`demod_mode`, colour code), and the `expected`
+block: identity fields the decode must match and yield/quality floors.
+Start with identity only — the harness reports the rest — and promote
+measured numbers to floors once you trust them.
+
+**What sample rate should I record at?**
+Higher than you think, honestly labelled. The decoder resamples to its
+per-protocol channel rate, but information missing from the file never
+comes back — 48 kHz TETRA structurally cannot lock — and a mislabelled
+rate poisons everything downstream. When in doubt, capture wide and keep
+the raw file; GopherTrunk's tooling can decimate later, and #764 was only
+solvable because the raw recordings still existed.
+
+**Do env-gated tests rot when nobody has the capture?**
+Less than you'd expect, because they compile and their non-gated
+neighbours share their helpers — and the ones that matter get run every
+time an investigation touches their protocol. The real rot risk is the
+opposite arrangement: instruments that live outside the test tree stop
+building, silently, the week nobody needs them.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: The On-Air Gate — Green Synthetics Prove Nothing]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+· Next →
+[Part 12: Failing First — The Regression Rule]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})

--- a/docs/_posts/2026-09-13-operator-cookbook-11-closet-appliance.md
+++ b/docs/_posts/2026-09-13-operator-cookbook-11-closet-appliance.md
@@ -265,14 +265,14 @@ so a slow restart names its culprit class instead of shrugging.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Random USB errors, dongle re-enumerates under load | undervoltage — the classic Pi failure | Use a proper supply; on a Pi, check the kernel log for its low-voltage warnings; move the SDR to a powered hub if the board browns out with bias-tee LNAs |
-| `sdr: watchdog: device missing from USB enumerate` repeating | flaky cable/port, or genuine power sag | The watchdog re-acquires by serial automatically; if it cycles, treat it as hardware — the [dongle-off-the-bus postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-18-the-stall-that-wasnt/' | relative_url }}) is the war story |
-| `ccdecoder: decode can't keep up with real time` | CPU-starved board — too many systems/taps for the silicon, or thermal throttling | Reduce taps/systems, add cooling, or step up the board; this WARN is the CPU signal, distinct from any RF problem |
-| Decodes fine for days, then killed with no log line | memory pressure — OOM-killer | The auto `memory_limit_mb` guards this; on tiny boards set it explicitly and watch heartbeat `heap_sys_mb` trends |
-| `api: auth disabled — mutation endpoints are not authenticated` at startup | empty `auth.mode` resolving to the closed-LAN default on a `0.0.0.0` bind | Set `mode: "auto"` or `"required"` with a `token_file` — deliberate posture, not defaults ([hardening]({{ '/hardening.html' | relative_url }})) |
-| Daemon starts, no radio, no error | device node permissions under the hardened unit | Check the udev rule + `DeviceAllow`/`SupplementaryGroups` lines; `gophertrunk sdr doctor` from a shell tells you who owns the dongle |
-| `systemctl stop` takes ~30 s | a streaming handler missed the stop signal (the fixed bug's shape) | The journal WARN above fires when the cap is hit — report it with the log; it is a bug, not a config problem |
-| Web console unreachable from the LAN | daemon bound to loopback | `api.http_addr: "0.0.0.0:8080"` — then do the auth row above, in that order |
+| Random USB errors, dongle re-enumerates under load | undervoltage — the classic Pi failure | Use a proper supply; check the Pi kernel log for low-voltage warnings; a powered hub helps when a bias-tee LNA browns the board out |
+| `sdr: watchdog: device missing from USB enumerate` repeating | flaky cable/port, or power sag | The watchdog re-acquires by serial automatically; if it cycles, treat it as hardware — the [dongle-off-the-bus postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-18-the-stall-that-wasnt/' | relative_url }}) is the war story |
+| `ccdecoder: decode can't keep up with real time` | CPU-starved board, or thermal throttling | Reduce taps/systems, add cooling, or step up the board; this WARN is the CPU signal, distinct from any RF problem |
+| Decodes for days, then killed with no log line | memory pressure — OOM-killer | The auto `memory_limit_mb` guards this; on tiny boards set it explicitly and watch heartbeat `heap_sys_mb` trends |
+| `api: auth disabled — mutation endpoints are not authenticated` at startup | empty `auth.mode` on a `0.0.0.0` bind | Set `mode: "auto"` or `"required"` with a `token_file` ([hardening]({{ '/hardening.html' | relative_url }})) |
+| Daemon starts, no radio, no error | device-node permissions under the hardened unit | Check the udev rule + `DeviceAllow`/`SupplementaryGroups`; `gophertrunk sdr doctor` tells you who owns the dongle |
+| `systemctl stop` takes ~30 s | a streaming handler missed the stop signal (the fixed bug's shape) | The journal WARN above fires at the cap — report it with the log; it's a bug, not a config problem |
+| Web console unreachable from the LAN | daemon bound to loopback | `api.http_addr: "0.0.0.0:8080"` — then the auth row above, in that order |
 
 ### How this recipe shapes operator practice
 

--- a/docs/_posts/2026-09-13-operator-cookbook-11-closet-appliance.md
+++ b/docs/_posts/2026-09-13-operator-cookbook-11-closet-appliance.md
@@ -24,32 +24,29 @@ you'll see.*
 > **TL;DR:** One static Go binary + the example unit at
 > [`docs/gophertrunk.service`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/gophertrunk.service)
 > makes a hardened appliance: `DynamicUser=true`, `ProtectSystem=strict`,
-> `DeviceAllow=char-usb_device rwm` for the pure-Go USB driver, `Restart=on-failure`,
-> logs in `journalctl -u gophertrunk -f`. Preflight with
-> `gophertrunk sdr doctor` (read-only driver-binding check), watch health via
-> `runtime: heartbeat` lines (`diagnostics.heartbeat_seconds`) and the USB
-> watchdog (`sdr.watchdog_interval_ms`) that re-acquires vanished dongles by
-> serial. Docker works too — the repo ships a `Dockerfile` and
-> `docker-compose.yml` whose `devices:` maps the dongle in. And
+> `DeviceAllow=char-usb_device rwm` for the pure-Go USB driver,
+> `Restart=on-failure`, logs in `journalctl -u gophertrunk -f`. Preflight
+> with `gophertrunk sdr doctor`, watch health via `runtime: heartbeat` lines
+> and the USB watchdog (`sdr.watchdog_interval_ms`) that re-acquires
+> vanished dongles by serial. Docker works too — the repo's
+> `docker-compose.yml` maps the dongle in via `devices:`. And
 > `systemctl restart` is now milliseconds, not a silent 30 s stall — that
 > teardown bug is fixed and warns if it ever recurs.
 
 **Key takeaways**
 
 - **An appliance is a binary plus supervision.** GopherTrunk is one static
-  executable with no libusb, no librtlsdr, no ALSA required — the whole
-  "install" is copying a file, and everything hard lives in the systemd unit.
+  executable — no libusb, no librtlsdr, no ALSA — so the "install" is
+  copying a file, and everything hard lives in the systemd unit.
 - **Hardening is shipped, not homework.** The example unit runs as a dynamic
   user with a read-only filesystem view, explicit `ReadWritePaths`, and a
   scoped USB `DeviceAllow` — you edit paths and serials, not policy.
 - **Headless health is three signals.** `runtime: heartbeat` proves the
-  process is alive and bounded, the SDR watchdog logs dongles leaving and
-  rejoining the bus, and the decode-status lines prove the radio side — learn
-  all three before the closet door closes.
+  process alive and bounded, the SDR watchdog narrates dongles leaving and
+  rejoining the bus, and the decode lines prove the radio side.
 - **Shutdown speed is a correctness feature.** A stop that takes 30 silent
-  seconds gets `KillMode`'d by init systems and blamed on ghosts. The
-  streaming handlers now exit on signal; a blown window logs a WARN naming
-  itself.
+  seconds gets blamed on ghosts. The streaming handlers now exit on signal;
+  a blown window logs a WARN naming itself.
 
 ## Cheat sheet
 
@@ -58,19 +55,19 @@ you'll see.*
 | Which board | Pi 4/5 class SBC or mini-PC sizing | [SBC build list]({{ '/gophertrunk-sbc-build/' | relative_url }}), [best SBC guide]({{ '/best-single-board-computer-for-gophertrunk/' | relative_url }}) |
 | Install & udev | binary, config, USB permissions | [Linux install]({{ '/install-linux.html' | relative_url }}), [hardening guide]({{ '/hardening.html' | relative_url }}) |
 | Supervision | hardened unit, restart-on-failure | `docs/gophertrunk.service`, [systemd deep dive]({{ '/blog/deep-dives/running-it-for-real-13-systemd-windows/' | relative_url }}) |
-| Containers | USB pass-through via `devices:` | repo `Dockerfile` + `docker-compose.yml`, [Docker deep dive]({{ '/blog/deep-dives/running-it-for-real-12-docker-usb/' | relative_url }}) |
-| Preflight | who owns the dongle before the daemon runs | `gophertrunk sdr doctor`, [sdr doctor deep dive]({{ '/blog/deep-dives/running-it-for-real-07-sdr-doctor-preflight/' | relative_url }}) |
+| Containers | USB pass-through via `devices:` | repo `docker-compose.yml`, [Docker deep dive]({{ '/blog/deep-dives/running-it-for-real-12-docker-usb/' | relative_url }}) |
+| Preflight | who owns the dongle before the daemon runs | `gophertrunk sdr doctor`, [deep dive]({{ '/blog/deep-dives/running-it-for-real-07-sdr-doctor-preflight/' | relative_url }}) |
 | Health & watchdogs | heartbeat line, USB re-acquire, memory cap | `diagnostics.heartbeat_seconds`, `sdr.watchdog_interval_ms`, `diagnostics.memory_limit_mb` |
-| Auth on the LAN | token-gated mutations on non-loopback binds | `api.auth`, [auth posture]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }}) |
+| Auth on the LAN | token-gated mutations off-loopback | `api.auth`, [auth posture]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }}) |
 
 ## In this post
 
 - **What you're building** — a supervised, hardened, self-reporting box.
-- **The shopping list** — the board, and the power supply you shouldn't cheap out on.
-- **The config** — the appliance-specific keys, on top of any earlier recipe.
+- **The shopping list** — the board, and the power supply not to cheap out on.
+- **The config** — the appliance-specific keys, atop any earlier recipe.
 - **The systemd unit** — install commands and what the hardening lines do.
 - **The Docker variation** — USB pass-through that actually works.
-- **First run & when it doesn't work** — headless health, undervoltage, USB resets, thermal.
+- **First run & when it doesn't work** — headless health, undervoltage, USB, thermal.
 
 ## What you're building
 
@@ -83,7 +80,7 @@ tells the *why* of each piece;
 covers the long-run failure modes. This recipe is the assembly.
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Block diagram of the closet appliance: inside the closet a Raspberry Pi runs systemd which supervises the gophertrunk daemon with restart on failure; the daemon owns an RTL-SDR dongle over USB guarded by a watchdog that re-acquires it by serial, emits runtime heartbeat lines and decode logs into the systemd journal, and serves the web console and API over the LAN to a laptop, with a bearer token gating mutations">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Block diagram of the closet appliance: a Raspberry Pi runs systemd supervising the gophertrunk daemon, which owns an RTL-SDR over USB guarded by a re-acquiring watchdog, emits heartbeat and decode lines into the journal, and serves the token-gated web console over the LAN">
   <rect x="10" y="16" width="400" height="208" rx="8" fill="none" stroke="var(--fg-muted)" stroke-dasharray="5 4"/>
   <text x="210" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the closet — Raspberry Pi / mini-PC, headless</text>
   <rect x="28" y="52" width="120" height="40" rx="4" fill="none" stroke="currentColor"/>
@@ -130,12 +127,12 @@ covers the long-run failure modes. This recipe is the assembly.
 Dongles and antenna carry over. The
 [SBC build list]({{ '/gophertrunk-sbc-build/' | relative_url }}) and the
 [Pi scanner guide]({{ '/raspberry-pi-sdr-scanner/' | relative_url }}) cover
-specific models and cases.
+specific models.
 
 ## The config
 
 Whatever system config you run, the appliance adds one theme: the box is on
-the LAN now, and nobody is watching it. Keys verified against
+the LAN and nobody is watching it. Keys verified against
 `config.example.yaml`:
 
 ```yaml
@@ -157,21 +154,19 @@ sdr:
 ```
 
 Three decisions. **`auth.mode: "auto"`** is the honest LAN posture: token
-required on non-loopback binds, loopback exempt. Set it *explicitly* — the
-[hardening guide]({{ '/hardening.html' | relative_url }}) documents that an
-empty `mode` now resolves to `disabled` for closed-LAN convenience, with a
-loud startup warning when that default takes effect on a non-loopback bind.
-`token_file` keeps the secret out of `config.yaml` and is re-read per
-request, so rotation needs no restart. **`memory_limit_mb: 0`** already
-protects you: it auto-derives a GC soft cap near 70% of physical RAM so the
-daemon bounds its footprint instead of meeting the OOM-killer.
+required on non-loopback binds, loopback exempt. Set it *explicitly* — per
+the [hardening guide]({{ '/hardening.html' | relative_url }}), an empty
+`mode` now resolves to `disabled` for closed-LAN convenience, with a loud
+startup warning on a non-loopback bind. `token_file` keeps the secret out
+of `config.yaml` and is re-read per request, so rotation needs no restart.
+**`memory_limit_mb: 0`** auto-derives a GC soft cap near 70% of physical
+RAM, so the daemon bounds its footprint instead of meeting the OOM-killer.
 **`heartbeat_seconds`** makes silence impossible: a periodic
 `runtime: heartbeat` line means a stopped log is itself a diagnosis.
 
 ## The systemd unit
 
-The repo ships a complete hardened unit. Install is five commands, straight
-from its header:
+The repo ships a complete hardened unit. Install, straight from its header:
 
 ```sh
 sudo install -m 0644 docs/gophertrunk.service /etc/systemd/system/gophertrunk.service
@@ -182,23 +177,21 @@ sudo systemctl daemon-reload && sudo systemctl enable --now gophertrunk
 ```
 
 (Edit `/etc/gophertrunk/config.yaml` before the last line — and note the
-`0640` mode: that's the Part 9 key-hygiene rule enforced by the installer.)
-The lines worth understanding rather than cargo-culting:
+`0640` mode: the Part 9 key-hygiene rule, enforced.) The lines worth
+understanding rather than cargo-culting:
 
 | Unit line | Why it's there |
 |---|---|
 | `Restart=on-failure` / `RestartSec=5` | crashes come back in five seconds; clean stops stay stopped |
-| `DynamicUser=true`, `NoNewPrivileges=true` | no dedicated account to manage, no privilege escalation path |
-| `ProtectSystem=strict` + `ReadWritePaths=` + `StateDirectory=gophertrunk` | the filesystem is read-only except where recordings and state actually live — point `ReadWritePaths` at your Part 10 archive dirs |
+| `DynamicUser=true`, `NoNewPrivileges=true` | no account to manage, no escalation path |
+| `ProtectSystem=strict` + `ReadWritePaths=` + `StateDirectory=` | filesystem read-only except where recordings and state live — point `ReadWritePaths` at your Part 10 archive dirs |
 | `DeviceAllow=char-usb_device rwm`, `SupplementaryGroups=plugdev` | the pure-Go USBDEVFS backend needs `/dev/bus/usb/*` read/write — no kernel driver, no libusb ([why]({{ '/blog/deep-dives/rf-front-end-01-why-pure-go-drivers/' | relative_url }})) |
 | `EnvironmentFile=-/etc/gophertrunk/env` (optional) | secrets outside the unit and the config |
 
 Logs land in the journal — `journalctl -u gophertrunk -f` is your new
 console. The udev rule granting non-root dongle access lives in the
-[hardware doc]({{ '/install-linux.html' | relative_url }}); apply it before
-first start.
-
-Before that first start, preflight the USB story from a shell:
+[Linux install guide]({{ '/install-linux.html' | relative_url }}); apply it,
+then preflight the USB story from a shell:
 
 ```sh
 gophertrunk sdr doctor        # read-only: which driver owns each known SDR
@@ -207,14 +200,13 @@ gophertrunk sdr list --probe  # enumeration + per-device gain ladders
 
 `sdr doctor` walks the known RTL-SDR and HackRF VID/PIDs and reports which
 kernel (or Windows) driver is bound to each, with an actionable next step —
-read-only, so it's safe alongside a live daemon. The
-[preflight deep dive]({{ '/blog/deep-dives/running-it-for-real-07-sdr-doctor-preflight/' | relative_url }})
-covers the verdicts.
+read-only, safe alongside a live daemon
+([preflight deep dive]({{ '/blog/deep-dives/running-it-for-real-07-sdr-doctor-preflight/' | relative_url }})).
 
 ## The Docker variation
 
 The repo ships a multi-stage `Dockerfile` and a `docker-compose.yml` whose
-`devices:` entry maps the dongle into the container:
+`devices:` entry maps the dongle in:
 
 ```yaml
     devices:
@@ -226,9 +218,8 @@ so a non-root container user can open the node, then smoke-test with
 `docker exec gophertrunk gophertrunk sdr list`. The
 [Docker deep dive]({{ '/blog/deep-dives/running-it-for-real-12-docker-usb/' | relative_url }})
 explains the trap: the mapped path names a *specific bus/device number*,
-which changes when the dongle re-enumerates — the reason systemd-on-metal is
-this recipe's default and mapping the whole `/dev/bus/usb` tree is the
-fallback for hotplug-prone hardware.
+which changes when the dongle re-enumerates — the reason systemd-on-metal
+is this recipe's default.
 
 ## First run — what healthy looks like
 
@@ -242,8 +233,8 @@ INF runtime: heartbeat uptime=1h0m0s goroutines=142 heap_alloc_mb=88 heap_sys_mb
 
 Read it like a vital sign: climbing goroutines or heap across hours is a
 leak, a frozen heartbeat on a live process is a hang, and the last line
-before an abrupt cut pins the pre-kill footprint for an OOM diagnosis. When
-a dongle drops off the bus, the watchdog narrates the whole recovery:
+before an abrupt cut pins the pre-kill footprint. When a dongle drops off
+the bus, the watchdog narrates the recovery:
 
 ```
 WRN sdr: watchdog: device missing from USB enumerate serial=00000001
@@ -256,10 +247,9 @@ Finally, test the thing appliances do most: restart.
 under a second. That speed is recent work: shutdown used to park for a full
 30 s whenever any SSE or live-audio client was attached — nothing told the
 streaming handlers to exit while the HTTP server politely waited, and the
-timeout was then miscounted as a clean exit. The fix threads a stop signal
-to every long-lived handler; the 30 s is now only a cap, and blowing it logs
-`api: graceful shutdown window expired — a streaming handler did not exit`,
-so a slow restart names its culprit class instead of shrugging.
+timeout was miscounted as a clean exit. Now a stop signal reaches every
+long-lived handler, the 30 s is only a cap, and blowing it logs
+`api: graceful shutdown window expired — a streaming handler did not exit`.
 
 ## When it doesn't work
 
@@ -277,25 +267,22 @@ so a slow restart names its culprit class instead of shrugging.
 ### How this recipe shapes operator practice
 
 - **Preflight, then trust.** `sdr doctor` and `sdr list --probe` before
-  `systemctl enable` turns "it doesn't work headless" into a category you
-  almost never meet.
+  `systemctl enable` retires "it doesn't work headless" almost entirely.
 - **Make silence impossible.** Heartbeat plus watchdog means every failure
-  mode leaves a journal trail; a box that can fail silently will.
+  leaves a journal trail; a box that can fail silently will.
 - **Restart as a test.** A fast, clean `systemctl restart` exercises the
-  entire teardown path — do it once after setup, on purpose, while you're
-  still watching.
+  whole teardown path — do it once after setup, while you're still watching.
 
 ## Variations
 
 - **The TUI closet.** SSH in and run
-  [`gophertrunk tui`]({{ '/tui.html' | relative_url }}) against the daemon —
-  the full cockpit in a terminal, no browser required.
+  [`gophertrunk tui`]({{ '/tui.html' | relative_url }}) — the full cockpit in
+  a terminal, no browser required.
 - **Docker Compose stack.** The compose file pairs naturally with a reverse
   proxy for [TLS]({{ '/blog/deep-dives/running-it-for-real-03-tls-reverse-proxy/' | relative_url }})
   when the console must leave the LAN.
-- **Split appliance.** Put the Pi at the antenna as a Part 8 `rtl_tcp` /
-  SoapyRemote source and the decode on a stronger box — closet appliance for
-  RF, desk machine for DSP.
+- **Split appliance.** Pi at the antenna as a Part 8 `rtl_tcp` / SoapyRemote
+  source, decode on a stronger box — closet for RF, desk for DSP.
 - **Windows service.** The same daemon runs as a Windows service via the
   installer; the [systemd & Windows deep dive]({{ '/blog/deep-dives/running-it-for-real-13-systemd-windows/' | relative_url }})
   covers both supervisors.
@@ -306,42 +293,41 @@ The appliance is running; now it can get *better at radio*. [Part
 12]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }})
 is the advanced RF build: two antennas on one coherent front end, MRC
 diversity combining, and the honest accounting of when a second antenna
-actually buys decode margin — and when it just buys a second feedline.
+buys decode margin — and when it just buys a second feedline.
 
 ## FAQ
 
 **Can a Raspberry Pi run GopherTrunk 24/7?**
 Yes — a Pi 4 comfortably runs a single-system trunking rig with recording
-and the web console, and a Pi 5 or mini-PC covers multi-system builds. The
+and the web console; a Pi 5 or mini-PC covers multi-system builds. The
 binary is pure Go with no native SDR libraries, so the ARM64 build runs
-as-is; sizing guidance lives in the [SBC guide]({{ '/best-single-board-computer-for-gophertrunk/' | relative_url }}).
+as-is; sizing lives in the [SBC guide]({{ '/best-single-board-computer-for-gophertrunk/' | relative_url }}).
 
 **Do I need to install librtlsdr or libusb on the appliance?**
-No. GopherTrunk's drivers speak USB directly through the kernel's USBDEVFS,
-so the only host requirements are the udev rule granting device-node access
+No. GopherTrunk's drivers speak USB directly through the kernel's USBDEVFS —
+the only host requirements are the udev rule granting device-node access
 and, under systemd hardening, the `DeviceAllow` line the shipped unit
 already carries.
 
 **How do I pass an RTL-SDR into Docker?**
 Map the device node with `devices:` in `docker-compose.yml` (or `--device`),
-matched to `lsusb`, with a host udev rule so the container user can open
-it. Verify with `docker exec gophertrunk gophertrunk sdr list`. Remember
-bus/device numbers change on re-enumeration — map `/dev/bus/usb` broadly if
-your dongle power-cycles.
+matched to `lsusb`, with a host udev rule so the container user can open it;
+verify with `docker exec gophertrunk gophertrunk sdr list`. Bus/device
+numbers change on re-enumeration — map `/dev/bus/usb` broadly if your
+dongle power-cycles.
 
 **How do I know a headless scanner is still healthy?**
-Three journal signals: the periodic `runtime: heartbeat` line (process
-alive, memory bounded), the absence of `sdr: watchdog: device missing`
-cycles (USB stable), and the ordinary rhythm of `control channel locked`
-and `recorder: call started/ended`. The web Dashboard shows the same facts
+Three journal signals: the periodic `runtime: heartbeat` line (alive,
+memory bounded), no `sdr: watchdog: device missing` cycles (USB stable),
+and the ordinary rhythm of `control channel locked` and
+`recorder: call started/ended`. The web Dashboard shows the same facts
 graphically from any LAN machine.
 
 **Why does my daemon warn about auth at startup?**
 It's bound to a non-loopback address with auth effectively off — the
-closed-LAN default. A prompt, not an error: set `api.auth.mode: "auto"` (or
-`"required"`) plus a `token_file` and the warning goes away along with the
-exposure. The [auth-posture deep dive]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }})
-explains the modes.
+closed-LAN default. A prompt, not an error: set `api.auth.mode: "auto"` or
+`"required"` plus a `token_file` and the warning goes away with the
+exposure ([auth-posture deep dive]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }})).
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-13-operator-cookbook-11-closet-appliance.md
+++ b/docs/_posts/2026-09-13-operator-cookbook-11-closet-appliance.md
@@ -1,0 +1,351 @@
+---
+title: "The Operator's Cookbook, Part 11: The Closet Appliance — Pi, systemd & Docker"
+description: Turn a GopherTrunk rig into a headless 24/7 appliance — a Raspberry Pi or mini-PC under a hardened systemd unit, Docker with USB pass-through, honest LAN auth posture, sdr doctor preflight, runtime heartbeats and USB watchdogs, and the graceful shutdown that finally takes milliseconds.
+category: tutorials
+keywords: raspberry pi sdr scanner 24/7, gophertrunk systemd service, docker rtl-sdr usb passthrough, headless police scanner setup, sdr daemon hardening linux, rtl-sdr udev rules, scanner appliance raspberry pi, sdr watchdog usb reset, gophertrunk cookbook
+tags: [operator-cookbook, raspberry-pi, systemd, docker, headless, operations]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 11
+---
+
+*Part 11 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 10]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }})
+made your recordings folder an archive worth keeping; this part gives it a
+home that never sleeps. The closet appliance is the rig most operators end
+up with: a small board in a closet, no monitor, started by systemd at boot,
+still decoding months later. The single Go binary makes this easy — the
+discipline is everything *around* the binary: supervision, permissions,
+watchdogs, and knowing healthy from a log line, because a log line is all
+you'll see.*
+
+> **TL;DR:** One static Go binary + the example unit at
+> [`docs/gophertrunk.service`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/gophertrunk.service)
+> makes a hardened appliance: `DynamicUser=true`, `ProtectSystem=strict`,
+> `DeviceAllow=char-usb_device rwm` for the pure-Go USB driver, `Restart=on-failure`,
+> logs in `journalctl -u gophertrunk -f`. Preflight with
+> `gophertrunk sdr doctor` (read-only driver-binding check), watch health via
+> `runtime: heartbeat` lines (`diagnostics.heartbeat_seconds`) and the USB
+> watchdog (`sdr.watchdog_interval_ms`) that re-acquires vanished dongles by
+> serial. Docker works too — the repo ships a `Dockerfile` and
+> `docker-compose.yml` whose `devices:` maps the dongle in. And
+> `systemctl restart` is now milliseconds, not a silent 30 s stall — that
+> teardown bug is fixed and warns if it ever recurs.
+
+**Key takeaways**
+
+- **An appliance is a binary plus supervision.** GopherTrunk is one static
+  executable with no libusb, no librtlsdr, no ALSA required — the whole
+  "install" is copying a file, and everything hard lives in the systemd unit.
+- **Hardening is shipped, not homework.** The example unit runs as a dynamic
+  user with a read-only filesystem view, explicit `ReadWritePaths`, and a
+  scoped USB `DeviceAllow` — you edit paths and serials, not policy.
+- **Headless health is three signals.** `runtime: heartbeat` proves the
+  process is alive and bounded, the SDR watchdog logs dongles leaving and
+  rejoining the bus, and the decode-status lines prove the radio side — learn
+  all three before the closet door closes.
+- **Shutdown speed is a correctness feature.** A stop that takes 30 silent
+  seconds gets `KillMode`'d by init systems and blamed on ghosts. The
+  streaming handlers now exit on signal; a blown window logs a WARN naming
+  itself.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Which board | Pi 4/5 class SBC or mini-PC sizing | [SBC build list]({{ '/gophertrunk-sbc-build/' | relative_url }}), [best SBC guide]({{ '/best-single-board-computer-for-gophertrunk/' | relative_url }}) |
+| Install & udev | binary, config, USB permissions | [Linux install]({{ '/install-linux.html' | relative_url }}), [hardening guide]({{ '/hardening.html' | relative_url }}) |
+| Supervision | hardened unit, restart-on-failure | `docs/gophertrunk.service`, [systemd deep dive]({{ '/blog/deep-dives/running-it-for-real-13-systemd-windows/' | relative_url }}) |
+| Containers | USB pass-through via `devices:` | repo `Dockerfile` + `docker-compose.yml`, [Docker deep dive]({{ '/blog/deep-dives/running-it-for-real-12-docker-usb/' | relative_url }}) |
+| Preflight | who owns the dongle before the daemon runs | `gophertrunk sdr doctor`, [sdr doctor deep dive]({{ '/blog/deep-dives/running-it-for-real-07-sdr-doctor-preflight/' | relative_url }}) |
+| Health & watchdogs | heartbeat line, USB re-acquire, memory cap | `diagnostics.heartbeat_seconds`, `sdr.watchdog_interval_ms`, `diagnostics.memory_limit_mb` |
+| Auth on the LAN | token-gated mutations on non-loopback binds | `api.auth`, [auth posture]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — a supervised, hardened, self-reporting box.
+- **The shopping list** — the board, and the power supply you shouldn't cheap out on.
+- **The config** — the appliance-specific keys, on top of any earlier recipe.
+- **The systemd unit** — install commands and what the hardening lines do.
+- **The Docker variation** — USB pass-through that actually works.
+- **First run & when it doesn't work** — headless health, undervoltage, USB resets, thermal.
+
+## What you're building
+
+Take any rig from Parts 1–10 and remove the human. The appliance boots,
+starts GopherTrunk under systemd, restarts itself on failure, and answers
+two remote surfaces: the web console, and `journalctl` over SSH. The
+[laptop-to-service deep dive]({{ '/blog/deep-dives/running-it-for-real-01-laptop-to-service/' | relative_url }})
+tells the *why* of each piece;
+[staying up]({{ '/blog/deep-dives/running-it-for-real-14-staying-up/' | relative_url }})
+covers the long-run failure modes. This recipe is the assembly.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Block diagram of the closet appliance: inside the closet a Raspberry Pi runs systemd which supervises the gophertrunk daemon with restart on failure; the daemon owns an RTL-SDR dongle over USB guarded by a watchdog that re-acquires it by serial, emits runtime heartbeat lines and decode logs into the systemd journal, and serves the web console and API over the LAN to a laptop, with a bearer token gating mutations">
+  <rect x="10" y="16" width="400" height="208" rx="8" fill="none" stroke="var(--fg-muted)" stroke-dasharray="5 4"/>
+  <text x="210" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the closet — Raspberry Pi / mini-PC, headless</text>
+  <rect x="28" y="52" width="120" height="40" rx="4" fill="none" stroke="currentColor"/>
+  <text x="88" y="69" text-anchor="middle" fill="currentColor" font-size="10">systemd</text>
+  <text x="88" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Restart=on-failure</text>
+  <line x1="88" y1="92" x2="88" y2="120" stroke="currentColor"/>
+  <polygon points="84,114 88,122 92,114" fill="currentColor"/>
+  <rect x="28" y="122" width="120" height="44" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="88" y="140" text-anchor="middle" fill="var(--accent)" font-size="10">gophertrunk run</text>
+  <text x="88" y="155" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DynamicUser, strict FS</text>
+  <rect x="196" y="122" width="96" height="44" rx="4" fill="none" stroke="currentColor"/>
+  <text x="244" y="140" text-anchor="middle" fill="currentColor" font-size="10">RTL-SDR</text>
+  <text x="244" y="155" text-anchor="middle" fill="var(--fg-muted)" font-size="9">/dev/bus/usb</text>
+  <line x1="148" y1="144" x2="196" y2="144" stroke="currentColor"/>
+  <text x="172" y="136" text-anchor="middle" fill="var(--fg-muted)" font-size="9">USB</text>
+  <path d="M 196 170 C 172 190 156 178 150 160" fill="none" stroke="var(--fg-muted)"/>
+  <text x="216" y="186" fill="var(--fg-muted)" font-size="9">watchdog: re-acquire by serial</text>
+  <rect x="196" y="52" width="196" height="40" rx="4" fill="none" stroke="currentColor"/>
+  <text x="294" y="69" text-anchor="middle" fill="currentColor" font-size="10">journald</text>
+  <text x="294" y="83" text-anchor="middle" fill="var(--fg-muted)" font-size="9">heartbeat · watchdog · decode lines</text>
+  <line x1="118" y1="122" x2="216" y2="92" stroke="var(--fg-muted)"/>
+  <rect x="470" y="52" width="196" height="52" rx="4" fill="none" stroke="currentColor"/>
+  <text x="568" y="72" text-anchor="middle" fill="currentColor" font-size="10">laptop: journalctl -f over SSH</text>
+  <text x="568" y="90" text-anchor="middle" fill="var(--fg-muted)" font-size="9">the only console this box has</text>
+  <rect x="470" y="132" width="196" height="52" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="568" y="152" text-anchor="middle" fill="var(--accent)" font-size="10">web console :8080 on the LAN</text>
+  <text x="568" y="170" text-anchor="middle" fill="var(--fg-muted)" font-size="9">mutations gated by bearer token</text>
+  <line x1="410" y1="76" x2="470" y2="76" stroke="currentColor" stroke-dasharray="3 3"/>
+  <line x1="410" y1="158" x2="470" y2="158" stroke="var(--accent)"/>
+  <text x="340" y="234" text-anchor="middle" fill="var(--fg-muted)" font-size="10">no monitor, no keyboard: supervision, permissions and log lines do the operator's job</text>
+</svg>
+<figcaption>The appliance in one picture: systemd supervises, the watchdog guards the USB port, and everything you'd normally see on a screen arrives as journal lines and web panels.</figcaption>
+</figure>
+
+## The shopping list
+
+| Item | Price (rough) | Notes |
+|---|---|---|
+| [Raspberry Pi]({{ '/reference/raspberry-pi/' | relative_url }}) 4/5 (or any x86 mini-PC) | ~$60–100 | a Pi 4 handles a single-system starter rig; multi-system and TETRA builds want a Pi 5 or mini-PC — see the [SBC guide]({{ '/best-single-board-computer-for-gophertrunk/' | relative_url }}) |
+| Official-grade power supply | ~$10 | the most skipped, most load-bearing item: undervoltage is the classic "random USB weirdness" cause |
+| Storage | varies | boot SD plus the Part 10 external disk if you archive |
+| Case with airflow | ~$10 | closets are warm; passive fins or a quiet fan |
+
+Dongles and antenna carry over. The
+[SBC build list]({{ '/gophertrunk-sbc-build/' | relative_url }}) and the
+[Pi scanner guide]({{ '/raspberry-pi-sdr-scanner/' | relative_url }}) cover
+specific models and cases.
+
+## The config
+
+Whatever system config you run, the appliance adds one theme: the box is on
+the LAN now, and nobody is watching it. Keys verified against
+`config.example.yaml`:
+
+```yaml
+log:
+  level: info
+
+api:
+  http_addr: "0.0.0.0:8080"        # reachable from the LAN, not just loopback
+  auth:
+    mode: "auto"                   # require a token off-loopback
+    token_file: "/etc/gophertrunk/api-token"
+
+diagnostics:
+  heartbeat_seconds: 60            # periodic runtime health line (0 = default 60)
+  memory_limit_mb: 0               # 0 auto-derives ~70% of RAM as a GC soft cap
+
+sdr:
+  watchdog_interval_ms: 30000      # USB-disconnect watchdog; re-acquires by serial
+```
+
+Three decisions. **`auth.mode: "auto"`** is the honest LAN posture: token
+required on non-loopback binds, loopback exempt. Set it *explicitly* — the
+[hardening guide]({{ '/hardening.html' | relative_url }}) documents that an
+empty `mode` now resolves to `disabled` for closed-LAN convenience, with a
+loud startup warning when that default takes effect on a non-loopback bind.
+`token_file` keeps the secret out of `config.yaml` and is re-read per
+request, so rotation needs no restart. **`memory_limit_mb: 0`** already
+protects you: it auto-derives a GC soft cap near 70% of physical RAM so the
+daemon bounds its footprint instead of meeting the OOM-killer.
+**`heartbeat_seconds`** makes silence impossible: a periodic
+`runtime: heartbeat` line means a stopped log is itself a diagnosis.
+
+## The systemd unit
+
+The repo ships a complete hardened unit. Install is five commands, straight
+from its header:
+
+```sh
+sudo install -m 0644 docs/gophertrunk.service /etc/systemd/system/gophertrunk.service
+sudo install -m 0755 bin/gophertrunk /usr/local/bin/gophertrunk
+sudo install -d -m 0755 /etc/gophertrunk
+sudo install -m 0640 config.example.yaml /etc/gophertrunk/config.yaml
+sudo systemctl daemon-reload && sudo systemctl enable --now gophertrunk
+```
+
+(Edit `/etc/gophertrunk/config.yaml` before the last line — and note the
+`0640` mode: that's the Part 9 key-hygiene rule enforced by the installer.)
+The lines worth understanding rather than cargo-culting:
+
+| Unit line | Why it's there |
+|---|---|
+| `Restart=on-failure` / `RestartSec=5` | crashes come back in five seconds; clean stops stay stopped |
+| `DynamicUser=true`, `NoNewPrivileges=true` | no dedicated account to manage, no privilege escalation path |
+| `ProtectSystem=strict` + `ReadWritePaths=` + `StateDirectory=gophertrunk` | the filesystem is read-only except where recordings and state actually live — point `ReadWritePaths` at your Part 10 archive dirs |
+| `DeviceAllow=char-usb_device rwm`, `SupplementaryGroups=plugdev` | the pure-Go USBDEVFS backend needs `/dev/bus/usb/*` read/write — no kernel driver, no libusb ([why]({{ '/blog/deep-dives/rf-front-end-01-why-pure-go-drivers/' | relative_url }})) |
+| `EnvironmentFile=-/etc/gophertrunk/env` (optional) | secrets outside the unit and the config |
+
+Logs land in the journal — `journalctl -u gophertrunk -f` is your new
+console. The udev rule granting non-root dongle access lives in the
+[hardware doc]({{ '/install-linux.html' | relative_url }}); apply it before
+first start.
+
+Before that first start, preflight the USB story from a shell:
+
+```sh
+gophertrunk sdr doctor        # read-only: which driver owns each known SDR
+gophertrunk sdr list --probe  # enumeration + per-device gain ladders
+```
+
+`sdr doctor` walks the known RTL-SDR and HackRF VID/PIDs and reports which
+kernel (or Windows) driver is bound to each, with an actionable next step —
+read-only, so it's safe alongside a live daemon. The
+[preflight deep dive]({{ '/blog/deep-dives/running-it-for-real-07-sdr-doctor-preflight/' | relative_url }})
+covers the verdicts.
+
+## The Docker variation
+
+The repo ships a multi-stage `Dockerfile` and a `docker-compose.yml` whose
+`devices:` entry maps the dongle into the container:
+
+```yaml
+    devices:
+      - "/dev/bus/usb/003/002:/dev/bus/usb/003/002"
+```
+
+Match the path to `lsusb` on the host, pair it with the host-side udev rule
+so a non-root container user can open the node, then smoke-test with
+`docker exec gophertrunk gophertrunk sdr list`. The
+[Docker deep dive]({{ '/blog/deep-dives/running-it-for-real-12-docker-usb/' | relative_url }})
+explains the trap: the mapped path names a *specific bus/device number*,
+which changes when the dongle re-enumerates — the reason systemd-on-metal is
+this recipe's default and mapping the whole `/dev/bus/usb` tree is the
+fallback for hotplug-prone hardware.
+
+## First run — what healthy looks like
+
+`sudo systemctl start gophertrunk`, then watch the journal. You'll see
+Part 1's trio (`api: listening`, `control channel locked`,
+`recorder: call started`), plus the appliance's own pulse once a minute:
+
+```
+INF runtime: heartbeat uptime=1h0m0s goroutines=142 heap_alloc_mb=88 heap_sys_mb=143 sys_mb=189 next_gc_mb=112 num_gc=412
+```
+
+Read it like a vital sign: climbing goroutines or heap across hours is a
+leak, a frozen heartbeat on a live process is a hang, and the last line
+before an abrupt cut pins the pre-kill footprint for an OOM diagnosis. When
+a dongle drops off the bus, the watchdog narrates the whole recovery:
+
+```
+WRN sdr: watchdog: device missing from USB enumerate serial=00000001
+INF sdr: watchdog: device reappeared; reacquiring serial=00000001
+```
+
+Finally, test the thing appliances do most: restart.
+`sudo systemctl restart gophertrunk` should log
+`gophertrunk shutdown initiated` → `gophertrunk shutdown complete` in well
+under a second. That speed is recent work: shutdown used to park for a full
+30 s whenever any SSE or live-audio client was attached — nothing told the
+streaming handlers to exit while the HTTP server politely waited, and the
+timeout was then miscounted as a clean exit. The fix threads a stop signal
+to every long-lived handler; the 30 s is now only a cap, and blowing it logs
+`api: graceful shutdown window expired — a streaming handler did not exit`,
+so a slow restart names its culprit class instead of shrugging.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Random USB errors, dongle re-enumerates under load | undervoltage — the classic Pi failure | Use a proper supply; on a Pi, check the kernel log for its low-voltage warnings; move the SDR to a powered hub if the board browns out with bias-tee LNAs |
+| `sdr: watchdog: device missing from USB enumerate` repeating | flaky cable/port, or genuine power sag | The watchdog re-acquires by serial automatically; if it cycles, treat it as hardware — the [dongle-off-the-bus postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-18-the-stall-that-wasnt/' | relative_url }}) is the war story |
+| `ccdecoder: decode can't keep up with real time` | CPU-starved board — too many systems/taps for the silicon, or thermal throttling | Reduce taps/systems, add cooling, or step up the board; this WARN is the CPU signal, distinct from any RF problem |
+| Decodes fine for days, then killed with no log line | memory pressure — OOM-killer | The auto `memory_limit_mb` guards this; on tiny boards set it explicitly and watch heartbeat `heap_sys_mb` trends |
+| `api: auth disabled — mutation endpoints are not authenticated` at startup | empty `auth.mode` resolving to the closed-LAN default on a `0.0.0.0` bind | Set `mode: "auto"` or `"required"` with a `token_file` — deliberate posture, not defaults ([hardening]({{ '/hardening.html' | relative_url }})) |
+| Daemon starts, no radio, no error | device node permissions under the hardened unit | Check the udev rule + `DeviceAllow`/`SupplementaryGroups` lines; `gophertrunk sdr doctor` from a shell tells you who owns the dongle |
+| `systemctl stop` takes ~30 s | a streaming handler missed the stop signal (the fixed bug's shape) | The journal WARN above fires when the cap is hit — report it with the log; it is a bug, not a config problem |
+| Web console unreachable from the LAN | daemon bound to loopback | `api.http_addr: "0.0.0.0:8080"` — then do the auth row above, in that order |
+
+### How this recipe shapes operator practice
+
+- **Preflight, then trust.** `sdr doctor` and `sdr list --probe` before
+  `systemctl enable` turns "it doesn't work headless" into a category you
+  almost never meet.
+- **Make silence impossible.** Heartbeat plus watchdog means every failure
+  mode leaves a journal trail; a box that can fail silently will.
+- **Restart as a test.** A fast, clean `systemctl restart` exercises the
+  entire teardown path — do it once after setup, on purpose, while you're
+  still watching.
+
+## Variations
+
+- **The TUI closet.** SSH in and run
+  [`gophertrunk tui`]({{ '/tui.html' | relative_url }}) against the daemon —
+  the full cockpit in a terminal, no browser required.
+- **Docker Compose stack.** The compose file pairs naturally with a reverse
+  proxy for [TLS]({{ '/blog/deep-dives/running-it-for-real-03-tls-reverse-proxy/' | relative_url }})
+  when the console must leave the LAN.
+- **Split appliance.** Put the Pi at the antenna as a Part 8 `rtl_tcp` /
+  SoapyRemote source and the decode on a stronger box — closet appliance for
+  RF, desk machine for DSP.
+- **Windows service.** The same daemon runs as a Windows service via the
+  installer; the [systemd & Windows deep dive]({{ '/blog/deep-dives/running-it-for-real-13-systemd-windows/' | relative_url }})
+  covers both supervisors.
+
+## Where this goes next
+
+The appliance is running; now it can get *better at radio*. [Part
+12]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }})
+is the advanced RF build: two antennas on one coherent front end, MRC
+diversity combining, and the honest accounting of when a second antenna
+actually buys decode margin — and when it just buys a second feedline.
+
+## FAQ
+
+**Can a Raspberry Pi run GopherTrunk 24/7?**
+Yes — a Pi 4 comfortably runs a single-system trunking rig with recording
+and the web console, and a Pi 5 or mini-PC covers multi-system builds. The
+binary is pure Go with no native SDR libraries, so the ARM64 build runs
+as-is; sizing guidance lives in the [SBC guide]({{ '/best-single-board-computer-for-gophertrunk/' | relative_url }}).
+
+**Do I need to install librtlsdr or libusb on the appliance?**
+No. GopherTrunk's drivers speak USB directly through the kernel's USBDEVFS,
+so the only host requirements are the udev rule granting device-node access
+and, under systemd hardening, the `DeviceAllow` line the shipped unit
+already carries.
+
+**How do I pass an RTL-SDR into Docker?**
+Map the device node with `devices:` in `docker-compose.yml` (or `--device`),
+matched to `lsusb`, with a host udev rule so the container user can open
+it. Verify with `docker exec gophertrunk gophertrunk sdr list`. Remember
+bus/device numbers change on re-enumeration — map `/dev/bus/usb` broadly if
+your dongle power-cycles.
+
+**How do I know a headless scanner is still healthy?**
+Three journal signals: the periodic `runtime: heartbeat` line (process
+alive, memory bounded), the absence of `sdr: watchdog: device missing`
+cycles (USB stable), and the ordinary rhythm of `control channel locked`
+and `recorder: call started/ended`. The web Dashboard shows the same facts
+graphically from any LAN machine.
+
+**Why does my daemon warn about auth at startup?**
+It's bound to a non-loopback address with auth effectively off — the
+closed-LAN default. A prompt, not an error: set `api.auth.mode: "auto"` (or
+`"required"`) plus a `token_file` and the warning goes away along with the
+exposure. The [auth-posture deep dive]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }})
+explains the modes.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: The Archival Rig — FLAC, Retention & the Call Log]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }})
+· Next →
+[Part 12: Two Antennas, One Signal — A Diversity Build]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }})

--- a/docs/_posts/2026-09-13-p25-end-to-end-11-wideband.md
+++ b/docs/_posts/2026-09-13-p25-end-to-end-11-wideband.md
@@ -1,0 +1,324 @@
+---
+title: "P25 End to End, Part 11: Wideband P25 — Watching the Whole System at Once"
+description: One wide capture, many control channels — the tuner-bank architecture behind role wideband, per-call voice taps carved from the same IQ stream, and the twin down-converter paths (the wideband DDCBank vs the single-channel Downconverter) whose drift let the fix for issue 764 miss the replay symptom in issue 771.
+category: deep-dives
+keywords: wideband p25 monitoring, sdr channelizer, ddc bank, polyphase channelizer, monitor multiple p25 sites one sdr, p25 voice taps, sdr pre-decimation input sample rate, wideband trunking scanner, gophertrunk p25
+tags: [p25-end-to-end, p25, wideband, dsp, channelizer, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 11
+---
+
+*Part 11 of **P25 End to End**, a 14-part deep dive that follows North
+America's dominant trunking protocol through GopherTrunk — from a raw C4FM
+carrier to recorded, named, multi-site voice.
+[Part 10]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})
+built the site map and roamed it one control channel at a time. This part
+removes the "one at a time": pin a single SDR across a band and every site
+inside its IQ window decodes simultaneously, out of one capture. It is also
+where the series' running thread lands hardest — the wideband tuner bank
+and the single-channel down-converter are **twin paths**, and the day a fix
+landed on one and not the other is the reason this repo has an
+issue-closing policy.*
+
+> **TL;DR:** `role: wideband` pins one dongle to a band centre; a
+> `tuner.Bank` (`internal/dsp/tuner/`) extracts a 48 kHz narrowband stream
+> per configured channel, and `internal/scanner/widebandt2` runs a
+> per-channel P25 (or DMR/NXDN) state machine on each — multi-site P25
+> means listing each site's CC as its own tap, decoded **in parallel, not
+> hunted**. Voice grants ride the same capture via per-call DDC taps
+> (`internal/sdr/wbvoice`, `voice_taps: N`). Two Bank implementations
+> exist (`DDCBank` per-tap NCO+resampler, `ChannelizerBank` polyphase;
+> `tuner_strategy: auto` picks by tap count) — and the wideband `DDCBank`
+> is a **different code path** from the single-channel
+> `ccdecoder.Downconverter` that `replay -tune-hz` and the hunting daemon
+> use. A fix to one does not touch the other: that is how the
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) "fix"
+> missed the [#771](https://github.com/MattCheramie/GopherTrunk/issues/771)
+> replay symptom. `sdr.input_sample_rate` adds a systemwide pre-decimation
+> stage when the front end must run faster than you decode.
+
+**Key takeaways**
+
+- **Parallel beats serial for multi-site.** A hunted single channel visits
+  sites one at a time (Part 10); a wideband bank watches every CC in the
+  IQ window at once, and grants can be voice-tapped from the same samples
+  without retuning anything.
+- **Two banks, one interface — and a second twin underneath.** `DDCBank`
+  and `ChannelizerBank` implement one `Bank` contract; below them, the
+  wideband bank and the single-channel `Downconverter` are parallel DDC
+  implementations that have provably drifted apart before.
+- **Symbol clocks come from `OutputRateHz()`, not the nominal target.** A
+  pathological input rate can land the tap a fraction of a percent off
+  48 kHz (issue #550) — a "baud drift" that looks exactly like a demod bug.
+- **A wide capture spends a shared budget.** One antenna, one gain, one
+  ADC across every tap (issue #749) — and raising the native rate to cover
+  more band can *lower* in-channel quality (#764). The levers are
+  `gain: "auto"` and `sdr.input_sample_rate`, not more megasamples.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Wideband engine | per-channel receivers + state machines on one SDR | `internal/scanner/widebandt2` (`Engine`) |
+| Bank contract | AddTap / Process / OutputRateHz per tap | `internal/dsp/tuner/tuner.go` (`Bank`) |
+| Per-tap DDC bank | one NCO mixer + rational resampler per tap | `internal/dsp/tuner/ddc.go` (`DDCBank`) |
+| Polyphase bank | shared channelizer + fine-tune DDC, many taps | `internal/dsp/tuner/channelizerbank.go` (`ChannelizerBank`) |
+| Voice taps | per-call virtual tuner on the wideband stream | `internal/sdr/wbvoice` (`VirtualTuner`, `voice_taps`) |
+| The single-channel twin | live hunting daemon + `replay -tune-hz` DDC | `internal/scanner/ccdecoder/ddc.go` (`Downconverter`) |
+| Pre-decimation lever | native rate → decode rate at the Device boundary | `sdr.input_sample_rate` (`internal/sdr/decimate.Device`) |
+
+## In this post
+
+- **One capture, many channels** — the wideband engine and multi-site P25 config.
+- **The bank** — two implementations of one contract, and the #764 CPU story.
+- **Voice without retuning** — per-call DDC taps as virtual tuners.
+- **The twin pair that made a fix miss** — #764, #771, and the drift rules.
+- **What a wide capture costs** — shared gain, CPU, and the honest limits.
+
+## One capture, many channels
+
+A 2.4 MS/s dongle sees roughly ±1.08 MHz of usable band after guard — on
+an 800 MHz system, easily several sites' control channels plus most of
+their voice channels. `role: wideband` pins the dongle to a centre
+frequency and lists channels, each referencing a `trunking.systems` entry
+whose protocol picks the state machine — `p25` runs the Phase 1 TSBK chain
+([Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})),
+`p25-phase2` the MAC chain
+([Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})),
+and DMR/NXDN mix freely on the same dongle. The per-channel receivers are
+the same ones the rest of this series met — the twin discipline starts
+with reusing them, not forking them.
+
+For **multi-site P25**, each site's control channel becomes its own
+`channels:` entry pointing at the same system. Every tap decodes in
+parallel out of the one capture — they are *not* hunted one at a time — so
+the [Part 10]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})
+site tracker fills in minutes instead of sessions.
+[The Hunt Part 9]({{ '/blog/deep-dives/the-hunt-09-wideband-multisite-p25/' | relative_url }})
+tells this story from the discovery side. Sites of one system can even
+differ in modulation: a per-channel `p25_phase1_demod_mode` override
+(issue #935) lets a genuinely-linear LSM site decode on the CQPSK path
+([Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }}))
+while its C4FM siblings keep the default — and the config docs warn, in
+bold, not to set `cqpsk` just because a site is *simulcast*: simulcast is a
+transmitter-coordination technique, not a modulation.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="A wideband capture drawn as a spectrum with four carrier humps inside a 2.4 megasample IQ window. Three DDC taps drop from carriers to parallel 48 kilohertz decoders: two P25 control-channel state machines for site 1 and site 2 and one DMR channel. A fourth, dashed tap labelled per-call voice tap is allocated on a voice grant and feeds the composer. All decoders publish onto one events bus.">
+  <line x1="30" y1="70" x2="650" y2="70" stroke="var(--fg-muted)"/>
+  <text x="340" y="18" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">one wideband capture — centre 852.0 MHz, 2.4 MS/s (±1.08 MHz usable)</text>
+  <path d="M60 70 Q85 30 110 70" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M200 70 Q225 26 250 70" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M370 70 Q395 34 420 70" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M520 70 Q545 38 570 70" fill="none" stroke="var(--accent)" stroke-width="2" stroke-dasharray="5 3"/>
+  <text x="85" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9">site 1 CC</text>
+  <text x="225" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9">site 2 CC</text>
+  <text x="395" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="9">DMR carrier</text>
+  <text x="545" y="84" text-anchor="middle" fill="var(--accent)" font-size="9">voice grant</text>
+  <line x1="85" y1="90" x2="85" y2="130" stroke="currentColor"/><polygon points="81,128 85,136 89,128" fill="currentColor"/>
+  <line x1="225" y1="90" x2="225" y2="130" stroke="currentColor"/><polygon points="221,128 225,136 229,128" fill="currentColor"/>
+  <line x1="395" y1="90" x2="395" y2="130" stroke="currentColor"/><polygon points="391,128 395,136 399,128" fill="currentColor"/>
+  <line x1="545" y1="90" x2="545" y2="130" stroke="var(--accent)" stroke-dasharray="5 3"/><polygon points="541,128 545,136 549,128" fill="var(--accent)"/>
+  <text x="340" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="9">tuner.Bank — one 48 kHz narrowband stream per tap (DDCBank or ChannelizerBank)</text>
+  <rect x="30" y="136" width="110" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="85" y="153" text-anchor="middle" fill="currentColor" font-size="9">P25 P1 receiver</text>
+  <text x="85" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">TSBK chain, site 1</text>
+  <rect x="170" y="136" width="110" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="225" y="153" text-anchor="middle" fill="currentColor" font-size="9">P25 P1 receiver</text>
+  <text x="225" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">TSBK chain, site 2</text>
+  <rect x="340" y="136" width="110" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="395" y="153" text-anchor="middle" fill="currentColor" font-size="9">DMR receiver</text>
+  <text x="395" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">Tier II/III chain</text>
+  <rect x="490" y="136" width="110" height="42" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 3"/>
+  <text x="545" y="153" text-anchor="middle" fill="var(--accent)" font-size="9">wbvoice tap</text>
+  <text x="545" y="167" text-anchor="middle" fill="var(--fg-muted)" font-size="9">per-call, → composer</text>
+  <line x1="85" y1="178" x2="300" y2="210" stroke="var(--fg-muted)"/>
+  <line x1="225" y1="178" x2="320" y2="210" stroke="var(--fg-muted)"/>
+  <line x1="395" y1="178" x2="360" y2="210" stroke="var(--fg-muted)"/>
+  <line x1="545" y1="178" x2="380" y2="210" stroke="var(--fg-muted)"/>
+  <rect x="240" y="210" width="200" height="28" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="228" text-anchor="middle" fill="var(--accent)" font-size="10">events bus → engine, grants, calls</text>
+</svg>
+<figcaption>Every carrier in the IQ window gets its own 48 kHz stream and its own state machine — control channels permanently, voice channels per call.</figcaption>
+</figure>
+
+## The bank
+
+The channelizer contract is small and both implementations honour it:
+
+```go
+// internal/dsp/tuner/tuner.go (shape)
+type Bank interface {
+    AddTap(offsetHz float64, sink SinkFunc) error
+    Process(src []complex64) // one wideband chunk in, every sink fed
+    InputRateHz() float64
+    // The rate the bank ACTUALLY emits — may differ a fraction of a
+    // percent from the nominal target (issue #550). Symbol clocks must
+    // be built from this value, not the nominal target.
+    OutputRateHz() float64
+    Reset()
+}
+```
+
+`DDCBank` runs one NCO mixer plus rational polyphase resampler per tap —
+O(taps × samples), simple and exact. `ChannelizerBank` amortises the
+anti-alias work across taps with a shared polyphase filter bank plus a
+fine-tune DDC per channel, which wins when tap counts grow;
+`tuner_strategy: auto` picks `ddc` up to six channels and `polyphase`
+above ([SDR Internals Part 5]({{ '/blog/deep-dives/sdr-internals-05-tuning-channelization/' | relative_url }})
+covers the DSP). That `OutputRateHz` comment in the contract is a scar: a
+non-standard input rate can reduce to a pathological L/M ratio, and the old
+fallback silently shifted the achieved rate — a 3.019 MS/s capture landed a
+144 kHz tap at 143762 Hz, −0.165% of symbol rate, the "baud drift"
+signature. The bounded `bestRatioUnderCaps` search (issue #550) lands
+143998 Hz instead.
+
+`DDCBank` also carries the CPU half of the #764 story. At 10 MS/s the old
+bank ran a 208:1 single-stage decimation *per tap*, which starved the live
+wideband pump goroutine until samples dropped at the hardware layer. The
+fix is a **shared** integer pre-decimation stage that runs once over the
+wideband stream, bringing it down to the ~2.5 MS/s regime the per-tap
+resamplers were tuned for — and below that floor the path is deliberately
+byte-for-byte identical to the pre-#764 behaviour, so the fix could not
+silently change working configs.
+
+## Voice without retuning
+
+A control-channel tap never moves; voice grants land wherever the band plan
+puts them. `internal/sdr/wbvoice` closes that gap: a `VirtualTuner`
+implements the same interfaces as a physical voice SDR
+(`SetCenterFreq` for the
+[voice pool]({{ '/blog/deep-dives/trunking-engine-04-voice-pool/' | relative_url }}),
+`StreamIQ` for the composer) but its `SetCenterFreq` allocates a per-call
+DDC tap on the wideband stream instead of touching hardware. It emits
+exactly 48 kHz (`wbvoice.NarrowbandRateHz`), so the composer's decimator
+collapses to a no-op. `voice_taps: N` sets how many concurrent calls one
+dongle carries; a grant outside the IQ window (minus a 5% guard) returns
+`ErrOutOfBand`, which the engine treats as "wrong tuner for this grant" and
+routes to the next free device — so one wideband dongle plus one physical
+voice SDR covers both the in-window common case and the out-of-window
+stragglers ([wideband-voice-taps]({{ '/reference/wideband-voice-taps/' | relative_url }})
+has the operator view).
+
+## The twin pair that made a fix miss
+
+Now the hard lesson. GopherTrunk has **two** wideband-to-narrowband
+implementations, and they are not wired together:
+
+| | `ccdecoder.Downconverter` | `tuner.DDCBank` |
+|---|---|---|
+| Taps | one channel | many |
+| Used by | hunting daemon's CC path, `replay -tune-hz`, siglab | `role: wideband`, wbvoice, hunt sweeps |
+| Rate handling | interpolates *up* too (sub-rate captures) | shared pre-decimation + per-tap resample |
+| File | `internal/scanner/ccdecoder/ddc.go` | `internal/dsp/tuner/ddc.go` |
+
+When issue #764 ("P25 decodes at 2.5 MS/s but not 10 MS/s") was first
+"fixed", the fix landed in the wideband `DDCBank`. The reporter's replay
+symptom lived in the single-channel `Downconverter` — a path the fix never
+touched — so the issue was closed twice while the symptom was still live,
+which is issue #771 and the origin of this repo's issue-closing policy
+(**never close until a failing-first regression passes and the reporter
+confirms**). The full postmortem chain is
+[Ten Megasamples]({{ '/blog/solution-postmortem/from-the-issue-tracker-05-ten-megasamples/' | relative_url }})
+and the
+[Two Pipelines finale]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }});
+the ending is worth restating because it changed the mental model. The
+decode path is **rate-invariant**: both down-converters normalise to the
+per-protocol channel rate
+([Part 1]({{ '/blog/deep-dives/p25-end-to-end-01-c4fm-carrier/' | relative_url }})'s
+48 kHz), and `ddc_highrate_test.go` pins that a noisy channel reaches the
+receiver at the same in-channel SNR whether decoded natively at 10 MS/s or
+decimated to 2.5 MS/s. The reporter's own captures then closed #764
+honestly: the 10 MS/s file replayed at ≈9.5 dB demod SNR against the
+2.5 MS/s file's ≈19.7 dB, an *independent* resampler reproduced the same
+deficit, and neither capture clipped — the ~10 dB was **baked into the
+samples** (front-end phase noise at the Airspy's native 10 MS/s clock),
+not GT's DSP. The decoder can only be as good as the samples.
+
+The twins have since been actively converged where it counts: the #550
+ratio fallback was ported into the `Downconverter` explicitly to close a
+"two separate DDC paths" divergence, and both files now say so in
+comments. But the structural rule stands — when you fix anything in one
+down-converter, go read the other one.
+
+## What a wide capture costs
+
+Three budgets, all shared across every tap:
+
+- **RF budget** (issue #749): one antenna, one centre, one gain. A fixed
+  gain chosen for the strongest site leaves weak co-tenants flat at the
+  ADC floor; a hot site can desensitise everything. Prefer `gain: "auto"`
+  on multi-site dongles — the daemon logs a startup WARN for a fixed-gain
+  multi-tap config — and watch
+  `gophertrunk_sdr_wideband_input_clip_ratio`. A genuinely weak distant
+  site may deserve its own dongle.
+- **CPU budget**: every tap is a full receiver. When decode falls behind,
+  the honest signals are the `ccdecoder: decode can't keep up with real
+  time` WARN and, on network SDRs, `soapyremote` overrun drops — a
+  *downstream* symptom, not a driver bug. `sdr.input_sample_rate` is the
+  systemwide lever: the hardware runs at its happy native rate (an Airspy
+  pinned to 10 MS/s) while `decimate.Device` integer-decimates to
+  `sdr.sample_rate` at the Device boundary, before the bank, the demods,
+  and every recording tap. It must be an exact integer multiple, and it
+  survives device reacquisition because it wraps the Device rather than
+  threading a second rate through the daemon.
+- **Physics budget**: the lever above is a load and recording-size fix,
+  *not* an RF fix — decimating 10 → 2.5 MS/s does not recover quality lost
+  to native-clock phase noise (#764 again;
+  [The Analog Edge Part 6]({{ '/blog/tutorials/analog-edge-06-sample-rate/' | relative_url }})
+  is the operator's guide to choosing rates).
+
+## Where this goes next
+
+Wideband is P25 monitoring at its most parallel — and it still inherits
+the weakest link of the series:
+[Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})
+faces the honest gap, the default C4FM voice path's missing equalizer and
+soft FEC, why the fix is gated on a real capture, and what contributing one
+looks like.
+
+## FAQ
+
+**Can one SDR really monitor a whole P25 system?**
+If the system's channels fit the dongle's usable IQ window (sample rate
+minus a 5% guard per edge), yes: every site's CC as a wideband tap, voice
+via `voice_taps`, with a physical voice SDR as fallback for out-of-window
+grants. Systems spread across more spectrum than one dongle sees need a
+second dongle — each `widebandt2.Engine` owns one SDR and they share only
+the bus.
+
+**Why does only one site decode while its siblings sit at the noise floor?**
+The channelizer is gain-flat across taps, so that difference is real RF: a
+weak or distant site at this shared centre and gain, or a strong site
+overloading the shared ADC. Check the input clip ratio first — if it's
+non-zero, *lower* the gain or add attenuation; otherwise try `gain: "auto"`
+(issue #749), and give a genuinely weak site its own dongle.
+
+**Should I raise the sample rate to cover more channels?**
+Only as far as the front end stays clean. More megasamples cost CPU per
+tap and, on some hardware, in-channel quality — the #764 capture pair
+measured ~10 dB *worse* demod SNR at the Airspy's native 10 MS/s than at
+2.5 MS/s, baked into the samples. If the hardware must run fast, set
+`sdr.input_sample_rate` and decode at a lower `sdr.sample_rate`.
+
+**What's the difference between `tuner_strategy: ddc` and `polyphase`?**
+Cost shape. `ddc` (`DDCBank`) pays per tap — simple and exact, fine to ~6
+channels. `polyphase` (`ChannelizerBank`) pays mostly once in a shared
+filter bank, winning as tap counts grow. `auto` picks by channel count;
+both honour the same `Bank` contract, so decoders can't tell them apart.
+
+**Why did the daemon decode a capture that `replay` wouldn't (or vice versa)?**
+Historically: because they channelize through different code (`DDCBank` vs
+`ccdecoder.Downconverter`) and a fix had landed on one side only — the
+#764/#771 story. Today the paths are pinned by rate-invariance tests and
+share the ratio math, but a daemon/replay disagreement is always worth
+filing: it is a twin-path drift detector by construction.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: Sites, WACNs & Roaming a Multi-Site System]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }})
+· Next →
+[Part 12: The Weak-Signal Gap — P1 Voice's Missing Levers]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})

--- a/docs/_posts/2026-09-13-p25-end-to-end-11-wideband.md
+++ b/docs/_posts/2026-09-13-p25-end-to-end-11-wideband.md
@@ -53,9 +53,9 @@ issue-closing policy.*
   pathological input rate can land the tap a fraction of a percent off
   48 kHz (issue #550) — a "baud drift" that looks exactly like a demod bug.
 - **A wide capture spends a shared budget.** One antenna, one gain, one
-  ADC across every tap (issue #749) — and raising the native rate to cover
-  more band can *lower* in-channel quality (#764). The levers are
-  `gain: "auto"` and `sdr.input_sample_rate`, not more megasamples.
+  ADC across every tap (issue #749) — and raising the native rate can
+  *lower* in-channel quality (#764). The levers are `gain: "auto"` and
+  `sdr.input_sample_rate`, not more megasamples.
 
 ## Cheat sheet
 
@@ -210,7 +210,7 @@ implementations, and they are not wired together:
 | | `ccdecoder.Downconverter` | `tuner.DDCBank` |
 |---|---|---|
 | Taps | one channel | many |
-| Used by | hunting daemon's CC path, `replay -tune-hz`, siglab | `role: wideband`, wbvoice, hunt sweeps |
+| Used by | hunting daemon's CC path, `replay -tune-hz` | `role: wideband`, wbvoice, siglab wideband decode |
 | Rate handling | interpolates *up* too (sub-rate captures) | shared pre-decimation + per-tap resample |
 | File | `internal/scanner/ccdecoder/ddc.go` | `internal/dsp/tuner/ddc.go` |
 
@@ -237,11 +237,11 @@ deficit, and neither capture clipped — the ~10 dB was **baked into the
 samples** (front-end phase noise at the Airspy's native 10 MS/s clock),
 not GT's DSP. The decoder can only be as good as the samples.
 
-The twins have since been actively converged where it counts: the #550
-ratio fallback was ported into the `Downconverter` explicitly to close a
-"two separate DDC paths" divergence, and both files now say so in
-comments. But the structural rule stands — when you fix anything in one
-down-converter, go read the other one.
+The twins have since been converged where it counts: the #550 ratio
+fallback was ported into the `Downconverter` explicitly to close the "two
+separate DDC paths" divergence, and both files say so in comments. But the
+structural rule stands — fix anything in one down-converter, go read the
+other one.
 
 ## What a wide capture costs
 
@@ -273,21 +273,20 @@ Three budgets, all shared across every tap:
 ## Where this goes next
 
 Wideband is P25 monitoring at its most parallel — and it still inherits
-the weakest link of the series:
+the series' weakest link:
 [Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})
-faces the honest gap, the default C4FM voice path's missing equalizer and
-soft FEC, why the fix is gated on a real capture, and what contributing one
-looks like.
+faces the honest gap — the default C4FM voice path's missing equalizer and
+soft FEC, why the fix is gated on a real capture, and what contributing
+one looks like.
 
 ## FAQ
 
 **Can one SDR really monitor a whole P25 system?**
 If the system's channels fit the dongle's usable IQ window (sample rate
 minus a 5% guard per edge), yes: every site's CC as a wideband tap, voice
-via `voice_taps`, with a physical voice SDR as fallback for out-of-window
-grants. Systems spread across more spectrum than one dongle sees need a
-second dongle — each `widebandt2.Engine` owns one SDR and they share only
-the bus.
+via `voice_taps`, a physical voice SDR as fallback for out-of-window
+grants. Systems spread wider than one dongle sees need a second dongle —
+each `widebandt2.Engine` owns one SDR and they share only the bus.
 
 **Why does only one site decode while its siblings sit at the noise floor?**
 The channelizer is gain-flat across taps, so that difference is real RF: a

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -31,10 +31,11 @@ itself.*
 > CRC-valid frames**. `TestProcessDecodesRealAirFormat`
 > (`internal/radio/motorola/process_test.go`) feeds the real SmartNet air
 > format to the decoder: the pre-[#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)
-> fabricated framing decodes **nothing**. And three tests in
-> `internal/scanner/ccdecoder/pipelines_dmo_test.go` all fail against the old
-> DMO grant path that opened recordings on noise. **The failing test is the
-> reproduction, and the reproduction is where the root cause surfaces.**
+> fabricated framing decodes **nothing**. And three
+> `internal/scanner/ccdecoder/pipelines_dmo_test.go` tests all fail against
+> the old DMO grant path that opened recordings on noise. **The failing test
+> is the reproduction, and the reproduction is where the root cause
+> surfaces.**
 
 **Key takeaways**
 
@@ -74,7 +75,7 @@ itself.*
 - **Three tests against one pipeline** — the noise-grant trio.
 - **Failing first as a diagnostic method** — root causes surface in the
   reproduction.
-- **When you cannot fail first** — the honest ending, and the Part 14 tie-in.
+- **When you cannot fail first** — the honest ending, the Part 14 tie-in.
 
 ## The rule, and what it is actually for
 
@@ -97,11 +98,11 @@ twice on fixes nobody had watched fail while the symptom stayed live
 Part 14 turns into policy.
 
 One earned caveat: a failing test proves you reproduced *a* bug; only outside
-evidence proves it's *the* bug. The villain of
+evidence proves it's *the* bug. The
 [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
-— the test that shares its assumption with the code — fabricates a convincing
-failure as easily as a convincing pass, and all three examples below had to
-defeat it first.
+villain — the test sharing its assumption with the code — fabricates a
+convincing failure as easily as a convincing pass, and all three examples
+below had to defeat it first.
 
 ## Zero frames, then two: the colour-0 descramble
 

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -89,30 +89,29 @@ cheapest verification gate in the series. A fix without a failing test makes
 two unproven claims at once: that you found the real cause, and that your
 change removes it. The failing test converts both into observations — it
 fails against the old code, so the reproduction is real; it passes against
-the new, so the change addresses *that* reproduction. This project learned
-the price of skipping them in public: issue
+the new, so the change addresses *that* reproduction. The price of skipping
+them was paid in public: issue
 [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was closed
 twice on fixes nobody had watched fail, while the symptom stayed live
 ([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)) — the story
-[the on-air gate]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
-told and Part 14 turns into policy.
+Part 14 turns into policy.
 
-One caveat the series has already earned: a failing test proves you
-reproduced *a* bug; only outside evidence proves it's *the* bug. The villain
-of [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
-— the test that shares its assumption with the code — fabricates a
-convincing failure as easily as a convincing pass, and all three examples
-below had to defeat it before the rule could work.
+One earned caveat: a failing test proves you reproduced *a* bug; only outside
+evidence proves it's *the* bug. The villain of
+[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+— the test that shares its assumption with the code — fabricates a convincing
+failure as easily as a convincing pass, and all three examples below had to
+defeat it first.
 
 ## Zero frames, then two: the colour-0 descramble
 
 [Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
 told the DMO story from the verdict side: clear TETRA direct-mode voice sat
 at a ~1/256 chance-floor CRC rate and got misread as encryption, when the
-real cause was that `DMBurstTCHSpeech` skipped descrambling at colour code 0.
+real cause was `DMBurstTCHSpeech` skipping descramble at colour code 0.
 TETRA scrambling is **not** an identity at colour 0 — the LFSR seeds to
-`0xC0000000` (EN 300 392-2 §8.2.5.2), which is exactly why the signalling
-paths always descramble and always decoded.
+`0xC0000000` (EN 300 392-2 §8.2.5.2), which is why the signalling paths, which
+always descramble, always decoded.
 
 The regression test is the interesting artifact, because the *old* suite had
 checked this and passed: its round-trips scrambled and descrambled under the
@@ -209,7 +208,7 @@ them* — at which point the idle-channel test could demand `dnbQualified == 0`
 against ~18 raw detections a second and watch the old code fail.
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two bug-fix workflows compared. Top row, guess-fix-close: symptom, guessed cause, fix, existing tests green, issue closed — with a dashed arrow looping from the closed issue back to the symptom, labelled reporter reopens. Bottom row, reproduce-fail-fix-pass: symptom, faithful reproduction, a test that fails against the old code (marked as where the root cause surfaces), the fix, the same test passing, verified close.">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two bug-fix workflows. Top: guess, fix, green tests, closed issue, and a dashed loop back to the symptom when the reporter reopens. Bottom: faithful reproduction, a test failing against the old code where the root cause surfaces, the fix, the same test passing, a verified close.">
   <text x="20" y="24" fill="currentColor" font-size="11" font-weight="bold">guess → fix → close</text>
   <rect x="20" y="36" width="92" height="28" rx="5" fill="none" stroke="currentColor"/>
   <text x="66" y="54" text-anchor="middle" fill="currentColor" font-size="10">symptom</text>
@@ -252,10 +251,10 @@ against ~18 raw detections a second and watch the old code fail.
 
 ## Failing first is a diagnostic method, not a formality
 
-The rule's reputation is bureaucratic: proof-of-work attached to a fix. In
-practice it's where most of the diagnosis happens, because **building a
-reproduction forces you to state, mechanically, what you believe the bug is**
-— and mechanical statements get checked in ways prose theories don't.
+The rule's reputation is bureaucratic. In practice it's where most of the
+diagnosis happens, because **building a reproduction forces you to state,
+mechanically, what you believe the bug is** — and mechanical statements get
+checked in ways prose theories don't.
 
 The DMO trio shows it best. "The grant fires on noise" was the theory; making
 a *test* say it required numbers — how often does the correlator fire on
@@ -284,12 +283,11 @@ in `samples/p25/` there is no test that fails first.
 
 So the workflow ends the only honest way it can: the issue **stays open**,
 with a status comment saying what's known and what's blocking — usually a
-capture request shaped by
-[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})'s
-discipline. What it must *not* end with is a close. Closing is a claim that
-the problem is gone, and that claim has its own definition, its own policy,
-and — after this project shipped the counterexample — its own guard hook.
-That is the finale's subject.
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})-shaped
+capture request. What it must *not* end with is a close. Closing is a claim
+that the problem is gone, and that claim has its own definition, its own
+policy, and — after this project shipped the counterexample — its own guard
+hook. That is the finale's subject.
 
 ## Where this goes next
 
@@ -321,16 +319,15 @@ problem).
 **What if writing the failing test takes longer than the fix?**
 It usually does, and that time is the diagnosis, not overhead. The colour-0
 fix was a guard removal; finding *which* guard took a colour sweep, a
-scrambler-seed check, and an encode-side rebuild of the test — while the
-"fix it and see" approach had already produced a wrong answer ("encrypted")
-from the same evidence.
+scrambler-seed check, and an encode-side rebuild of the test — while "fix it
+and see" had already produced a wrong answer ("encrypted") from the same
+evidence.
 
 **How do I fail first when the bug only appears on air?**
 Get the air onto disk: an IQ capture replayed through an env-gated harness is
 a failing test an operator can run (`GT_TETRA_DMO_IQ=… go test -run
 TestTETRADMOReplay`). Part 11 covers the conventions. When even that isn't
-available: the fix waits, the issue stays open, and the capture request *is*
-the work product.
+available: the fix waits, and the capture request *is* the work product.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -1,6 +1,6 @@
 ---
 title: "From Spec to Shipping, Part 12: Failing First — The Regression Rule"
-description: Why every GopherTrunk bug fix is one narrow commit plus a regression test that fails without the fix — and three worked examples where writing the failing test WAS the diagnosis, from the DMO colour-0 descramble to the SmartNet rebuild to the noise-grant trio.
+description: Why every GopherTrunk bug fix is one narrow commit plus a regression test that fails without the fix — with three worked examples where writing the failing test was the diagnosis, from the DMO colour-0 descramble to the SmartNet rebuild to the noise-grant trio.
 category: deep-dives
 keywords: failing first regression test, regression test that fails without the fix, reproduce a bug before fixing it, dmo colour code descramble regression, smartnet decoder rebuild test, protocol decoder bug fixing, go testing discipline, gophertrunk from spec to shipping
 tags: [from-spec-to-shipping, testing, regressions, methodology, tetra, smartnet]
@@ -205,7 +205,7 @@ one learned residue of the 255-dibit timeslot grid) is untestable, because
 the "transmitter" itself didn't keep slot time. `buildDMODibitStream` now
 emits every burst on its own 255-dibit timeslot, *as a real radio transmits
 them* — at which point the idle-channel test could demand `dnbQualified == 0`
-against ~18 raw detections a second and watch the old code fail.
+against the detection rain and watch the old code fail.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two bug-fix workflows. Top: guess, fix, green tests, closed issue, and a dashed loop back to the symptom when the reporter reopens. Bottom: faithful reproduction, a test failing against the old code where the root cause surfaces, the fix, the same test passing, a verified close.">
@@ -269,8 +269,8 @@ design came out of the same arithmetic. Likewise the colour-0 test — writing
 0?*, whose answer (`0xC0000000`, not identity) was the bug.
 
 And when you *can't* make the test fail, that's data too: whatever you
-reproduced isn't what was reported, and you found out at your desk instead of
-in the reporter's follow-up comment.
+reproduced isn't what was reported — and you found out at your desk, not in
+the reporter's follow-up.
 
 ## When you cannot fail first
 

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -17,8 +17,8 @@ references to code you can trust on air.
 made captures first-class test fixtures. This part is the rule that governs
 what you do with them: **a bug fix is one narrow commit plus a regression
 test that fails without the fix and passes with it** — and if you can't write
-the failing test, you haven't reproduced the bug, so you keep digging instead
-of guessing. Three worked examples show the failing test doing the diagnosis
+the failing test, you haven't reproduced the bug, so keep digging instead of
+guessing. Three worked examples show the failing test doing the diagnosis
 itself.*
 
 > **TL;DR:** `CONTRIBUTING.md` states the rule in one line — *"regression test
@@ -45,9 +45,9 @@ itself.*
   needed the test's world made faithful first: an unconditional scrambler, a
   real-air bit stream, a true 255-dibit slot grid — Part 7's lesson paying
   rent.
-- **Failing-first inverts the workflow, and the inversion is the point.**
-  Reproduce → fail → fix → pass front-loads the diagnosis; guess → fix →
-  close defers it to the reporter, who becomes your regression suite.
+- **The inversion is the point.** Reproduce → fail → fix → pass front-loads
+  the diagnosis; guess → fix → close defers it to the reporter, who becomes
+  your regression suite.
 - **When no failing test is possible, the fix does not land.** The P25 C4FM
   weak-signal levers are diagnosed, designed — and parked until a capture can
   make a test fail
@@ -115,9 +115,9 @@ always descramble, always decoded.
 
 The regression test is the interesting artifact, because the *old* suite had
 checked this and passed: its round-trips scrambled and descrambled under the
-same `colour != 0` condition — self-consistent on both sides, green either
-way, blind to the asymmetry. The fix's test changes one thing: the encode
-side now behaves like the air, unconditionally.
+same `colour != 0` condition — self-consistent, green either way, blind to
+the asymmetry. The fix's test changes one thing: the encode side now behaves
+like the air, unconditionally.
 
 ```go
 // internal/radio/tetra/dmo_decode_test.go (shape) — TestDMTCHSpeechRoundTrip
@@ -277,9 +277,8 @@ the reporter's follow-up.
 The rule's honest edge case: some failures can't be reproduced from what you
 have. The P25 Phase 1 C4FM weak-signal gap is the standing example — the
 diagnosis is structural and confident (no equalizer, no soft-decision FEC on
-that path; the same two levers that roughly doubled TETRA yield), the fix is
-designed, and *nothing has landed*, because without a weak C4FM voice capture
-in `samples/p25/` there is no test that fails first.
+that path), the fix is designed, and *nothing has landed*, because without a
+weak C4FM voice capture in `samples/p25/` there is no test that fails first.
 
 So the workflow ends the only honest way it can: the issue **stays open**,
 with a status comment saying what's known and what's blocking — usually a
@@ -303,17 +302,16 @@ a transient.
 
 **What makes a regression test "failing-first" rather than just a test?**
 Provenance: it was run against the pre-fix code and observed to fail, and the
-observation is recorded (GopherTrunk writes it into the test's doc comment —
-"verified failing-first against the old code"). A test only ever seen green
-proves the code satisfies the test; it never proves the test detects the bug.
+observation is recorded — GopherTrunk writes it into the test's doc comment
+("verified failing-first against the old code"). A test only ever seen green
+proves the code satisfies the test, never that the test detects the bug.
 
 **Isn't this just test-driven development?**
 It's TDD's contrapositive, applied to defects: TDD writes a failing test to
 specify behaviour that doesn't exist yet; failing-first writes one to
-reproduce behaviour that shouldn't. The extra burden is fidelity — a
-regression test's world must match the air, the wire, or the protocol, or it
-reproduces nothing (the
-[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+reproduce behaviour that shouldn't. The extra burden is fidelity — the test's
+world must match the air, the wire, or the protocol, or it reproduces nothing
+(the [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
 problem).
 
 **What if writing the failing test takes longer than the fix?**

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -72,8 +72,8 @@ itself.*
 - **Zero frames, then two** — the DMO colour-0 descramble regression.
 - **A decoder that decodes nothing** — the SmartNet real-air-format test.
 - **Three tests against one pipeline** — the noise-grant trio.
-- **Failing first as a diagnostic method** — why root causes surface while
-  building the reproduction.
+- **Failing first as a diagnostic method** — root causes surface in the
+  reproduction.
 - **When you cannot fail first** — the honest ending, and the Part 14 tie-in.
 
 ## The rule, and what it is actually for
@@ -173,12 +173,11 @@ Notice the input: not the old encoder's output, but a stream built to the
 framing **two independent proven-on-air decoders** transmit and consume —
 OP25's `rx_smartnet` and trunk-recorder's parser, cross-checked as
 [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
-prescribes. That provenance is what makes the failure meaningful: feed this
-stream to the old decoder and it produces zero locks and zero grants — the
-reporter's `cchunt: hunt failed` symptom, reproduced on the desk, no antenna
-required. (And per the on-air gate, even the rebuild stays
-capture-verification-pending until the reporter's 854.5625 MHz capture
-replays through it — synthetic-green has fooled this exact decoder before.)
+prescribes. That provenance is what makes the failure meaningful: the old
+decoder produces zero locks and zero grants from it — the reporter's
+`cchunt: hunt failed` symptom, reproduced on the desk, no antenna required.
+(Per the on-air gate, even the rebuild stays capture-verification-pending
+until the reporter's 854.5625 MHz capture replays through it.)
 
 ## Three tests against one pipeline: the noise-grant trio
 

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -44,22 +44,21 @@ itself.*
   on a theory is a guess wearing a commit message.
 - **The hard part is making the test *able* to fail.** All three examples
   needed the test's world made faithful first: an unconditional scrambler, a
-  real-air bit stream, a true 255-dibit slot grid — Part 7's lesson paying
-  rent.
+  real-air bit stream, a true 255-dibit slot grid.
 - **The inversion is the point.** Reproduce → fail → fix → pass front-loads
   the diagnosis; guess → fix → close defers it to the reporter, who becomes
   your regression suite.
 - **When no failing test is possible, the fix does not land.** The P25 C4FM
-  weak-signal levers are diagnosed, designed — and parked until a capture can
-  make a test fail
-  ([Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})'s
-  subject).
+  weak-signal levers are diagnosed, designed — and parked until a capture
+  can make a test fail —
+  [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})'s
+  subject.
 
 ## Cheat sheet
 
 | Concern | What it does | Where it lives |
 |---|---|---|
-| The rule | bug fix = one narrow commit + a test that fails without it | `CONTRIBUTING.md` ("How changes are scoped") |
+| The rule | bug fix = narrow commit + a test that fails without it | `CONTRIBUTING.md` ("How changes are scoped") |
 | Colour-0 regression | encode side scrambles unconditionally, like real air | `internal/radio/tetra/dmo_decode_test.go` (`TestDMTCHSpeechRoundTrip`) |
 | SmartNet regression | real-air OSW stream → old decoder = zero decodes | `internal/radio/motorola/process_test.go` (`TestProcessDecodesRealAirFormat`) |
 | Noise-grant trio | idle channel, lock ordering, re-arm — three failure modes | `internal/scanner/ccdecoder/pipelines_dmo_test.go` |
@@ -97,12 +96,10 @@ twice on fixes nobody had watched fail while the symptom stayed live
 ([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)) — the story
 Part 14 turns into policy.
 
-One earned caveat: a failing test proves you reproduced *a* bug; only outside
-evidence proves it's *the* bug. The
+One earned caveat: a failing test proves you reproduced *a* bug; only
+outside evidence proves it's *the* bug — the
 [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
-villain — the test sharing its assumption with the code — fabricates a
-convincing failure as easily as a convincing pass, and all three examples
-below had to defeat it first.
+villain fabricates a convincing failure as easily as a convincing pass.
 
 ## Zero frames, then two: the colour-0 descramble
 
@@ -291,20 +288,19 @@ policy, and its own guard hook. That is the finale's subject.
 ## Where this goes next
 
 A failing test proves the fix worked once, on your fixture. Whether it keeps
-working in the field only the running system can say — which means it has to
-be able to *say* things.
+working in the field only the running system can say — so it has to be able
+to *say* things.
 [Part 13]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})
-is about building diagnostics as instruments: counters on every branch,
-verdict lines written for operators, and WARNs that can tell a condition from
-a transient.
+builds diagnostics as instruments: counters on every branch, verdict lines
+written for operators, WARNs that can tell a condition from a transient.
 
 ## FAQ
 
 **What makes a regression test "failing-first" rather than just a test?**
-Provenance: it was run against the pre-fix code and observed to fail, and the
-observation is recorded — GopherTrunk writes it into the test's doc comment
-("verified failing-first against the old code"). A test only ever seen green
-proves the code satisfies the test, never that the test detects the bug.
+Provenance: it ran against the pre-fix code, was observed to fail, and the
+observation is recorded in the test's doc comment ("verified failing-first
+against the old code"). A test only ever seen green proves the code
+satisfies the test, never that the test detects the bug.
 
 **Isn't this just test-driven development?**
 It's TDD's contrapositive, applied to defects: TDD writes a failing test to

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -14,46 +14,45 @@ series_part: 12
 decoder actually gets written — from standards documents and independent
 references to code you can trust on air.
 [Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
-made captures first-class test fixtures — the evidence that grades a decoder.
-This part is the rule that governs what you do with that evidence: **a bug fix
-is one narrow commit plus a regression test that fails without the fix and
-passes with it** — and if you can't write the failing test, you haven't
-reproduced the bug, so you keep digging instead of guessing. Three worked
-examples show the failing test doing the diagnosis itself.*
+made captures first-class test fixtures. This part is the rule that governs
+what you do with them: **a bug fix is one narrow commit plus a regression
+test that fails without the fix and passes with it** — and if you can't write
+the failing test, you haven't reproduced the bug, so you keep digging instead
+of guessing. Three worked examples show the failing test doing the diagnosis
+itself.*
 
 > **TL;DR:** `CONTRIBUTING.md` states the rule in one line — *"regression test
 > that fails without the fix and passes with it"* — and the tree is full of
 > tests built to that shape. `TestDMTCHSpeechRoundTrip`
 > (`internal/radio/tetra/dmo_decode_test.go`) scrambles its encode side
-> **unconditionally**, like a real transmitter: against the old colour-0
-> descramble skip it gets **0 speech frames**; with the
+> **unconditionally**, like a real transmitter: the old colour-0 descramble
+> skip yields **0 speech frames**; the
 > [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003) fix, **2
 > CRC-valid frames**. `TestProcessDecodesRealAirFormat`
 > (`internal/radio/motorola/process_test.go`) feeds the real SmartNet air
 > format to the decoder: the pre-[#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)
-> fabricated framing decodes **nothing** from it. And three tests in
+> fabricated framing decodes **nothing**. And three tests in
 > `internal/scanner/ccdecoder/pipelines_dmo_test.go` all fail against the old
-> DMO grant path that opened recordings on noise. The pattern in every case:
-> **the failing test is the reproduction, and the reproduction is where the
-> root cause surfaces.**
+> DMO grant path that opened recordings on noise. **The failing test is the
+> reproduction, and the reproduction is where the root cause surfaces.**
 
 **Key takeaways**
 
 - **A failing test is a reproduction you can re-run.** Until something fails
-  on demand, you have a theory about the bug, not the bug — and a fix built on
-  a theory is a guess wearing a commit message.
-- **The hard part of failing-first is making the test *able* to fail.** All
-  three examples needed the test's world made more faithful first: an
-  unconditional scrambler, a real-air bit stream, a true 255-dibit slot grid.
-  That work is Part 7's lesson paying rent.
+  on demand, you have a theory about the bug, not the bug — and a fix built
+  on a theory is a guess wearing a commit message.
+- **The hard part is making the test *able* to fail.** All three examples
+  needed the test's world made faithful first: an unconditional scrambler, a
+  real-air bit stream, a true 255-dibit slot grid — Part 7's lesson paying
+  rent.
 - **Failing-first inverts the workflow, and the inversion is the point.**
   Reproduce → fail → fix → pass front-loads the diagnosis; guess → fix →
   close defers it to the reporter, who becomes your regression suite.
 - **When no failing test is possible, the fix does not land.** The P25 C4FM
   weak-signal levers are diagnosed, designed — and parked until a capture can
-  make a test fail. That discipline is
-  [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})'s
-  whole subject.
+  make a test fail
+  ([Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})'s
+  subject).
 
 ## Cheat sheet
 
@@ -80,10 +79,10 @@ examples show the failing test doing the diagnosis itself.*
 ## The rule, and what it is actually for
 
 `CONTRIBUTING.md` scopes a bug fix in one sentence: *one commit, narrow diff,
-regression test that fails without the fix and passes with it.* The project's
-standing guidance sharpens the contrapositive: **if you can't write a test
-that fails first, you have not yet reproduced the bug — keep digging or ask
-for a reproduction, don't guess at a fix.**
+regression test that fails without the fix and passes with it.* The standing
+guidance sharpens the contrapositive: **if you can't write a test that fails
+first, you have not yet reproduced the bug — keep digging or ask for a
+reproduction, don't guess at a fix.**
 
 Read as process, that sounds like ceremony. Read as epistemology, it's the
 cheapest verification gate in the series. A fix without a failing test makes
@@ -110,24 +109,22 @@ below had to defeat it before the rule could work.
 [Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
 told the DMO story from the verdict side: clear TETRA direct-mode voice sat
 at a ~1/256 chance-floor CRC rate and got misread as encryption, when the
-real cause was that `DMBurstTCHSpeech` skipped descrambling at colour code 0
-— inherited from a TMO shortcut that was safe there only because a TMO
-extended colour code is never 0. TETRA scrambling is **not** an identity at
-colour 0: the LFSR seeds to `0xC0000000` (EN 300 392-2 §8.2.5.2), which is
-exactly why the signalling paths always descramble and always decoded.
+real cause was that `DMBurstTCHSpeech` skipped descrambling at colour code 0.
+TETRA scrambling is **not** an identity at colour 0 — the LFSR seeds to
+`0xC0000000` (EN 300 392-2 §8.2.5.2), which is exactly why the signalling
+paths always descramble and always decoded.
 
-The regression test is the interesting artifact, because the *old* test suite
-had checked this and passed. Its round-trips scrambled and descrambled under
-the same `colour != 0` condition — self-consistent on both sides, green
-either way, blind to the asymmetry. The fix's test changes one thing: the
-encode side now behaves like the air, unconditionally.
+The regression test is the interesting artifact, because the *old* suite had
+checked this and passed: its round-trips scrambled and descrambled under the
+same `colour != 0` condition — self-consistent on both sides, green either
+way, blind to the asymmetry. The fix's test changes one thing: the encode
+side now behaves like the air, unconditionally.
 
 ```go
 // internal/radio/tetra/dmo_decode_test.go (shape) — TestDMTCHSpeechRoundTrip
 // The colour-0 iteration is the failing-first regression for issue #1003:
-// a real DMO transmitter scrambles TCH/S with the DM colour code even at
-// colour 0 (seed 0xC0000000, §8.2.5.2), so a decoder that skips descramble
-// at colour 0 leaves the block scrambled and the class-2 CRC fails.
+// real air scrambles TCH/S even at colour 0 (seed 0xC0000000, §8.2.5.2), so
+// a decoder that skips descramble there fails the class-2 CRC.
 for _, colour := range []uint32{0, 0x0AB1F} {
     /* … encode two speech frames through EN 300 395-2 TCH/S coding … */
     onair := framing.ScrambleTetra(type4, colour) // scrambled like real air, incl. colour 0
@@ -139,30 +136,29 @@ for _, colour := range []uint32{0, 0x0AB1F} {
 }
 ```
 
-Verified failing-first, with the numbers on record: the old code returns **0
-frames** at colour 0; the fixed code returns the **2 CRC-valid frames** that
-went in. That asymmetric shape — pin one side to reality, let the other side
-prove itself — is the whole difference between this test and its green
-predecessor, and it's the constructive mirror of the
+Verified failing-first, numbers on record: the old code returns **0 frames**
+at colour 0; the fixed code returns the **2 CRC-valid frames** that went in.
+That asymmetric shape — pin one side to reality, let the other side prove
+itself — is the whole difference from the green predecessor, and the
+constructive mirror of the
 [self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
-The full saga, colour sweep and all, is in
+Full saga:
 [TETRA End to End Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }}).
 
 ## A decoder that decodes nothing: the SmartNet regression
 
 [Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})'s
 case study ended with a rebuilt Motorola SmartNet decoder — the original's
-24-bit sync word and BCH(64,16,11) framing matched no real reference, so no
-real system could ever lock, while every synthetic test glowed green. The
-rebuild's headline regression states the indictment as a runnable fact:
+fabricated framing matched no real reference, so no real system could ever
+lock, while every synthetic test glowed green. The rebuild's headline
+regression states the indictment as a runnable fact:
 
 ```go
 // internal/radio/motorola/process_test.go (shape) — TestProcessDecodesRealAirFormat
-// The issue #1143 regression: a control-channel stream in the REAL SmartNet
-// air format (OP25 rx_smartnet framing) must lock and publish the grant.
-// The pre-#1143 decoder (24-bit sync 0xA4D7AA + BCH(64,16,11), a framing no
-// real system transmits) decodes NOTHING from this stream — verified
-// failing-first against the old code.
+// The issue #1143 regression: a stream in the REAL SmartNet air format (OP25
+// rx_smartnet framing) must lock and publish the grant. The pre-#1143
+// decoder (24-bit sync 0xA4D7AA + BCH(64,16,11), a framing no real system
+// transmits) decodes NOTHING from it — verified failing-first.
 cc := New(Options{Bus: bus, SystemName: "Real", FrequencyHz: 854_562_500})
 cc.Process(realAirStream(200, seq...), 0)
 
@@ -173,47 +169,45 @@ if len(locked) == 0 {
 /* … grant must carry tg 0xB010, src 0x2E9A, 861.5375 MHz (channel 0x1A5) … */
 ```
 
-Notice what the test's input is: not the old encoder's output, but a stream
-built to the framing **two independent proven-on-air decoders** transmit and
-consume — OP25's `rx_smartnet` and trunk-recorder's parser, cross-checked as
+Notice the input: not the old encoder's output, but a stream built to the
+framing **two independent proven-on-air decoders** transmit and consume —
+OP25's `rx_smartnet` and trunk-recorder's parser, cross-checked as
 [Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
-prescribes. That provenance is what makes the failure meaningful. Feed this
+prescribes. That provenance is what makes the failure meaningful: feed this
 stream to the old decoder and it produces zero locks and zero grants — the
 reporter's `cchunt: hunt failed` symptom, reproduced on the desk, no antenna
-required. Fourteen months of green tests never said that; one failing-first
-test did. (And per the on-air gate, even this rebuild stays
+required. (And per the on-air gate, even the rebuild stays
 capture-verification-pending until the reporter's 854.5625 MHz capture
 replays through it — synthetic-green has fooled this exact decoder before.)
 
 ## Three tests against one pipeline: the noise-grant trio
 
-The richest example is the DMO grant path, because one field report yielded
-**three distinct failing tests** — each pinning a different way the old code
-was wrong. The report: the daemon granted and opened a recording ~230 ms
-after startup on a *silent* channel, then never granted again — the
-operator's real 10-second PTT, which genuinely locked (`dsb_schs_crc=46/54`),
-produced nothing. The mechanism (told in full in
+The richest example is the DMO grant path: one field report yielded **three
+distinct failing tests**, each pinning a different way the old code was
+wrong. The report: the daemon granted and opened a recording ~230 ms after
+startup on a *silent* channel, then never granted again — the operator's
+real 10-second PTT, which genuinely locked (`dsb_schs_crc=46/54`), produced
+nothing. The mechanism (told in full in
 [TETRA End to End Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})):
-the DNB burst correlator is loose enough to fire **~18 times per second on
-pure noise**, and the grant logic took raw detections as traffic.
+the DNB burst correlator fires **~18 times per second on pure noise**, and
+the grant logic took raw detections as traffic.
 
 | Test (`pipelines_dmo_test.go`) | The failure it pins | Old code's behaviour |
 |---|---|---|
-| `TestTETRADMOPipelineIgnoresIdleChannel` | 10 s of noise must yield no lock, no grant, zero *qualified* DNBs — while raw detections keep raining | grants in ~230 ms on nothing |
+| `TestTETRADMOPipelineIgnoresIdleChannel` | 10 s of noise: no lock, no grant, zero *qualified* DNBs — while raw detections keep raining | grants in ~230 ms on nothing |
 | `TestTETRADMOPipelineGrantsOnlyAfterLock` | no grant may precede `cc.locked` | `dnbSinceLock` was named for a lock the guard never consulted |
-| `TestTETRADMOPipelineRearmsBetweenTransmissions` | after a silent gap, a second PTT must grant again | re-arm needed a DNB drought the 18/s noise made impossible — and was only evaluated when a burst arrived |
+| `TestTETRADMOPipelineRearmsBetweenTransmissions` | after a silent gap, a second PTT must grant again | re-arm needed a drought the 18/s noise made impossible — and only ran when a burst arrived |
 
 All three fail against the old pipeline. But the load-bearing work happened
 *before* the assertions could mean anything: the synthetic transmitter had to
-become faithful. The old test fixture laid bursts into the stream with
-arbitrary filler between them — and against that layout, the eventual fix
+become faithful. The old fixture laid bursts into the stream with arbitrary
+filler between them — and against that layout the eventual fix
 (`tetra.DMSlotGrid`, which qualifies bursts by voting their positions onto
 one learned residue of the 255-dibit timeslot grid) is untestable, because
 the "transmitter" itself didn't keep slot time. `buildDMODibitStream` now
 emits every burst on its own 255-dibit timeslot, *as a real radio transmits
 them* — at which point the idle-channel test could demand `dnbQualified == 0`
-against ~18 raw detections a second and watch the old code fail. A test can
-only disagree with you if its world is real enough to disagree in.
+against ~18 raw detections a second and watch the old code fail.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two bug-fix workflows compared. Top row, guess-fix-close: symptom, guessed cause, fix, existing tests green, issue closed — with a dashed arrow looping from the closed issue back to the symptom, labelled reporter reopens. Bottom row, reproduce-fail-fix-pass: symptom, faithful reproduction, a test that fails against the old code (marked as where the root cause surfaces), the fix, the same test passing, verified close.">
@@ -268,14 +262,13 @@ The DMO trio shows it best. "The grant fires on noise" was the theory; making
 a *test* say it required numbers — how often does the correlator fire on
 noise? Working that out (529 of the 4^11 possible 11-dibit sequences match
 within tolerance 2, across eight matched filters, at 18,000 dibits/s — ~18
-false detections a second, and the operator's own log measured 18.7/s) didn't
-just justify the test; it dictated the fix's shape. A threshold can't beat an
-18/s rain, but a slot-grid residue vote can: one radio on one clock puts
-every burst on one residue mod 255, noise is uniform over all 255. The
-reproduction and the design came out of the same arithmetic. Likewise the
-colour-0 test — writing "scramble like real air" forced the question *what
-does real air do at colour 0?*, whose answer (`0xC0000000`, not identity) was
-the bug.
+false detections a second; the operator's log measured 18.7/s) didn't just
+justify the test; it dictated the fix's shape. A threshold can't beat an 18/s
+rain, but a slot-grid residue vote can: one radio on one clock puts every
+burst on one residue mod 255, noise is uniform over all 255. Reproduction and
+design came out of the same arithmetic. Likewise the colour-0 test — writing
+"scramble like real air" forced the question *what does real air do at colour
+0?*, whose answer (`0xC0000000`, not identity) was the bug.
 
 And when you *can't* make the test fail, that's data too: whatever you
 reproduced isn't what was reported, and you found out at your desk instead of
@@ -288,10 +281,7 @@ have. The P25 Phase 1 C4FM weak-signal gap is the standing example — the
 diagnosis is structural and confident (no equalizer, no soft-decision FEC on
 that path; the same two levers that roughly doubled TETRA yield), the fix is
 designed, and *nothing has landed*, because without a weak C4FM voice capture
-in `samples/p25/` there is no test that fails first. Guessing a DSP fix and
-shipping it green-on-synthetics is precisely the failure mode
-[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
-exists to prevent.
+in `samples/p25/` there is no test that fails first.
 
 So the workflow ends the only honest way it can: the issue **stays open**,
 with a status comment saying what's known and what's blocking — usually a
@@ -304,9 +294,9 @@ That is the finale's subject.
 
 ## Where this goes next
 
-A failing test proves the fix worked once, on your machine, on your fixture.
-Whether it keeps working in the field is a question only the running system
-can answer — which means the running system has to be able to *say* things.
+A failing test proves the fix worked once, on your fixture. Whether it keeps
+working in the field only the running system can say — which means it has to
+be able to *say* things.
 [Part 13]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})
 is about building diagnostics as instruments: counters on every branch,
 verdict lines written for operators, and WARNs that can tell a condition from
@@ -315,42 +305,33 @@ a transient.
 ## FAQ
 
 **What makes a regression test "failing-first" rather than just a test?**
-Provenance: it was run against the pre-fix code and observed to fail, and
-that observation is recorded (GopherTrunk writes it into the test's doc
-comment — "verified failing-first against the old code"). A test written
-after the fix and only ever seen green proves the code satisfies the test; it
-never proves the test detects the bug.
+Provenance: it was run against the pre-fix code and observed to fail, and the
+observation is recorded (GopherTrunk writes it into the test's doc comment —
+"verified failing-first against the old code"). A test only ever seen green
+proves the code satisfies the test; it never proves the test detects the bug.
 
 **Isn't this just test-driven development?**
 It's TDD's contrapositive, applied to defects: TDD writes a failing test to
 specify behaviour that doesn't exist yet; failing-first writes one to
-reproduce behaviour that shouldn't. The extra burden is fidelity — a TDD test
-can define its own world, but a regression test's world must match the air,
-the wire, or the protocol, or it reproduces nothing (the
+reproduce behaviour that shouldn't. The extra burden is fidelity — a
+regression test's world must match the air, the wire, or the protocol, or it
+reproduces nothing (the
 [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
 problem).
 
 **What if writing the failing test takes longer than the fix?**
 It usually does, and that time is the diagnosis, not overhead. The colour-0
-fix was a two-line guard removal; finding *which* two lines took a colour
-sweep, a scrambler-seed check, and an encode-side rebuild of the test — and
-the old "fix it and see" approach had already produced a wrong answer
-("encrypted") from the same evidence.
+fix was a guard removal; finding *which* guard took a colour sweep, a
+scrambler-seed check, and an encode-side rebuild of the test — while the
+"fix it and see" approach had already produced a wrong answer ("encrypted")
+from the same evidence.
 
 **How do I fail first when the bug only appears on air?**
 Get the air onto disk: an IQ capture replayed through an env-gated harness is
 a failing test an operator can run (`GT_TETRA_DMO_IQ=… go test -run
 TestTETRADMOReplay`). Part 11 covers the conventions. When even that isn't
-available, the answer is the last section's: the fix waits, the issue stays
-open, and the capture request *is* the work product.
-
-**My new test fails against the old code — am I done diagnosing?**
-Almost. Check what it fails *on*: a test can fail against old code for a
-reason unrelated to the reported symptom, which quietly substitutes your bug
-for the reporter's. Tie the assertion to the report's observable (zero
-frames, a grant on silence, `hunt failed`) and, where you can, to the
-reporter's own numbers — the trio's tests quote the operator's log in their
-comments for exactly this reason.
+available: the fix waits, the issue stays open, and the capture request *is*
+the work product.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -1,0 +1,360 @@
+---
+title: "From Spec to Shipping, Part 12: Failing First — The Regression Rule"
+description: Why every GopherTrunk bug fix is one narrow commit plus a regression test that fails without the fix — and three worked examples where writing the failing test WAS the diagnosis, from the DMO colour-0 descramble to the SmartNet rebuild to the noise-grant trio.
+category: deep-dives
+keywords: failing first regression test, regression test that fails without the fix, reproduce a bug before fixing it, dmo colour code descramble regression, smartnet decoder rebuild test, protocol decoder bug fixing, go testing discipline, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, testing, regressions, methodology, tetra, smartnet]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 12
+---
+
+*Part 12 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+made captures first-class test fixtures — the evidence that grades a decoder.
+This part is the rule that governs what you do with that evidence: **a bug fix
+is one narrow commit plus a regression test that fails without the fix and
+passes with it** — and if you can't write the failing test, you haven't
+reproduced the bug, so you keep digging instead of guessing. Three worked
+examples show the failing test doing the diagnosis itself.*
+
+> **TL;DR:** `CONTRIBUTING.md` states the rule in one line — *"regression test
+> that fails without the fix and passes with it"* — and the tree is full of
+> tests built to that shape. `TestDMTCHSpeechRoundTrip`
+> (`internal/radio/tetra/dmo_decode_test.go`) scrambles its encode side
+> **unconditionally**, like a real transmitter: against the old colour-0
+> descramble skip it gets **0 speech frames**; with the
+> [#1003](https://github.com/MattCheramie/GopherTrunk/issues/1003) fix, **2
+> CRC-valid frames**. `TestProcessDecodesRealAirFormat`
+> (`internal/radio/motorola/process_test.go`) feeds the real SmartNet air
+> format to the decoder: the pre-[#1143](https://github.com/MattCheramie/GopherTrunk/issues/1143)
+> fabricated framing decodes **nothing** from it. And three tests in
+> `internal/scanner/ccdecoder/pipelines_dmo_test.go` all fail against the old
+> DMO grant path that opened recordings on noise. The pattern in every case:
+> **the failing test is the reproduction, and the reproduction is where the
+> root cause surfaces.**
+
+**Key takeaways**
+
+- **A failing test is a reproduction you can re-run.** Until something fails
+  on demand, you have a theory about the bug, not the bug — and a fix built on
+  a theory is a guess wearing a commit message.
+- **The hard part of failing-first is making the test *able* to fail.** All
+  three examples needed the test's world made more faithful first: an
+  unconditional scrambler, a real-air bit stream, a true 255-dibit slot grid.
+  That work is Part 7's lesson paying rent.
+- **Failing-first inverts the workflow, and the inversion is the point.**
+  Reproduce → fail → fix → pass front-loads the diagnosis; guess → fix →
+  close defers it to the reporter, who becomes your regression suite.
+- **When no failing test is possible, the fix does not land.** The P25 C4FM
+  weak-signal levers are diagnosed, designed — and parked until a capture can
+  make a test fail. That discipline is
+  [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})'s
+  whole subject.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The rule | bug fix = one narrow commit + a test that fails without it | `CONTRIBUTING.md` ("How changes are scoped") |
+| Colour-0 regression | encode side scrambles unconditionally, like real air | `internal/radio/tetra/dmo_decode_test.go` (`TestDMTCHSpeechRoundTrip`) |
+| SmartNet regression | real-air OSW stream → old decoder = zero decodes | `internal/radio/motorola/process_test.go` (`TestProcessDecodesRealAirFormat`) |
+| Noise-grant trio | idle channel, lock ordering, re-arm — three failure modes | `internal/scanner/ccdecoder/pipelines_dmo_test.go` |
+| Faithful synthetic transmitter | every burst on a true 255-dibit timeslot | `pipelines_dmo_test.go` (`buildDMODibitStream`) |
+| When you can't fail first | the issue stays open, gated on evidence | `CLAUDE.md` issue-closing policy → Part 14 |
+
+## In this post
+
+- **The rule, and what it is actually for** — a failing test is a
+  reproduction, not paperwork.
+- **Zero frames, then two** — the DMO colour-0 descramble regression.
+- **A decoder that decodes nothing** — the SmartNet real-air-format test.
+- **Three tests against one pipeline** — the noise-grant trio.
+- **Failing first as a diagnostic method** — why root causes surface while
+  building the reproduction.
+- **When you cannot fail first** — the honest ending, and the Part 14 tie-in.
+
+## The rule, and what it is actually for
+
+`CONTRIBUTING.md` scopes a bug fix in one sentence: *one commit, narrow diff,
+regression test that fails without the fix and passes with it.* The project's
+standing guidance sharpens the contrapositive: **if you can't write a test
+that fails first, you have not yet reproduced the bug — keep digging or ask
+for a reproduction, don't guess at a fix.**
+
+Read as process, that sounds like ceremony. Read as epistemology, it's the
+cheapest verification gate in the series. A fix without a failing test makes
+two unproven claims at once: that you found the real cause, and that your
+change removes it. The failing test converts both into observations — it
+fails against the old code, so the reproduction is real; it passes against
+the new, so the change addresses *that* reproduction. This project learned
+the price of skipping them in public: issue
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was closed
+twice on fixes nobody had watched fail, while the symptom stayed live
+([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)) — the story
+[the on-air gate]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+told and Part 14 turns into policy.
+
+One caveat the series has already earned: a failing test proves you
+reproduced *a* bug; only outside evidence proves it's *the* bug. The villain
+of [Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+— the test that shares its assumption with the code — fabricates a
+convincing failure as easily as a convincing pass, and all three examples
+below had to defeat it before the rule could work.
+
+## Zero frames, then two: the colour-0 descramble
+
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+told the DMO story from the verdict side: clear TETRA direct-mode voice sat
+at a ~1/256 chance-floor CRC rate and got misread as encryption, when the
+real cause was that `DMBurstTCHSpeech` skipped descrambling at colour code 0
+— inherited from a TMO shortcut that was safe there only because a TMO
+extended colour code is never 0. TETRA scrambling is **not** an identity at
+colour 0: the LFSR seeds to `0xC0000000` (EN 300 392-2 §8.2.5.2), which is
+exactly why the signalling paths always descramble and always decoded.
+
+The regression test is the interesting artifact, because the *old* test suite
+had checked this and passed. Its round-trips scrambled and descrambled under
+the same `colour != 0` condition — self-consistent on both sides, green
+either way, blind to the asymmetry. The fix's test changes one thing: the
+encode side now behaves like the air, unconditionally.
+
+```go
+// internal/radio/tetra/dmo_decode_test.go (shape) — TestDMTCHSpeechRoundTrip
+// The colour-0 iteration is the failing-first regression for issue #1003:
+// a real DMO transmitter scrambles TCH/S with the DM colour code even at
+// colour 0 (seed 0xC0000000, §8.2.5.2), so a decoder that skips descramble
+// at colour 0 leaves the block scrambled and the class-2 CRC fails.
+for _, colour := range []uint32{0, 0x0AB1F} {
+    /* … encode two speech frames through EN 300 395-2 TCH/S coding … */
+    onair := framing.ScrambleTetra(type4, colour) // scrambled like real air, incl. colour 0
+    /* … frame as a DNB, run the real extractor … */
+    frames := DMBurstTCHSpeech(*dnb, colour)
+    if len(frames) != 2 {
+        t.Fatalf("colour %#x: got %d frames, want 2 (CRC failed?)", colour, len(frames))
+    }
+}
+```
+
+Verified failing-first, with the numbers on record: the old code returns **0
+frames** at colour 0; the fixed code returns the **2 CRC-valid frames** that
+went in. That asymmetric shape — pin one side to reality, let the other side
+prove itself — is the whole difference between this test and its green
+predecessor, and it's the constructive mirror of the
+[self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
+The full saga, colour sweep and all, is in
+[TETRA End to End Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }}).
+
+## A decoder that decodes nothing: the SmartNet regression
+
+[Part 8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }})'s
+case study ended with a rebuilt Motorola SmartNet decoder — the original's
+24-bit sync word and BCH(64,16,11) framing matched no real reference, so no
+real system could ever lock, while every synthetic test glowed green. The
+rebuild's headline regression states the indictment as a runnable fact:
+
+```go
+// internal/radio/motorola/process_test.go (shape) — TestProcessDecodesRealAirFormat
+// The issue #1143 regression: a control-channel stream in the REAL SmartNet
+// air format (OP25 rx_smartnet framing) must lock and publish the grant.
+// The pre-#1143 decoder (24-bit sync 0xA4D7AA + BCH(64,16,11), a framing no
+// real system transmits) decodes NOTHING from this stream — verified
+// failing-first against the old code.
+cc := New(Options{Bus: bus, SystemName: "Real", FrequencyHz: 854_562_500})
+cc.Process(realAirStream(200, seq...), 0)
+
+locked, grants := drainEvents(sub)
+if len(locked) == 0 {
+    t.Fatal("no cc.locked from a real-air-format stream")
+}
+/* … grant must carry tg 0xB010, src 0x2E9A, 861.5375 MHz (channel 0x1A5) … */
+```
+
+Notice what the test's input is: not the old encoder's output, but a stream
+built to the framing **two independent proven-on-air decoders** transmit and
+consume — OP25's `rx_smartnet` and trunk-recorder's parser, cross-checked as
+[Part 3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})
+prescribes. That provenance is what makes the failure meaningful. Feed this
+stream to the old decoder and it produces zero locks and zero grants — the
+reporter's `cchunt: hunt failed` symptom, reproduced on the desk, no antenna
+required. Fourteen months of green tests never said that; one failing-first
+test did. (And per the on-air gate, even this rebuild stays
+capture-verification-pending until the reporter's 854.5625 MHz capture
+replays through it — synthetic-green has fooled this exact decoder before.)
+
+## Three tests against one pipeline: the noise-grant trio
+
+The richest example is the DMO grant path, because one field report yielded
+**three distinct failing tests** — each pinning a different way the old code
+was wrong. The report: the daemon granted and opened a recording ~230 ms
+after startup on a *silent* channel, then never granted again — the
+operator's real 10-second PTT, which genuinely locked (`dsb_schs_crc=46/54`),
+produced nothing. The mechanism (told in full in
+[TETRA End to End Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})):
+the DNB burst correlator is loose enough to fire **~18 times per second on
+pure noise**, and the grant logic took raw detections as traffic.
+
+| Test (`pipelines_dmo_test.go`) | The failure it pins | Old code's behaviour |
+|---|---|---|
+| `TestTETRADMOPipelineIgnoresIdleChannel` | 10 s of noise must yield no lock, no grant, zero *qualified* DNBs — while raw detections keep raining | grants in ~230 ms on nothing |
+| `TestTETRADMOPipelineGrantsOnlyAfterLock` | no grant may precede `cc.locked` | `dnbSinceLock` was named for a lock the guard never consulted |
+| `TestTETRADMOPipelineRearmsBetweenTransmissions` | after a silent gap, a second PTT must grant again | re-arm needed a DNB drought the 18/s noise made impossible — and was only evaluated when a burst arrived |
+
+All three fail against the old pipeline. But the load-bearing work happened
+*before* the assertions could mean anything: the synthetic transmitter had to
+become faithful. The old test fixture laid bursts into the stream with
+arbitrary filler between them — and against that layout, the eventual fix
+(`tetra.DMSlotGrid`, which qualifies bursts by voting their positions onto
+one learned residue of the 255-dibit timeslot grid) is untestable, because
+the "transmitter" itself didn't keep slot time. `buildDMODibitStream` now
+emits every burst on its own 255-dibit timeslot, *as a real radio transmits
+them* — at which point the idle-channel test could demand `dnbQualified == 0`
+against ~18 raw detections a second and watch the old code fail. A test can
+only disagree with you if its world is real enough to disagree in.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 210" width="680" height="210" role="img" aria-label="Two bug-fix workflows compared. Top row, guess-fix-close: symptom, guessed cause, fix, existing tests green, issue closed — with a dashed arrow looping from the closed issue back to the symptom, labelled reporter reopens. Bottom row, reproduce-fail-fix-pass: symptom, faithful reproduction, a test that fails against the old code (marked as where the root cause surfaces), the fix, the same test passing, verified close.">
+  <text x="20" y="24" fill="currentColor" font-size="11" font-weight="bold">guess → fix → close</text>
+  <rect x="20" y="36" width="92" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="66" y="54" text-anchor="middle" fill="currentColor" font-size="10">symptom</text>
+  <line x1="112" y1="50" x2="142" y2="50" stroke="currentColor"/><polygon points="140,46 148,50 140,54" fill="currentColor"/>
+  <rect x="150" y="36" width="104" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="202" y="54" text-anchor="middle" fill="currentColor" font-size="10">guessed cause</text>
+  <line x1="254" y1="50" x2="284" y2="50" stroke="currentColor"/><polygon points="282,46 290,50 282,54" fill="currentColor"/>
+  <rect x="292" y="36" width="56" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="320" y="54" text-anchor="middle" fill="currentColor" font-size="10">fix</text>
+  <line x1="348" y1="50" x2="378" y2="50" stroke="currentColor"/><polygon points="376,46 384,50 376,54" fill="currentColor"/>
+  <rect x="386" y="36" width="130" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="451" y="54" text-anchor="middle" fill="currentColor" font-size="9">existing tests green</text>
+  <line x1="516" y1="50" x2="546" y2="50" stroke="currentColor"/><polygon points="544,46 552,50 544,54" fill="currentColor"/>
+  <rect x="554" y="36" width="104" height="28" rx="5" fill="none" stroke="currentColor"/>
+  <text x="606" y="54" text-anchor="middle" fill="currentColor" font-size="10">issue closed</text>
+  <path d="M 606 64 C 606 96 66 96 66 68" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <polygon points="62,70 66,62 70,70" fill="var(--fg-muted)"/>
+  <text x="340" y="104" text-anchor="middle" fill="var(--fg-muted)" font-size="9">reporter reopens: the symptom was still live (#764 → #771)</text>
+  <text x="20" y="132" fill="var(--accent)" font-size="11" font-weight="bold">reproduce → fail → fix → pass</text>
+  <rect x="20" y="144" width="92" height="34" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="66" y="165" text-anchor="middle" fill="var(--accent)" font-size="10">symptom</text>
+  <line x1="112" y1="161" x2="140" y2="161" stroke="var(--accent)"/><polygon points="138,157 146,161 138,165" fill="var(--accent)"/>
+  <rect x="148" y="144" width="122" height="34" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="209" y="159" text-anchor="middle" fill="var(--accent)" font-size="9">faithful reproduction</text>
+  <text x="209" y="171" text-anchor="middle" fill="var(--fg-muted)" font-size="8">real-air stream / slot grid</text>
+  <line x1="270" y1="161" x2="298" y2="161" stroke="var(--accent)"/><polygon points="296,157 304,161 296,165" fill="var(--accent)"/>
+  <rect x="306" y="144" width="126" height="34" rx="5" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="369" y="159" text-anchor="middle" fill="var(--accent)" font-size="9">test FAILS vs old code</text>
+  <text x="369" y="171" text-anchor="middle" fill="var(--fg-muted)" font-size="8">root cause surfaces here</text>
+  <line x1="432" y1="161" x2="460" y2="161" stroke="var(--accent)"/><polygon points="458,157 466,161 458,165" fill="var(--accent)"/>
+  <rect x="468" y="144" width="52" height="34" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="494" y="165" text-anchor="middle" fill="var(--accent)" font-size="10">fix</text>
+  <line x1="520" y1="161" x2="548" y2="161" stroke="var(--accent)"/><polygon points="546,157 554,161 546,165" fill="var(--accent)"/>
+  <rect x="556" y="144" width="104" height="34" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="608" y="159" text-anchor="middle" fill="var(--accent)" font-size="9">same test passes</text>
+  <text x="608" y="171" text-anchor="middle" fill="var(--fg-muted)" font-size="8">→ verified close (Part 14)</text>
+</svg>
+<figcaption>Both workflows write the same fix — but only the bottom one ever observes the bug happening, and the observation is where the real cause surfaces.</figcaption>
+</figure>
+
+## Failing first is a diagnostic method, not a formality
+
+The rule's reputation is bureaucratic: proof-of-work attached to a fix. In
+practice it's where most of the diagnosis happens, because **building a
+reproduction forces you to state, mechanically, what you believe the bug is**
+— and mechanical statements get checked in ways prose theories don't.
+
+The DMO trio shows it best. "The grant fires on noise" was the theory; making
+a *test* say it required numbers — how often does the correlator fire on
+noise? Working that out (529 of the 4^11 possible 11-dibit sequences match
+within tolerance 2, across eight matched filters, at 18,000 dibits/s — ~18
+false detections a second, and the operator's own log measured 18.7/s) didn't
+just justify the test; it dictated the fix's shape. A threshold can't beat an
+18/s rain, but a slot-grid residue vote can: one radio on one clock puts
+every burst on one residue mod 255, noise is uniform over all 255. The
+reproduction and the design came out of the same arithmetic. Likewise the
+colour-0 test — writing "scramble like real air" forced the question *what
+does real air do at colour 0?*, whose answer (`0xC0000000`, not identity) was
+the bug.
+
+And when you *can't* make the test fail, that's data too: whatever you
+reproduced isn't what was reported, and you found out at your desk instead of
+in the reporter's follow-up comment.
+
+## When you cannot fail first
+
+The rule's honest edge case: some failures can't be reproduced from what you
+have. The P25 Phase 1 C4FM weak-signal gap is the standing example — the
+diagnosis is structural and confident (no equalizer, no soft-decision FEC on
+that path; the same two levers that roughly doubled TETRA yield), the fix is
+designed, and *nothing has landed*, because without a weak C4FM voice capture
+in `samples/p25/` there is no test that fails first. Guessing a DSP fix and
+shipping it green-on-synthetics is precisely the failure mode
+[Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})
+exists to prevent.
+
+So the workflow ends the only honest way it can: the issue **stays open**,
+with a status comment saying what's known and what's blocking — usually a
+capture request shaped by
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})'s
+discipline. What it must *not* end with is a close. Closing is a claim that
+the problem is gone, and that claim has its own definition, its own policy,
+and — after this project shipped the counterexample — its own guard hook.
+That is the finale's subject.
+
+## Where this goes next
+
+A failing test proves the fix worked once, on your machine, on your fixture.
+Whether it keeps working in the field is a question only the running system
+can answer — which means the running system has to be able to *say* things.
+[Part 13]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})
+is about building diagnostics as instruments: counters on every branch,
+verdict lines written for operators, and WARNs that can tell a condition from
+a transient.
+
+## FAQ
+
+**What makes a regression test "failing-first" rather than just a test?**
+Provenance: it was run against the pre-fix code and observed to fail, and
+that observation is recorded (GopherTrunk writes it into the test's doc
+comment — "verified failing-first against the old code"). A test written
+after the fix and only ever seen green proves the code satisfies the test; it
+never proves the test detects the bug.
+
+**Isn't this just test-driven development?**
+It's TDD's contrapositive, applied to defects: TDD writes a failing test to
+specify behaviour that doesn't exist yet; failing-first writes one to
+reproduce behaviour that shouldn't. The extra burden is fidelity — a TDD test
+can define its own world, but a regression test's world must match the air,
+the wire, or the protocol, or it reproduces nothing (the
+[Part 7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})
+problem).
+
+**What if writing the failing test takes longer than the fix?**
+It usually does, and that time is the diagnosis, not overhead. The colour-0
+fix was a two-line guard removal; finding *which* two lines took a colour
+sweep, a scrambler-seed check, and an encode-side rebuild of the test — and
+the old "fix it and see" approach had already produced a wrong answer
+("encrypted") from the same evidence.
+
+**How do I fail first when the bug only appears on air?**
+Get the air onto disk: an IQ capture replayed through an env-gated harness is
+a failing test an operator can run (`GT_TETRA_DMO_IQ=… go test -run
+TestTETRADMOReplay`). Part 11 covers the conventions. When even that isn't
+available, the answer is the last section's: the fix waits, the issue stays
+open, and the capture request *is* the work product.
+
+**My new test fails against the old code — am I done diagnosing?**
+Almost. Check what it fails *on*: a test can fail against old code for a
+reason unrelated to the reported symptom, which quietly substitutes your bug
+for the reporter's. Tie the assertion to the report's observable (zero
+frames, a grant on silence, `hunt failed`) and, where you can, to the
+reporter's own numbers — the trio's tests quote the operator's log in their
+comments for exactly this reason.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: Capture-Driven Development]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+· Next →
+[Part 13: Instruments, Not Logs]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})

--- a/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
+++ b/docs/_posts/2026-09-14-from-spec-to-shipping-12-failing-first.md
@@ -63,7 +63,7 @@ itself.*
 | SmartNet regression | real-air OSW stream → old decoder = zero decodes | `internal/radio/motorola/process_test.go` (`TestProcessDecodesRealAirFormat`) |
 | Noise-grant trio | idle channel, lock ordering, re-arm — three failure modes | `internal/scanner/ccdecoder/pipelines_dmo_test.go` |
 | Faithful synthetic transmitter | every burst on a true 255-dibit timeslot | `pipelines_dmo_test.go` (`buildDMODibitStream`) |
-| When you can't fail first | the issue stays open, gated on evidence | `CLAUDE.md` issue-closing policy → Part 14 |
+| When you can't fail first | the issue stays open, gated on evidence | `CLAUDE.md` policy → Part 14 |
 
 ## In this post
 
@@ -92,7 +92,7 @@ fails against the old code, so the reproduction is real; it passes against
 the new, so the change addresses *that* reproduction. The price of skipping
 them was paid in public: issue
 [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was closed
-twice on fixes nobody had watched fail, while the symptom stayed live
+twice on fixes nobody had watched fail while the symptom stayed live
 ([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)) — the story
 Part 14 turns into policy.
 
@@ -137,9 +137,9 @@ for _, colour := range []uint32{0, 0x0AB1F} {
 
 Verified failing-first, numbers on record: the old code returns **0 frames**
 at colour 0; the fixed code returns the **2 CRC-valid frames** that went in.
-That asymmetric shape — pin one side to reality, let the other side prove
-itself — is the whole difference from the green predecessor, and the
-constructive mirror of the
+That asymmetric shape — pin one side to reality, let the other prove itself —
+is the whole difference from the green predecessor, and the constructive
+mirror of the
 [self-consistent trap]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
 Full saga:
 [TETRA End to End Part 12]({{ '/blog/deep-dives/tetra-end-to-end-12-dmo-descramble-colour/' | relative_url }}).
@@ -185,8 +185,8 @@ distinct failing tests**, each pinning a different way the old code was
 wrong. The report: the daemon granted and opened a recording ~230 ms after
 startup on a *silent* channel, then never granted again — the operator's
 real 10-second PTT, which genuinely locked (`dsb_schs_crc=46/54`), produced
-nothing. The mechanism (told in full in
-[TETRA End to End Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})):
+nothing. The mechanism
+([TETRA End to End Part 13]({{ '/blog/deep-dives/tetra-end-to-end-13-dmo-pipeline-grants/' | relative_url }})):
 the DNB burst correlator fires **~18 times per second on pure noise**, and
 the grant logic took raw detections as traffic.
 
@@ -258,15 +258,15 @@ checked in ways prose theories don't.
 
 The DMO trio shows it best. "The grant fires on noise" was the theory; making
 a *test* say it required numbers — how often does the correlator fire on
-noise? Working that out (529 of the 4^11 possible 11-dibit sequences match
-within tolerance 2, across eight matched filters, at 18,000 dibits/s — ~18
-false detections a second; the operator's log measured 18.7/s) didn't just
-justify the test; it dictated the fix's shape. A threshold can't beat an 18/s
-rain, but a slot-grid residue vote can: one radio on one clock puts every
-burst on one residue mod 255, noise is uniform over all 255. Reproduction and
-design came out of the same arithmetic. Likewise the colour-0 test — writing
-"scramble like real air" forced the question *what does real air do at colour
-0?*, whose answer (`0xC0000000`, not identity) was the bug.
+noise? Working that out (529 of 4^11 possible 11-dibit patterns match at
+tolerance 2, times eight filters, at 18,000 dibits/s — ~18 false
+detections/s; the operator's log measured 18.7) didn't just justify the test;
+it dictated the fix's shape. A threshold can't beat an 18/s rain, but a
+slot-grid residue vote can: one radio on one clock puts every burst on one
+residue mod 255, noise is uniform over all 255. Reproduction and design came
+out of the same arithmetic. Likewise the colour-0 test — writing "scramble
+like real air" forced the question *what does real air do at colour 0?*,
+whose answer (`0xC0000000`, not identity) was the bug.
 
 And when you *can't* make the test fail, that's data too: whatever you
 reproduced isn't what was reported — and you found out at your desk, not in
@@ -285,8 +285,7 @@ with a status comment saying what's known and what's blocking — usually a
 [Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})-shaped
 capture request. What it must *not* end with is a close. Closing is a claim
 that the problem is gone, and that claim has its own definition, its own
-policy, and — after this project shipped the counterexample — its own guard
-hook. That is the finale's subject.
+policy, and its own guard hook. That is the finale's subject.
 
 ## Where this goes next
 

--- a/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
+++ b/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
@@ -15,10 +15,10 @@ copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
 [Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
 put the rig in a closet and taught it to survive unattended. This part is the
 advanced RF build: **two antennas feeding one decoder**, phase-coherently
-combined so a fade on one branch is covered by the other. It is the most
-instrument-heavy recipe in the series — diversity is the one upgrade that can
-silently do nothing (or, before the aligner, actively hurt), so the log lines
-that prove it's working matter more here than anywhere else.*
+combined so a fade on one branch is covered by the other. Diversity is the
+one upgrade that can silently do nothing — or, before the aligner, actively
+hurt — so the log lines that prove it's working matter more here than
+anywhere else in the series.*
 
 > **TL;DR:** Diversity needs **one radio with two coherent RX channels** — a
 > USRP B210 (shared LO) or an X310 with TwinRX daughterboards (independent
@@ -38,12 +38,10 @@ that prove it's working matter more here than anywhere else.*
 - **Diversity is the last lever, not the first.** A better antenna, feedline
   and gain staging (Parts 7–9 of
   [The Analog Edge]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }}))
-  buy more margin per dollar. Build this when one antenna genuinely fades —
-  and only after the single-branch rig already decodes.
+  buy more margin per dollar. Build this when one antenna genuinely fades.
 - **Hardware class decides the mode.** A shared-LO front end has one fixed
-  inter-branch phase; separate daughterboards with independent PLLs lock at a
-  random phase that then walks. `branch_phase_deg` in the health line tells
-  you which class you own, before any capture.
+  inter-branch phase; independent PLLs lock at a random phase that then
+  walks. `branch_phase_deg` tells you which class you own, before any capture.
 - **Coherence, not dBFS, is the verdict on the combine.** The
   [coherence]({{ '/reference/coherence/' | relative_url }}) figure is
   independent of RF gain — raising gain to make diversity "engage" is never
@@ -67,38 +65,35 @@ that prove it's working matter more here than anywhere else.*
 ## In this post
 
 - **What you're building** — two antennas, one coherent front end, one combined stream.
-- **The shopping list** — why this is the expensive recipe, and the two hardware classes.
+- **The shopping list** — the two hardware classes, honestly priced.
 - **The config** — `diversity: mrc` on a SoapyRemote device, every key verified.
 - **First run — what healthy looks like** — the MRC health line, field by field.
-- **The honest ceiling** — what MRC can and cannot buy you.
-- **The pre-combine A/B** — capturing both branches and grading the combine offline.
-- **When it doesn't work** — symptom → cause → fix.
-- **Variations** — mrc-static, longer captures, single-port pinning.
+- **The honest ceiling & the pre-combine A/B** — what MRC can buy, and how to prove it.
+- **When it doesn't work** — symptom → cause → fix, then variations.
 
 ## What you're building
 
 The finished rig is the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
 remote-radio build with a second antenna: a two-channel SDR runs
 `SoapySDRServer` near the antennas, GopherTrunk opens **both** RX channels,
-and the driver phase-aligns and sums them into a single maximised-SNR stream
-before the decoder ever sees IQ. Everything downstream — control-channel
-decode, voice taps, recordings — is unchanged; diversity is invisible except
-in the health log and, when the channel fades, in the calls that keep
-decoding.
+and the driver phase-aligns and sums them into one maximised-SNR stream
+before the decoder ever sees IQ. Everything downstream is unchanged;
+diversity is invisible except in the health log and, when the channel fades,
+in the calls that keep decoding.
 
 Three stages inside the driver do the work, in order: a **pre-combine capture
 tap** (raw, so evidence stays untouched), an **inter-branch aligner** that
-measures and removes the fractional-sample start skew between the two streams
-(on one field rig, 2.6 samples of skew made the combine decode **22% worse**
-than the best branch alone — the aligner is why that can't happen anymore),
-and the **MRC combiner** itself, which estimates one complex gain per
-calibration window and either tracks it (`mrc`) or freezes it (`mrc-static`).
-The deep-dive story of how each stage earned its place is
+removes the fractional-sample start skew between the streams (on one field
+rig, 2.6 samples of skew made the combine decode **22% worse** than the best
+branch alone — the aligner is why that can't happen anymore), and the **MRC
+combiner**, which estimates one complex gain per calibration window and
+either tracks it (`mrc`) or freezes it (`mrc-static`). How each stage earned
+its place is
 [Weak-Signal Engineering Parts 10–11]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }});
-this recipe is the operator's side of it.
+this recipe is the operator's side.
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the diversity build: two antennas feed the two RX channels of one coherent SDR running SoapySDRServer; inside GopherTrunk's soapyremote driver the de-interleaved branches pass a pre-combine capture tap, then an inter-branch aligner, then the MRC combiner which emits one combined wideband stream to the decoder; a meter labelled branch_phase_deg reads the inter-branch phase, constant for shared-LO hardware and walking for independent PLLs">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the diversity build: two antennas feed the two RX channels of one coherent SDR running SoapySDRServer; inside GopherTrunk's soapyremote driver the branches pass a pre-combine capture tap, then the inter-branch aligner, then the MRC combiner, which emits one combined wideband stream to the decoder.">
   <rect x="10" y="40" width="64" height="30" rx="4" fill="none" stroke="currentColor"/>
   <text x="42" y="59" text-anchor="middle" fill="currentColor" font-size="10">ant A</text>
   <rect x="10" y="150" width="64" height="30" rx="4" fill="none" stroke="currentColor"/>
@@ -141,15 +136,15 @@ stream, nothing to phase-align).
 
 | Item | Class | Notes |
 |---|---|---|
-| USRP B210 (or similar 2-ch, shared-LO SDR) | shared LO | one chip, both channels — inter-branch phase is a hardware constant; `mrc-static` territory |
-| USRP X310 + 2× TwinRX | independent PLLs | separate daughterboards (`rx_subdev_spec=B:0 A:0`): frequency-locked but the relative phase is random per lock and walks after it — tracking `mrc` territory ([USRP notes]({{ '/reference/usrp-ettus/' | relative_url }})) |
-| Two antennas, same band + polarisation | — | co-located (think a wavelength or two apart, not metres — see the honest ceiling below), each with a decent feedline ([Part 8 of The Analog Edge]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})) |
-| A host for `SoapySDRServer` | — | the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }}) remote pattern; wired network, budget for two channels of CS16 |
+| USRP B210 (or similar 2-ch shared-LO SDR) | shared LO | one chip, both channels — inter-branch phase is a hardware constant; `mrc-static` territory |
+| USRP X310 + 2× TwinRX | independent PLLs | separate daughterboards (`rx_subdev_spec=B:0 A:0`): frequency-locked, but the relative phase is random per lock and walks after it — tracking `mrc` territory ([USRP notes]({{ '/reference/usrp-ettus/' | relative_url }})) |
+| Two antennas, same band + polarisation | — | co-located — a wavelength or two apart, not metres — with decent [feedline]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }}) |
+| A host for `SoapySDRServer` | — | the Part 8 remote pattern; wired network, budget for two channels of CS16 |
 
 No external reference oscillator is required for the X310/TwinRX class: a
-field capture proved the dual-daughterboard stream is coherent as delivered
-(wideband coherence 0.95+ on a healthy run) — the calibrator handles the
-phase, that's its job.
+field capture proved the dual-daughterboard stream coherent as delivered
+(wideband coherence 0.95+ on a healthy run) — handling the phase is the
+calibrator's job.
 
 ## The config
 
@@ -181,17 +176,15 @@ trunking:
         - 467_912_500
 ```
 
-Three notes. **`antenna:`** is the only correct way to pick ports — port names
-are device-specific (a B210 has `TX/RX` and `RX2`, a TwinRX has `RX1` and
-`RX2`), and GopherTrunk validates the list against the device and reads it
-back, so a config moved between rigs fails loudly instead of silently keeping
-driver defaults. **`diversity: "mrc"`** re-estimates the branch gain
-continuously; **`"mrc-static"`** freezes it after one estimate — which to pick
-is what the first run tells you. And the system block is whatever protocol you
-actually monitor; the combine happens below the protocol layer, so a
+Three notes. **`antenna:`** is the only correct way to pick ports — names are
+device-specific (a B210 has `TX/RX` and `RX2`, a TwinRX has `RX1` and `RX2`),
+and GopherTrunk validates the list against the device and reads it back, so a
+config moved between rigs fails loudly instead of silently keeping driver
+defaults. **`diversity: "mrc"`** re-estimates the branch gain continuously;
+**`"mrc-static"`** freezes it after one estimate — the first run tells you
+which to pick. And the combine happens below the protocol layer, so a
 [Part 4]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})
-TETRA rig or a [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})
-P25 rig rides it identically.
+TETRA rig or a Part 1 P25 rig rides it identically.
 
 ## First run — what healthy looks like
 
@@ -208,22 +201,21 @@ Read it field by field — this line is the whole cockpit:
 - **`branch_dbfs`** — both branches alive and within a few dB of each other.
   A branch ~10 dB down is a weak antenna or feedline, and MRC on a
   floor-limited branch is roughly no-gain: fix *that branch's* RF first.
-- **`coherence`** — the normalised cross-correlation between branches, and it
-  is **gain-independent by construction**. On a healthy co-located pair at
-  moderate bandwidth expect high values (0.9+); on wide captures where the
-  wanted carrier is a small fraction of the band, much lower numbers are
-  normal and the lock gates scale with the window to allow for it — the
+- **`coherence`** — the normalised cross-correlation between branches,
+  **gain-independent by construction**. A healthy co-located pair reads high
+  (0.9+) at moderate bandwidth; on wide captures where the wanted carrier is a
+  small fraction of the band, lower numbers are normal and the lock gates
+  scale with the window to allow for it — the
   [coherence-not-dBFS]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
   post is the full story.
-- **`branch_phase_deg`** — the no-capture hardware-class instrument. Watch it
-  across a few lines: **constant** (within a degree or two) means a shared-LO
-  front end, and `mrc-static` would serve you fine; **walking** (a TwinRX rig
-  measured about −0.2°/s — a frozen constant decays over minutes) means
-  independent PLLs, and tracking `mrc` is the right default.
+- **`branch_phase_deg`** — the no-capture hardware-class instrument.
+  **Constant** across lines means a shared-LO front end and `mrc-static`
+  would serve; **walking** (a TwinRX rig measured about −0.2°/s — a frozen
+  constant decays over minutes) means independent PLLs and tracking `mrc`.
 - **`updates` / `holds`** — accepted vs rejected calibration windows.
-  Healthy is `updates` climbing and `holds` near zero. `updates` frozen while
-  `holds` climbs means the combiner locked once and has been coasting on a
-  stale gain — it WARNs after 90 s of that.
+  Healthy is `updates` climbing with `holds` near zero; `updates` frozen
+  while `holds` climbs means coasting on a stale gain, and it WARNs after
+  90 s of that.
 
 One more line worth knowing on sight, once per stream or retune:
 
@@ -241,27 +233,26 @@ calibrated once.
 Now the part a recipe owes you before you spend this money. Post-aligner, MRC
 is a **no-harm** combine: every capture A/B run to date scores the combined
 arms within one decoded frame of the best branch alone. But those captures
-decode at their ~100% yield ceiling — when the signal is already strong,
-matching the best branch *is* the ceiling, and a real gain **over** the best
-branch is still undemonstrated on air. The theory says it shows up on weak,
-fading signals; if your diversity rig produces a weak-signal pre-combine
-capture where the combined arm beats both branches, that capture is genuinely
-wanted upstream.
+decode at their ~100% yield ceiling — matching the best branch *is* the
+ceiling there, and a real gain **over** the best branch is still
+undemonstrated on air. Theory says it shows up on weak, fading signals; a
+weak-signal pre-combine capture where the combined arm beats both branches is
+genuinely wanted upstream.
 
-Second honest limit: the combine applies **one complex gain to the whole
-wideband stream**. Two antennas metres apart give every carrier its own phase
-difference, and a single scalar can only align one of them — the signature is
-coherence stuck around 0.3–0.5 that no tracking improves. Co-locate the
-antennas; per-channel combining after the DDC is known future work, not a
-config option ([MRC gotchas]({{ '/reference/mrc-diversity-gotchas/' | relative_url }})).
+Second limit: the combine applies **one complex gain to the whole wideband
+stream**. Antennas metres apart give every carrier its own phase difference,
+and a single scalar can only align one of them — the signature is coherence
+stuck around 0.3–0.5 that no tracking improves. Co-locate the antennas;
+per-channel combining after the DDC is known future work, not a config option
+([MRC gotchas]({{ '/reference/mrc-diversity-gotchas/' | relative_url }})).
 
 ## The pre-combine A/B
 
-Every other IQ tap in the daemon —
+Every other IQ tap —
 [`baseband.auto_record`]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}),
 the scope feeds — sits *downstream* of the combiner, so a capture from any of
-them has one combiner already baked in. `diversity_capture` is the one tap
-that records the branches raw, straight after de-interleave:
+them has one combiner baked in. `diversity_capture` is the one tap that
+records the branches raw, straight after de-interleave:
 
 ```
 INF soapyremote: diversity capture armed — dumping pre-combine per-branch IQ prefix=../iq/mrc/precombine seconds=30 branches=2
@@ -270,8 +261,8 @@ INF soapyremote: diversity capture complete — replay it with GT_DIVERSITY_CAPT
 
 You get `<prefix>.br0.cs16`, `<prefix>.br1.cs16` and a `.diversity.json`
 sidecar; a datagram that didn't carry every branch is dropped from **both**
-files, never written short, because one short write silently desynchronises
-the pair. Then grade every combiner against your own air:
+files, never written short — one short write silently desynchronises the
+pair. Then grade every combiner against your own air:
 
 ```sh
 GT_DIVERSITY_CAPTURE=../iq/mrc/precombine.diversity.json \
@@ -279,32 +270,31 @@ GT_DIVERSITY_CAPTURE=../iq/mrc/precombine.diversity.json \
 ```
 
 The harness prints a windowed coherence/gain/**phase** trace with plain-text
-verdicts ("branch phase is essentially CONSTANT — a frozen calibration is
-fine on this hardware" vs "branch phase WALKS"), measures the inter-branch
-delay, and decodes the capture through each branch alone plus static,
-tracking, aligned and narrowband combine arms — **scored by CRC-clean decode
-yield**, because yield is the only metric that can't flatter a combiner. If
-tracking beats static on *your* capture, you've just answered the mode
-question with evidence instead of hardware folklore.
+verdicts ("branch phase is essentially CONSTANT" vs "branch phase WALKS"),
+measures the inter-branch delay, and decodes the capture through each branch
+alone plus static, tracking, aligned and narrowband combine arms — **scored
+by CRC-clean decode yield**, the one metric that can't flatter a combiner. If
+tracking beats static on *your* capture, the mode question is answered with
+evidence instead of hardware folklore.
 
 ## When it doesn't work
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| WARN `MRC diversity got 1 of 2 channels in the stream` | the server never delivered the second RX channel | check `args` (`rx_subdev_spec`), that the device really has two RX channels, and that the server accepted a 2-channel stream |
-| WARN `MRC diversity branch is dead — … below the reference receiver` | that antenna's connection, feedline, or per-branch gain | reseat/re-test that branch's RF path; the port assignment is `antenna:` |
-| WARN `MRC diversity branches are not coherent` | antennas on different bands/polarisation, widely separated, or the front end isn't frequency-locked | co-locate, match polarisation, check `clock_source`/`time_source`; if one `branch_dbfs` sits far below the other, fix *its* gain staging |
-| Calibrated once, then WARN `has not accepted a calibration window in 90s` | the wideband-scalar limitation — one gain can't align every carrier from separated antennas | move the antennas together, or freeze deliberately with `mrc-static` |
-| Combine decodes *worse* than one antenna alone | on current builds, almost certainly not skew (the aligner handles it) — suspect a branch dragging the estimate | run the pre-combine A/B; the arm table names the culprit |
-| Tempted to raise gain until diversity "engages" | the old absolute-power trap | don't — `coherence` is independent of RF gain; raising gain moves signal and noise together ([gain staging]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})) |
+| WARN `MRC diversity got 1 of 2 channels in the stream` | the server never delivered the second RX channel | check `args` (`rx_subdev_spec`) and that the device really has two RX channels |
+| WARN `MRC diversity branch is dead` | that antenna's connection, feedline or per-branch gain | reseat/re-test that branch's RF path; port assignment is `antenna:` |
+| WARN `MRC diversity branches are not coherent` | different bands/polarisation, widely separated antennas, or no frequency lock | co-locate, match polarisation, check `clock_source`/`time_source`; a far-down `branch_dbfs` wants *its* gain staging fixed |
+| Calibrated once, then WARN `has not accepted a calibration window` | the wideband-scalar limitation — one gain can't align every carrier from separated antennas | move the antennas together, or freeze deliberately with `mrc-static` |
+| Combine decodes *worse* than one antenna alone | not skew (the aligner handles it) — a branch is dragging the estimate | run the pre-combine A/B; the arm table names the culprit |
+| Tempted to raise gain until diversity "engages" | the old absolute-power trap | don't — `coherence` is gain-independent ([gain staging]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})) |
 
 That last row has history: an earlier build gated calibration on a fixed
 coherence constant, and its WARN told a bandwidth-diluted operator that
-raising RF gain would *not* help — which in their regime was exactly wrong
-(their weak branch needed +5 dB of per-branch gain). The gates now bound the
-estimate's phase error instead of a raw threshold, and the WARN points at
-per-branch gain staging. The lesson generalises across this whole series:
-**never trust an absolute-dBFS rule; trust coherence and decode yield.**
+raising RF gain would *not* help — exactly wrong in their regime (their weak
+branch needed +5 dB of per-branch gain). The gates now bound the estimate's
+phase error instead, and the WARN points at per-branch gain staging. The
+series-wide lesson: **never trust an absolute-dBFS rule; trust coherence and
+decode yield.**
 
 ## Variations
 
@@ -314,12 +304,12 @@ per-branch gain staging. The lesson generalises across this whole series:
 - **Longer evidence** — `diversity_capture_seconds` accepts up to 120 s (a
   1 GiB/branch cap always applies). At 200–250 kS/s two CS16 branches are only
   ~1.6 MB/s total, so take the long capture.
-- **Single-channel, port-pinned** — `diversity: ""` with `antenna: [RX2]` is
-  the same radio as a plain remote SDR but with the port explicit and
-  validated; useful for the "each branch alone" baseline before you commit.
+- **Single-channel, port-pinned** — `diversity: ""` with `antenna: [RX2]`:
+  the same radio as a plain remote SDR with the port explicit and validated —
+  the "each branch alone" baseline before you commit.
 - **Voice under diversity** — the combined stream is an ordinary tuner to the
-  rest of the daemon, so `role: wideband` with `voice_taps` on top of it works
-  exactly as in [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}).
+  rest of the daemon; `role: wideband` with `voice_taps` on top works exactly
+  as in Part 1.
 
 ## Where this goes next
 
@@ -333,36 +323,36 @@ things live from the browser, and exporting the result back to files you own.
 
 **Do I need a diversity setup for a scanner rig?**
 Almost certainly not first. Diversity is the only lever that costs serious
-hardware, and it addresses one specific regime: a signal that *fades* at your
-location. A better antenna, low-loss feedline and correct gain staging buy
-more decode margin per dollar; build this when those are done and a marginal
-system still swings.
+hardware, and it addresses one regime: a signal that *fades* at your location.
+A better antenna, low-loss feedline and correct gain staging buy more decode
+margin per dollar; build this when those are done and a marginal system still
+swings.
 
 **Should I use mrc or mrc-static?**
-Let `branch_phase_deg` answer: run `mrc`, watch the health line for a few
-minutes. If the phase sits constant, your hardware is shared-LO class and
-`mrc-static` is equivalent and simpler. If it walks — TwinRX-style independent
-PLLs — stay on `mrc`, because a frozen constant decays over minutes.
+Let `branch_phase_deg` answer: run `mrc` and watch the health line for a few
+minutes. Constant phase means shared-LO hardware — `mrc-static` is equivalent
+and simpler. Walking phase — TwinRX-style independent PLLs — means stay on
+`mrc`, because a frozen constant decays over minutes.
 
 **Can I do diversity with two RTL-SDR dongles?**
 No. The combine needs two RX channels behind one clock in one sample stream —
-`diversity: mrc` opens RX0+RX1 on a single SoapyRemote device. Two separate
-dongles have independent oscillators and independent USB timelines; there is
-no constant phase or delay for the calibrator to find.
+`diversity: mrc` opens RX0+RX1 on a single SoapyRemote device. Separate
+dongles have independent oscillators and USB timelines; there is no constant
+phase or delay for the calibrator to find.
 
 **Why is my coherence only 0.3 when everything decodes fine?**
 Wideband coherence is diluted by every hertz of noise-only bandwidth around
 your carrier — a clean channel occupying a small fraction of a wide capture
-reads low even when the branches agree perfectly in-channel. The lock gates
-scale with the estimation window for exactly this reason. Judge the combine by
-decode yield and the WARN lines, not by wishing the number toward 1.0.
+reads low even when the branches agree perfectly in-channel, which is why the
+lock gates scale with the estimation window. Judge the combine by decode
+yield and the WARN lines, not by wishing the number toward 1.0.
 
 **Does MRC help against a strong interferer?**
-Not blind, no — that's interference rejection combining (IRC), and measured on
-a synthetic co-channel scene, blind IRC buys 0.0 dB (the channel estimate is
+Not blind, no — that's interference rejection combining (IRC). Measured on a
+synthetic co-channel scene, blind IRC buys 0.0 dB (the channel estimate is
 contaminated by the interferer itself); the same code given a training
-sequence buys over 20 dB. That's why IRC exists only as an offline harness arm
-today, not a `diversity:` mode.
+sequence buys over 20 dB. That's why IRC exists only as an offline harness
+arm, not a `diversity:` mode.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
+++ b/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
@@ -72,7 +72,7 @@ anywhere else in the series.*
 
 ## What you're building
 
-The finished rig is the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+The [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
 remote-radio build with a second antenna: a two-channel SDR runs
 `SoapySDRServer` near the antennas, GopherTrunk opens **both** RX channels,
 and the driver phase-aligns and sums them into one maximised-SNR stream
@@ -80,19 +80,19 @@ before the decoder ever sees IQ. Everything downstream is unchanged;
 diversity is invisible except in the health log and, when the channel fades,
 in the calls that keep decoding.
 
-Three stages inside the driver do the work, in order: a **pre-combine capture
-tap** (raw, so evidence stays untouched), an **inter-branch aligner** that
-removes the fractional-sample start skew between the streams (on one field
-rig, 2.6 samples of skew made the combine decode **22% worse** than the best
+Three driver stages do the work, in order: a **pre-combine capture tap**
+(raw, so evidence stays untouched), an **inter-branch aligner** that removes
+the fractional-sample start skew between the streams (on one field rig,
+2.6 samples of skew made the combine decode **22% worse** than the best
 branch alone — the aligner is why that can't happen anymore), and the **MRC
 combiner**, which estimates one complex gain per calibration window and
-either tracks it (`mrc`) or freezes it (`mrc-static`). How each stage earned
-its place is
+either tracks (`mrc`) or freezes it (`mrc-static`). How each stage earned its
+place is
 [Weak-Signal Engineering Parts 10–11]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }});
 this recipe is the operator's side.
 
 <figure class="lab-figure">
-<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the diversity build: two antennas feed the two RX channels of one coherent SDR running SoapySDRServer; inside GopherTrunk's soapyremote driver the branches pass a pre-combine capture tap, then the inter-branch aligner, then the MRC combiner, which emits one combined wideband stream to the decoder.">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two antennas feed the two RX channels of one coherent SDR running SoapySDRServer; inside GopherTrunk's driver the branches pass a pre-combine capture tap, the inter-branch aligner, and the MRC combiner, which emits one combined wideband stream to the decoder.">
   <rect x="10" y="40" width="64" height="30" rx="4" fill="none" stroke="currentColor"/>
   <text x="42" y="59" text-anchor="middle" fill="currentColor" font-size="10">ant A</text>
   <rect x="10" y="150" width="64" height="30" rx="4" fill="none" stroke="currentColor"/>
@@ -115,22 +115,22 @@ this recipe is the operator's side.
   <text x="408" y="117" text-anchor="middle" fill="currentColor" font-size="10">inter-branch aligner (delay_samples)</text>
   <rect x="280" y="140" width="256" height="30" rx="4" fill="none" stroke="var(--accent)"/>
   <text x="408" y="159" text-anchor="middle" fill="var(--accent)" font-size="10">MRC combiner (mrc / mrc-static)</text>
-  <text x="408" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="9">health: coherence · branch_gain_db · branch_phase_deg</text>
-  <text x="408" y="204" text-anchor="middle" fill="var(--fg-muted)" font-size="9">constant phase ⇒ shared LO · walking ⇒ tracking mode</text>
+  <text x="408" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="9">health line: coherence · branch_gain_db · branch_phase_deg</text>
+  <text x="408" y="204" text-anchor="middle" fill="var(--fg-muted)" font-size="9">phase constant ⇒ shared LO · walking ⇒ tracking</text>
   <line x1="552" y1="155" x2="592" y2="155" stroke="var(--accent)"/>
   <polygon points="586,151 594,155 586,159" fill="var(--accent)"/>
   <rect x="594" y="128" width="76" height="54" rx="4" fill="none" stroke="currentColor"/>
   <text x="632" y="150" text-anchor="middle" fill="currentColor" font-size="10">one wideband</text>
   <text x="632" y="164" text-anchor="middle" fill="currentColor" font-size="10">stream → decode</text>
 </svg>
-<figcaption>The whole diversity build: the decoder never knows there were two antennas — the capture tap, the aligner and the combiner live inside the driver, and one log line reports whether they're earning their keep.</figcaption>
+<figcaption>The decoder never knows there were two antennas — the capture tap, aligner and combiner live inside the driver, and one log line reports whether they're earning their keep.</figcaption>
 </figure>
 
 ## The shopping list
 
-This is the expensive recipe, and the honest first line is: **most rigs don't
-need it.** You need one radio with two RX channels sharing a frequency
-reference — two separate dongles will not do.
+The honest first line: **most rigs don't need this.** You need one radio with
+two RX channels sharing a frequency reference — two separate dongles will not
+do.
 
 | Item | Class | Notes |
 |---|---|---|
@@ -176,11 +176,11 @@ trunking:
 
 Three notes. **`antenna:`** is the only correct way to pick ports — names are
 device-specific (a B210 has `TX/RX` and `RX2`, a TwinRX has `RX1` and `RX2`),
-and GopherTrunk validates the list against the device and reads it back, so a
-config moved between rigs fails loudly instead of silently keeping driver
-defaults. **`diversity: "mrc"`** re-estimates the branch gain continuously;
-**`"mrc-static"`** freezes it after one estimate — the first run tells you
-which to pick. And the combine happens below the protocol layer, so a
+and GopherTrunk validates the list and reads it back, so a config moved
+between rigs fails loudly. **`diversity: "mrc"`** re-estimates the branch
+gain continuously; **`"mrc-static"`** freezes it after one estimate — the
+first run tells you which to pick. And the combine happens below the protocol
+layer, so a
 [Part 4]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})
 TETRA rig or a Part 1 P25 rig rides it identically.
 
@@ -212,9 +212,9 @@ Read it field by field — this line is the whole cockpit:
   is `updates` climbing with `holds` near zero; `updates` frozen while
   `holds` climbs means coasting on a stale gain, and it WARNs after 90 s.
 
-One more line worth knowing on sight, once per stream or retune — the
-aligner latching the start skew between the streams (per-stream, which is why
-it's re-measured every time rather than calibrated once):
+One more line to know on sight, once per stream or retune — the aligner
+latching the start skew (per-stream, which is why it's re-measured every time
+rather than calibrated once):
 
 ```
 INF soapyremote: MRC inter-branch delay measured — delaying the early branch to align the combine delay_samples=0.41 peak_rho=0.94
@@ -233,9 +233,9 @@ genuinely wanted upstream.
 
 Second limit: the combine applies **one complex gain to the whole wideband
 stream**. Antennas metres apart give every carrier its own phase difference,
-and a single scalar can only align one of them — the signature is coherence
-stuck around 0.3–0.5 that no tracking improves. Co-locate the antennas;
-per-channel combining after the DDC is known future work, not a config option
+and a single scalar can only align one — the signature is coherence stuck
+around 0.3–0.5 that no tracking improves. Co-locate the antennas; per-channel
+combining after the DDC is future work, not a config option
 ([MRC gotchas]({{ '/reference/mrc-diversity-gotchas/' | relative_url }})).
 
 ### The pre-combine A/B
@@ -265,9 +265,8 @@ The harness prints a windowed coherence/gain/**phase** trace with plain-text
 verdicts ("branch phase is essentially CONSTANT" vs "branch phase WALKS"),
 measures the inter-branch delay, and decodes the capture through each branch
 alone plus static, tracking, aligned and narrowband combine arms — **scored
-by CRC-clean decode yield**, the one metric that can't flatter a combiner. If
-tracking beats static on *your* capture, the mode question is answered with
-evidence instead of hardware folklore.
+by CRC-clean decode yield**, the one metric that can't flatter a combiner.
+That table answers the mode question with evidence instead of folklore.
 
 ## When it doesn't work
 
@@ -290,17 +289,16 @@ rule; trust coherence and decode yield.**
 ### Variations
 
 - **`diversity: "mrc-static"`** — one-shot calibration, frozen. Correct for
-  shared-LO hardware (constant `branch_phase_deg`), and the standard A/B
-  reference arm on any rig.
+  shared-LO hardware, and the standard A/B reference arm on any rig.
 - **Longer evidence** — `diversity_capture_seconds` accepts up to 120 s (a
-  1 GiB/branch cap always applies). At 200–250 kS/s two CS16 branches are only
-  ~1.6 MB/s total, so take the long capture.
+  1 GiB/branch cap always applies); at 200–250 kS/s two CS16 branches are
+  only ~1.6 MB/s total, so take the long capture.
 - **Single-channel, port-pinned** — `diversity: ""` with `antenna: [RX2]`:
-  the same radio as a plain remote SDR with the port explicit and validated —
-  the "each branch alone" baseline before you commit.
+  a plain remote SDR with the port explicit and validated — the "each branch
+  alone" baseline before you commit.
 - **Voice under diversity** — the combined stream is an ordinary tuner to the
-  rest of the daemon; `role: wideband` with `voice_taps` on top works exactly
-  as in Part 1.
+  daemon; `role: wideband` with `voice_taps` on top works exactly as in
+  Part 1.
 
 ## Where this goes next
 
@@ -328,14 +326,14 @@ and simpler. Walking phase — TwinRX-style independent PLLs — means stay on
 No. The combine needs two RX channels behind one clock in one sample stream —
 `diversity: mrc` opens RX0+RX1 on a single SoapyRemote device. Separate
 dongles have independent oscillators and USB timelines; there is no constant
-phase or delay for the calibrator to find.
+phase for the calibrator to find.
 
 **Why is my coherence only 0.3 when everything decodes fine?**
 Wideband coherence is diluted by every hertz of noise-only bandwidth around
 your carrier — a clean channel occupying a small fraction of a wide capture
 reads low even when the branches agree perfectly in-channel, which is why the
 lock gates scale with the estimation window. Judge the combine by decode
-yield and the WARN lines, not by wishing the number toward 1.0.
+yield and the WARN lines.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
+++ b/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
@@ -228,7 +228,7 @@ is per-stream (a field pair measured 2.60 samples on one run and 0.41 on the
 next, same rig), which is exactly why it's re-measured every time rather than
 calibrated once.
 
-## The honest ceiling
+## The honest ceiling — and the A/B that tests it
 
 Now the part a recipe owes you before you spend this money. Post-aligner, MRC
 is a **no-harm** combine: every capture A/B run to date scores the combined
@@ -246,7 +246,7 @@ stuck around 0.3–0.5 that no tracking improves. Co-locate the antennas;
 per-channel combining after the DDC is known future work, not a config option
 ([MRC gotchas]({{ '/reference/mrc-diversity-gotchas/' | relative_url }})).
 
-## The pre-combine A/B
+### The pre-combine A/B
 
 Every other IQ tap —
 [`baseband.auto_record`]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}),
@@ -296,7 +296,7 @@ phase error instead, and the WARN points at per-branch gain staging. The
 series-wide lesson: **never trust an absolute-dBFS rule; trust coherence and
 decode yield.**
 
-## Variations
+### Variations
 
 - **`diversity: "mrc-static"`** — one-shot calibration, frozen. Correct for
   shared-LO hardware (constant `branch_phase_deg`), and the standard A/B

--- a/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
+++ b/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
@@ -24,13 +24,12 @@ anywhere else in the series.*
 > USRP B210 (shared LO) or an X310 with TwinRX daughterboards (independent
 > PLLs) — mounted over `sdr.soapy_remote[]` with `diversity: "mrc"` and
 > `antenna: [RX1, RX2]`. Health is one log line every 30 s:
-> `soapyremote: MRC diversity branches` with `coherence`, `branch_gain_db` and
-> `branch_phase_deg`. **`branch_phase_deg` is the instrument**: constant ⇒
-> shared-LO hardware, `mrc-static` is fine; walking ⇒ independent PLLs, you
-> want tracking `mrc`. The honest ceiling: MRC is guaranteed **≥ the best
-> branch alone**, but a real gain *over* it only shows on weak signals — prove
-> yours with a `diversity_capture` pre-combine dump and
-> `TestDiversityCombinerReplay`, scored by decode yield, never by
+> `soapyremote: MRC diversity branches`, and **`branch_phase_deg` is the
+> instrument**: constant ⇒ shared-LO hardware, `mrc-static` is fine; walking
+> ⇒ independent PLLs, you want tracking `mrc`. The honest ceiling: MRC is
+> guaranteed **≥ the best branch alone**, but a real gain *over* it only
+> shows on weak signals — prove yours with a `diversity_capture` pre-combine
+> dump and `TestDiversityCombinerReplay`, scored by decode yield, never by
 > [dBFS]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }}).
 
 **Key takeaways**
@@ -131,8 +130,7 @@ this recipe is the operator's side.
 
 This is the expensive recipe, and the honest first line is: **most rigs don't
 need it.** You need one radio with two RX channels sharing a frequency
-reference — two separate dongles will not do (independent clocks, no common
-stream, nothing to phase-align).
+reference — two separate dongles will not do.
 
 | Item | Class | Notes |
 |---|---|---|
@@ -198,35 +196,30 @@ INF soapyremote: MRC diversity branches addr=192.168.1.60:55132 branch_dbfs="ch0
 
 Read it field by field — this line is the whole cockpit:
 
-- **`branch_dbfs`** — both branches alive and within a few dB of each other.
-  A branch ~10 dB down is a weak antenna or feedline, and MRC on a
-  floor-limited branch is roughly no-gain: fix *that branch's* RF first.
+- **`branch_dbfs`** — both branches alive and within a few dB. A branch
+  ~10 dB down is a weak antenna or feedline, and MRC on a floor-limited
+  branch is roughly no-gain: fix *that branch's* RF first.
 - **`coherence`** — the normalised cross-correlation between branches,
-  **gain-independent by construction**. A healthy co-located pair reads high
-  (0.9+) at moderate bandwidth; on wide captures where the wanted carrier is a
-  small fraction of the band, lower numbers are normal and the lock gates
-  scale with the window to allow for it — the
+  **gain-independent by construction**. A healthy co-located pair reads 0.9+
+  at moderate bandwidth; on wide captures lower numbers are normal and the
+  lock gates scale with the window —
   [coherence-not-dBFS]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
-  post is the full story.
+  is the full story.
 - **`branch_phase_deg`** — the no-capture hardware-class instrument.
-  **Constant** across lines means a shared-LO front end and `mrc-static`
-  would serve; **walking** (a TwinRX rig measured about −0.2°/s — a frozen
-  constant decays over minutes) means independent PLLs and tracking `mrc`.
-- **`updates` / `holds`** — accepted vs rejected calibration windows.
-  Healthy is `updates` climbing with `holds` near zero; `updates` frozen
-  while `holds` climbs means coasting on a stale gain, and it WARNs after
-  90 s of that.
+  **Constant** across lines means shared-LO and `mrc-static` would serve;
+  **walking** (a TwinRX rig measured about −0.2°/s — a frozen constant decays
+  over minutes) means independent PLLs and tracking `mrc`.
+- **`updates` / `holds`** — accepted vs rejected calibration windows. Healthy
+  is `updates` climbing with `holds` near zero; `updates` frozen while
+  `holds` climbs means coasting on a stale gain, and it WARNs after 90 s.
 
-One more line worth knowing on sight, once per stream or retune:
+One more line worth knowing on sight, once per stream or retune — the
+aligner latching the start skew between the streams (per-stream, which is why
+it's re-measured every time rather than calibrated once):
 
 ```
 INF soapyremote: MRC inter-branch delay measured — delaying the early branch to align the combine delay_samples=0.41 peak_rho=0.94
 ```
-
-That is the aligner latching the start skew between the two streams. The skew
-is per-stream (a field pair measured 2.60 samples on one run and 0.41 on the
-next, same rig), which is exactly why it's re-measured every time rather than
-calibrated once.
 
 ## The honest ceiling — and the A/B that tests it
 
@@ -234,8 +227,8 @@ Now the part a recipe owes you before you spend this money. Post-aligner, MRC
 is a **no-harm** combine: every capture A/B run to date scores the combined
 arms within one decoded frame of the best branch alone. But those captures
 decode at their ~100% yield ceiling — matching the best branch *is* the
-ceiling there, and a real gain **over** the best branch is still
-undemonstrated on air. Theory says it shows up on weak, fading signals; a
+ceiling there — so a real gain **over** the best branch is still
+undemonstrated on air. Theory says it shows on weak, fading signals; a
 weak-signal pre-combine capture where the combined arm beats both branches is
 genuinely wanted upstream.
 
@@ -313,20 +306,19 @@ decode yield.**
 
 ## Where this goes next
 
-The rig now has every piece of hardware this series will ask you to buy. What
-it doesn't have yet is *names* — every talkgroup, radio and site is still a
-number. [Part 13]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }})
-is the zero-hardware recipe: alias CSVs with their real column formats, naming
-things live from the browser, and exporting the result back to files you own.
+The rig now has every piece of hardware this series will ask you to buy —
+but every talkgroup and radio is still a number.
+[Part 13]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }})
+is the zero-hardware recipe: alias CSVs and their real columns, naming things
+live from the browser, and exporting the result back to files you own.
 
 ## FAQ
 
 **Do I need a diversity setup for a scanner rig?**
-Almost certainly not first. Diversity is the only lever that costs serious
-hardware, and it addresses one regime: a signal that *fades* at your location.
-A better antenna, low-loss feedline and correct gain staging buy more decode
-margin per dollar; build this when those are done and a marginal system still
-swings.
+Almost certainly not first. It's the only lever that costs serious hardware,
+and it addresses one regime: a signal that *fades* at your location. Antenna,
+feedline and gain staging buy more margin per dollar; build this when those
+are done and a marginal system still swings.
 
 **Should I use mrc or mrc-static?**
 Let `branch_phase_deg` answer: run `mrc` and watch the health line for a few
@@ -346,13 +338,6 @@ your carrier — a clean channel occupying a small fraction of a wide capture
 reads low even when the branches agree perfectly in-channel, which is why the
 lock gates scale with the estimation window. Judge the combine by decode
 yield and the WARN lines, not by wishing the number toward 1.0.
-
-**Does MRC help against a strong interferer?**
-Not blind, no — that's interference rejection combining (IRC). Measured on a
-synthetic co-channel scene, blind IRC buys 0.0 dB (the channel estimate is
-contaminated by the interferer itself); the same code given a training
-sequence buys over 20 dB. That's why IRC exists only as an offline harness
-arm, not a `diversity:` mode.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
+++ b/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
@@ -146,7 +146,7 @@ calibrator's job.
 
 ## The config
 
-Everything below is the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+The [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
 SoapyRemote block plus three diversity keys, all verified against
 `config.example.yaml`:
 
@@ -187,8 +187,7 @@ TETRA rig or a Part 1 P25 rig rides it identically.
 ## First run — what healthy looks like
 
 Start the daemon and let it lock as usual (`tetra cc locked freq=467912500
-mcc=… mnc=…` on this recipe's system). The diversity-specific heartbeat is one
-INFO line every 30 seconds:
+mcc=… mnc=…` here). The diversity heartbeat is one INFO line every 30 s:
 
 ```
 INF soapyremote: MRC diversity branches addr=192.168.1.60:55132 branch_dbfs="ch0=-51.2 ch1=-50.6" reference_branch=1 calibrated=true coherence=0.95 branch_gain_db=-1.2 branch_phase_deg=145.3 mode=mrc updates=6682 holds=0
@@ -285,9 +284,8 @@ That last row has history: an earlier build gated calibration on a fixed
 coherence constant, and its WARN told a bandwidth-diluted operator that
 raising RF gain would *not* help — exactly wrong in their regime (their weak
 branch needed +5 dB of per-branch gain). The gates now bound the estimate's
-phase error instead, and the WARN points at per-branch gain staging. The
-series-wide lesson: **never trust an absolute-dBFS rule; trust coherence and
-decode yield.**
+phase error instead. The series-wide lesson: **never trust an absolute-dBFS
+rule; trust coherence and decode yield.**
 
 ### Variations
 

--- a/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
+++ b/docs/_posts/2026-09-14-operator-cookbook-12-diversity-mrc.md
@@ -1,0 +1,372 @@
+---
+title: "The Operator's Cookbook, Part 12: Two Antennas, One Signal — A Diversity Build"
+description: A complete GopherTrunk diversity build — a two-channel SDR over SoapyRemote with diversity mrc, reading the MRC health line (coherence, branch_phase_deg), choosing mrc vs mrc-static by hardware class, and the pre-combine capture A/B that proves whether combining actually helps.
+category: tutorials
+keywords: sdr diversity receiver setup, maximal ratio combining sdr, usrp x310 twinrx diversity, dual antenna scanner rig, mrc vs mrc-static, branch coherence sdr, pre-combine iq capture, gophertrunk diversity config, gophertrunk cookbook
+tags: [operator-cookbook, diversity, mrc, usrp, soapyremote, rf]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 12
+---
+
+*Part 12 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
+put the rig in a closet and taught it to survive unattended. This part is the
+advanced RF build: **two antennas feeding one decoder**, phase-coherently
+combined so a fade on one branch is covered by the other. It is the most
+instrument-heavy recipe in the series — diversity is the one upgrade that can
+silently do nothing (or, before the aligner, actively hurt), so the log lines
+that prove it's working matter more here than anywhere else.*
+
+> **TL;DR:** Diversity needs **one radio with two coherent RX channels** — a
+> USRP B210 (shared LO) or an X310 with TwinRX daughterboards (independent
+> PLLs) — mounted over `sdr.soapy_remote[]` with `diversity: "mrc"` and
+> `antenna: [RX1, RX2]`. Health is one log line every 30 s:
+> `soapyremote: MRC diversity branches` with `coherence`, `branch_gain_db` and
+> `branch_phase_deg`. **`branch_phase_deg` is the instrument**: constant ⇒
+> shared-LO hardware, `mrc-static` is fine; walking ⇒ independent PLLs, you
+> want tracking `mrc`. The honest ceiling: MRC is guaranteed **≥ the best
+> branch alone**, but a real gain *over* it only shows on weak signals — prove
+> yours with a `diversity_capture` pre-combine dump and
+> `TestDiversityCombinerReplay`, scored by decode yield, never by
+> [dBFS]({{ '/blog/tutorials/analog-edge-02-dbfs/' | relative_url }}).
+
+**Key takeaways**
+
+- **Diversity is the last lever, not the first.** A better antenna, feedline
+  and gain staging (Parts 7–9 of
+  [The Analog Edge]({{ '/blog/tutorials/analog-edge-07-antennas/' | relative_url }}))
+  buy more margin per dollar. Build this when one antenna genuinely fades —
+  and only after the single-branch rig already decodes.
+- **Hardware class decides the mode.** A shared-LO front end has one fixed
+  inter-branch phase; separate daughterboards with independent PLLs lock at a
+  random phase that then walks. `branch_phase_deg` in the health line tells
+  you which class you own, before any capture.
+- **Coherence, not dBFS, is the verdict on the combine.** The
+  [coherence]({{ '/reference/coherence/' | relative_url }}) figure is
+  independent of RF gain — raising gain to make diversity "engage" is never
+  the answer, and the config file says so in as many words.
+- **MRC ≥ best branch is a floor, not a promise of gain.** On a strong signal
+  every combined arm just matches the better antenna. The gain case lives on
+  weak signals, and the pre-combine capture A/B is how you check yours.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Enable combining | open RX0+RX1, combine into one stream | `sdr.soapy_remote[].diversity: "mrc"` |
+| Freeze the estimate | one-shot calibration, for A/B or shared-LO rigs | `diversity: "mrc-static"` |
+| Antenna ports | per-channel port assignment, validated + read back | `antenna: [RX1, RX2]` |
+| Hardware-class instrument | constant vs walking inter-branch phase | `branch_phase_deg` in the MRC health line |
+| Pre-combine evidence | per-branch IQ dump only the driver can make | `diversity_capture`, `diversity_capture_seconds` |
+| Offline A/B | replay both branches through every combiner arm | `TestDiversityCombinerReplay` (`GT_DIVERSITY_CAPTURE`) |
+| The concepts | why MRC works and where it can't | [antenna diversity]({{ '/reference/antenna-diversity/' | relative_url }}), [MRC gotchas]({{ '/reference/mrc-diversity-gotchas/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — two antennas, one coherent front end, one combined stream.
+- **The shopping list** — why this is the expensive recipe, and the two hardware classes.
+- **The config** — `diversity: mrc` on a SoapyRemote device, every key verified.
+- **First run — what healthy looks like** — the MRC health line, field by field.
+- **The honest ceiling** — what MRC can and cannot buy you.
+- **The pre-combine A/B** — capturing both branches and grading the combine offline.
+- **When it doesn't work** — symptom → cause → fix.
+- **Variations** — mrc-static, longer captures, single-port pinning.
+
+## What you're building
+
+The finished rig is the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+remote-radio build with a second antenna: a two-channel SDR runs
+`SoapySDRServer` near the antennas, GopherTrunk opens **both** RX channels,
+and the driver phase-aligns and sums them into a single maximised-SNR stream
+before the decoder ever sees IQ. Everything downstream — control-channel
+decode, voice taps, recordings — is unchanged; diversity is invisible except
+in the health log and, when the channel fades, in the calls that keep
+decoding.
+
+Three stages inside the driver do the work, in order: a **pre-combine capture
+tap** (raw, so evidence stays untouched), an **inter-branch aligner** that
+measures and removes the fractional-sample start skew between the two streams
+(on one field rig, 2.6 samples of skew made the combine decode **22% worse**
+than the best branch alone — the aligner is why that can't happen anymore),
+and the **MRC combiner** itself, which estimates one complex gain per
+calibration window and either tracks it (`mrc`) or freezes it (`mrc-static`).
+The deep-dive story of how each stage earned its place is
+[Weak-Signal Engineering Parts 10–11]({{ '/blog/deep-dives/weak-signal-engineering-10-mrc-calibration/' | relative_url }});
+this recipe is the operator's side of it.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Signal chain of the diversity build: two antennas feed the two RX channels of one coherent SDR running SoapySDRServer; inside GopherTrunk's soapyremote driver the de-interleaved branches pass a pre-combine capture tap, then an inter-branch aligner, then the MRC combiner which emits one combined wideband stream to the decoder; a meter labelled branch_phase_deg reads the inter-branch phase, constant for shared-LO hardware and walking for independent PLLs">
+  <rect x="10" y="40" width="64" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="42" y="59" text-anchor="middle" fill="currentColor" font-size="10">ant A</text>
+  <rect x="10" y="150" width="64" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="42" y="169" text-anchor="middle" fill="currentColor" font-size="10">ant B</text>
+  <rect x="104" y="30" width="120" height="160" rx="6" fill="none" stroke="currentColor"/>
+  <text x="164" y="50" text-anchor="middle" fill="currentColor" font-size="10">2-ch SDR</text>
+  <text x="164" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="9">B210 / X310+TwinRX</text>
+  <text x="164" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="9">RX1 → ch0</text>
+  <text x="164" y="100" text-anchor="middle" fill="var(--fg-muted)" font-size="9">RX2 → ch1</text>
+  <text x="164" y="126" text-anchor="middle" fill="var(--fg-muted)" font-size="9">SoapySDRServer</text>
+  <line x1="74" y1="55" x2="104" y2="55" stroke="currentColor"/>
+  <line x1="74" y1="165" x2="104" y2="120" stroke="currentColor"/>
+  <line x1="224" y1="110" x2="262" y2="110" stroke="currentColor"/>
+  <polygon points="256,106 264,110 256,114" fill="currentColor"/>
+  <rect x="264" y="24" width="288" height="196" rx="6" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <text x="408" y="42" text-anchor="middle" fill="var(--fg-muted)" font-size="10">GopherTrunk soapyremote driver</text>
+  <rect x="280" y="56" width="256" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="408" y="75" text-anchor="middle" fill="currentColor" font-size="10">pre-combine capture tap (diversity_capture)</text>
+  <rect x="280" y="98" width="256" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="408" y="117" text-anchor="middle" fill="currentColor" font-size="10">inter-branch aligner (delay_samples)</text>
+  <rect x="280" y="140" width="256" height="30" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="408" y="159" text-anchor="middle" fill="var(--accent)" font-size="10">MRC combiner (mrc / mrc-static)</text>
+  <text x="408" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="9">health: coherence · branch_gain_db · branch_phase_deg</text>
+  <text x="408" y="204" text-anchor="middle" fill="var(--fg-muted)" font-size="9">constant phase ⇒ shared LO · walking ⇒ tracking mode</text>
+  <line x1="552" y1="155" x2="592" y2="155" stroke="var(--accent)"/>
+  <polygon points="586,151 594,155 586,159" fill="var(--accent)"/>
+  <rect x="594" y="128" width="76" height="54" rx="4" fill="none" stroke="currentColor"/>
+  <text x="632" y="150" text-anchor="middle" fill="currentColor" font-size="10">one wideband</text>
+  <text x="632" y="164" text-anchor="middle" fill="currentColor" font-size="10">stream → decode</text>
+</svg>
+<figcaption>The whole diversity build: the decoder never knows there were two antennas — the capture tap, the aligner and the combiner live inside the driver, and one log line reports whether they're earning their keep.</figcaption>
+</figure>
+
+## The shopping list
+
+This is the expensive recipe, and the honest first line is: **most rigs don't
+need it.** You need one radio with two RX channels sharing a frequency
+reference — two separate dongles will not do (independent clocks, no common
+stream, nothing to phase-align).
+
+| Item | Class | Notes |
+|---|---|---|
+| USRP B210 (or similar 2-ch, shared-LO SDR) | shared LO | one chip, both channels — inter-branch phase is a hardware constant; `mrc-static` territory |
+| USRP X310 + 2× TwinRX | independent PLLs | separate daughterboards (`rx_subdev_spec=B:0 A:0`): frequency-locked but the relative phase is random per lock and walks after it — tracking `mrc` territory ([USRP notes]({{ '/reference/usrp-ettus/' | relative_url }})) |
+| Two antennas, same band + polarisation | — | co-located (think a wavelength or two apart, not metres — see the honest ceiling below), each with a decent feedline ([Part 8 of The Analog Edge]({{ '/blog/tutorials/analog-edge-08-feedline-connectors/' | relative_url }})) |
+| A host for `SoapySDRServer` | — | the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }}) remote pattern; wired network, budget for two channels of CS16 |
+
+No external reference oscillator is required for the X310/TwinRX class: a
+field capture proved the dual-daughterboard stream is coherent as delivered
+(wideband coherence 0.95+ on a healthy run) — the calibrator handles the
+phase, that's its job.
+
+## The config
+
+Everything below is the [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }})
+SoapyRemote block plus three diversity keys, all verified against
+`config.example.yaml`:
+
+```yaml
+sdr:
+  sample_rate: 250_000        # soapy_remote isn't bound to RTL rate limits
+  soapy_remote:
+    - addr: "192.168.1.60:55132"
+      driver: "uhd"
+      args: "rx_subdev_spec=B:0 A:0"   # X310: one channel per TwinRX
+      serial: "usrp-attic"
+      role: control
+      format: "CS16"
+      gain: "auto"
+      diversity: "mrc"                 # "" | "mrc" | "mrc-static"
+      antenna: [RX1, RX2]              # RX1→channel 0, RX2→channel 1
+      # diversity_capture: "../iq/mrc/precombine"
+      # diversity_capture_seconds: 30
+
+trunking:
+  systems:
+    - name: "Metro-TETRA"
+      protocol: tetra
+      control_channels:
+        - 467_912_500
+```
+
+Three notes. **`antenna:`** is the only correct way to pick ports — port names
+are device-specific (a B210 has `TX/RX` and `RX2`, a TwinRX has `RX1` and
+`RX2`), and GopherTrunk validates the list against the device and reads it
+back, so a config moved between rigs fails loudly instead of silently keeping
+driver defaults. **`diversity: "mrc"`** re-estimates the branch gain
+continuously; **`"mrc-static"`** freezes it after one estimate — which to pick
+is what the first run tells you. And the system block is whatever protocol you
+actually monitor; the combine happens below the protocol layer, so a
+[Part 4]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }})
+TETRA rig or a [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})
+P25 rig rides it identically.
+
+## First run — what healthy looks like
+
+Start the daemon and let it lock as usual (`tetra cc locked freq=467912500
+mcc=… mnc=…` on this recipe's system). The diversity-specific heartbeat is one
+INFO line every 30 seconds:
+
+```
+INF soapyremote: MRC diversity branches addr=192.168.1.60:55132 branch_dbfs="ch0=-51.2 ch1=-50.6" reference_branch=1 calibrated=true coherence=0.95 branch_gain_db=-1.2 branch_phase_deg=145.3 mode=mrc updates=6682 holds=0
+```
+
+Read it field by field — this line is the whole cockpit:
+
+- **`branch_dbfs`** — both branches alive and within a few dB of each other.
+  A branch ~10 dB down is a weak antenna or feedline, and MRC on a
+  floor-limited branch is roughly no-gain: fix *that branch's* RF first.
+- **`coherence`** — the normalised cross-correlation between branches, and it
+  is **gain-independent by construction**. On a healthy co-located pair at
+  moderate bandwidth expect high values (0.9+); on wide captures where the
+  wanted carrier is a small fraction of the band, much lower numbers are
+  normal and the lock gates scale with the window to allow for it — the
+  [coherence-not-dBFS]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }})
+  post is the full story.
+- **`branch_phase_deg`** — the no-capture hardware-class instrument. Watch it
+  across a few lines: **constant** (within a degree or two) means a shared-LO
+  front end, and `mrc-static` would serve you fine; **walking** (a TwinRX rig
+  measured about −0.2°/s — a frozen constant decays over minutes) means
+  independent PLLs, and tracking `mrc` is the right default.
+- **`updates` / `holds`** — accepted vs rejected calibration windows.
+  Healthy is `updates` climbing and `holds` near zero. `updates` frozen while
+  `holds` climbs means the combiner locked once and has been coasting on a
+  stale gain — it WARNs after 90 s of that.
+
+One more line worth knowing on sight, once per stream or retune:
+
+```
+INF soapyremote: MRC inter-branch delay measured — delaying the early branch to align the combine delay_samples=0.41 peak_rho=0.94
+```
+
+That is the aligner latching the start skew between the two streams. The skew
+is per-stream (a field pair measured 2.60 samples on one run and 0.41 on the
+next, same rig), which is exactly why it's re-measured every time rather than
+calibrated once.
+
+## The honest ceiling
+
+Now the part a recipe owes you before you spend this money. Post-aligner, MRC
+is a **no-harm** combine: every capture A/B run to date scores the combined
+arms within one decoded frame of the best branch alone. But those captures
+decode at their ~100% yield ceiling — when the signal is already strong,
+matching the best branch *is* the ceiling, and a real gain **over** the best
+branch is still undemonstrated on air. The theory says it shows up on weak,
+fading signals; if your diversity rig produces a weak-signal pre-combine
+capture where the combined arm beats both branches, that capture is genuinely
+wanted upstream.
+
+Second honest limit: the combine applies **one complex gain to the whole
+wideband stream**. Two antennas metres apart give every carrier its own phase
+difference, and a single scalar can only align one of them — the signature is
+coherence stuck around 0.3–0.5 that no tracking improves. Co-locate the
+antennas; per-channel combining after the DDC is known future work, not a
+config option ([MRC gotchas]({{ '/reference/mrc-diversity-gotchas/' | relative_url }})).
+
+## The pre-combine A/B
+
+Every other IQ tap in the daemon —
+[`baseband.auto_record`]({{ '/blog/tutorials/analog-edge-10-capture-discipline/' | relative_url }}),
+the scope feeds — sits *downstream* of the combiner, so a capture from any of
+them has one combiner already baked in. `diversity_capture` is the one tap
+that records the branches raw, straight after de-interleave:
+
+```
+INF soapyremote: diversity capture armed — dumping pre-combine per-branch IQ prefix=../iq/mrc/precombine seconds=30 branches=2
+INF soapyremote: diversity capture complete — replay it with GT_DIVERSITY_CAPTURE to A/B combiners offline
+```
+
+You get `<prefix>.br0.cs16`, `<prefix>.br1.cs16` and a `.diversity.json`
+sidecar; a datagram that didn't carry every branch is dropped from **both**
+files, never written short, because one short write silently desynchronises
+the pair. Then grade every combiner against your own air:
+
+```sh
+GT_DIVERSITY_CAPTURE=../iq/mrc/precombine.diversity.json \
+  go test ./cmd/gophertrunk -run TestDiversityCombinerReplay -v
+```
+
+The harness prints a windowed coherence/gain/**phase** trace with plain-text
+verdicts ("branch phase is essentially CONSTANT — a frozen calibration is
+fine on this hardware" vs "branch phase WALKS"), measures the inter-branch
+delay, and decodes the capture through each branch alone plus static,
+tracking, aligned and narrowband combine arms — **scored by CRC-clean decode
+yield**, because yield is the only metric that can't flatter a combiner. If
+tracking beats static on *your* capture, you've just answered the mode
+question with evidence instead of hardware folklore.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| WARN `MRC diversity got 1 of 2 channels in the stream` | the server never delivered the second RX channel | check `args` (`rx_subdev_spec`), that the device really has two RX channels, and that the server accepted a 2-channel stream |
+| WARN `MRC diversity branch is dead — … below the reference receiver` | that antenna's connection, feedline, or per-branch gain | reseat/re-test that branch's RF path; the port assignment is `antenna:` |
+| WARN `MRC diversity branches are not coherent` | antennas on different bands/polarisation, widely separated, or the front end isn't frequency-locked | co-locate, match polarisation, check `clock_source`/`time_source`; if one `branch_dbfs` sits far below the other, fix *its* gain staging |
+| Calibrated once, then WARN `has not accepted a calibration window in 90s` | the wideband-scalar limitation — one gain can't align every carrier from separated antennas | move the antennas together, or freeze deliberately with `mrc-static` |
+| Combine decodes *worse* than one antenna alone | on current builds, almost certainly not skew (the aligner handles it) — suspect a branch dragging the estimate | run the pre-combine A/B; the arm table names the culprit |
+| Tempted to raise gain until diversity "engages" | the old absolute-power trap | don't — `coherence` is independent of RF gain; raising gain moves signal and noise together ([gain staging]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})) |
+
+That last row has history: an earlier build gated calibration on a fixed
+coherence constant, and its WARN told a bandwidth-diluted operator that
+raising RF gain would *not* help — which in their regime was exactly wrong
+(their weak branch needed +5 dB of per-branch gain). The gates now bound the
+estimate's phase error instead of a raw threshold, and the WARN points at
+per-branch gain staging. The lesson generalises across this whole series:
+**never trust an absolute-dBFS rule; trust coherence and decode yield.**
+
+## Variations
+
+- **`diversity: "mrc-static"`** — one-shot calibration, frozen. Correct for
+  shared-LO hardware (constant `branch_phase_deg`), and the standard A/B
+  reference arm on any rig.
+- **Longer evidence** — `diversity_capture_seconds` accepts up to 120 s (a
+  1 GiB/branch cap always applies). At 200–250 kS/s two CS16 branches are only
+  ~1.6 MB/s total, so take the long capture.
+- **Single-channel, port-pinned** — `diversity: ""` with `antenna: [RX2]` is
+  the same radio as a plain remote SDR but with the port explicit and
+  validated; useful for the "each branch alone" baseline before you commit.
+- **Voice under diversity** — the combined stream is an ordinary tuner to the
+  rest of the daemon, so `role: wideband` with `voice_taps` on top of it works
+  exactly as in [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}).
+
+## Where this goes next
+
+The rig now has every piece of hardware this series will ask you to buy. What
+it doesn't have yet is *names* — every talkgroup, radio and site is still a
+number. [Part 13]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }})
+is the zero-hardware recipe: alias CSVs with their real column formats, naming
+things live from the browser, and exporting the result back to files you own.
+
+## FAQ
+
+**Do I need a diversity setup for a scanner rig?**
+Almost certainly not first. Diversity is the only lever that costs serious
+hardware, and it addresses one specific regime: a signal that *fades* at your
+location. A better antenna, low-loss feedline and correct gain staging buy
+more decode margin per dollar; build this when those are done and a marginal
+system still swings.
+
+**Should I use mrc or mrc-static?**
+Let `branch_phase_deg` answer: run `mrc`, watch the health line for a few
+minutes. If the phase sits constant, your hardware is shared-LO class and
+`mrc-static` is equivalent and simpler. If it walks — TwinRX-style independent
+PLLs — stay on `mrc`, because a frozen constant decays over minutes.
+
+**Can I do diversity with two RTL-SDR dongles?**
+No. The combine needs two RX channels behind one clock in one sample stream —
+`diversity: mrc` opens RX0+RX1 on a single SoapyRemote device. Two separate
+dongles have independent oscillators and independent USB timelines; there is
+no constant phase or delay for the calibrator to find.
+
+**Why is my coherence only 0.3 when everything decodes fine?**
+Wideband coherence is diluted by every hertz of noise-only bandwidth around
+your carrier — a clean channel occupying a small fraction of a wide capture
+reads low even when the branches agree perfectly in-channel. The lock gates
+scale with the estimation window for exactly this reason. Judge the combine by
+decode yield and the WARN lines, not by wishing the number toward 1.0.
+
+**Does MRC help against a strong interferer?**
+Not blind, no — that's interference rejection combining (IRC), and measured on
+a synthetic co-channel scene, blind IRC buys 0.0 dB (the channel estimate is
+contaminated by the interferer itself); the same code given a training
+sequence buys over 20 dB. That's why IRC exists only as an offline harness arm
+today, not a `diversity:` mode.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: The Closet Appliance — Pi, systemd & Docker]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }})
+· Next →
+[Part 13: Naming Everything — Aliases, Labels & Exports]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }})

--- a/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
+++ b/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
@@ -217,17 +217,15 @@ Default C4FM Phase 1 voice is, literally, the odd path out.
 ## The gap, measured
 
 "Noise-fragile" is not a vibe here; it is a committed CI number. The
-synthetic BER-vs-SNR sweep in `receiver/sweep_test.go` drives the **real
-receiver** on both demod paths across an injected-SNR ladder and gates the
-result against closed-form references:
+synthetic BER-vs-SNR sweep in `receiver/sweep_test.go`
+(`TestSweepImplementationLossBudget`) drives the **real receiver** on both
+demod paths across an injected-SNR ladder and gates the result against
+closed-form references:
 
-```go
-// internal/radio/p25/phase1/receiver/sweep_test.go (shape) — sweepGates
-// CQPSK lands ~3.85 dB off coherent QPSK at 1% SER;
-// C4FM ~23.8 dB off coherent 4-PAM. Budgets add ~2–3 dB of margin.
-{mode: DemodCQPSK, ref: metrics.SERCoherentQPSK, targetSER: 1e-2, lossBudgetDB: 6.0},
-{mode: DemodC4FM,  ref: metrics.SER4PAM,         targetSER: 1e-2, lossBudgetDB: 27.0},
-```
+| Path | Reference curve | Measured loss @ 1% SER | Committed budget |
+|---|---|---|---|
+| CQPSK (`DemodCQPSK`) | coherent QPSK (`metrics.SERCoherentQPSK`) | ~3.85 dB | 6.0 dB |
+| C4FM (`DemodC4FM`) | coherent 4-PAM (`metrics.SER4PAM`) | ~23.8 dB | 27.0 dB |
 
 Read the two numbers together. The linear path — coherent demod, equalizer,
 Gardner timing — reaches 1% symbol errors within ~4 dB of the coherent QPSK

--- a/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
+++ b/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
@@ -67,11 +67,11 @@ what single recording unblocks them.*
 ## In this post
 
 - **The report** — a hardware Astro Spectra sets the bound.
-- **The chain, audited** — what the C4FM voice path runs and what it discards.
-- **The twin that got the equalizer** — `fse`, Phase 2, and the inverted twin thread.
-- **The gap, measured** — what the BER sweep's loss budgets actually say.
+- **The chain, audited** — what the C4FM voice path runs and discards.
+- **The twin that got the equalizer** — `fse`, Phase 2, the inverted thread.
+- **The gap, measured** — what the sweep's loss budgets actually say.
 - **Why the port is parked** — proven levers, missing evidence.
-- **The instrument is waiting** — what to record and what happens next.
+- **The instrument is waiting** — what to record, and what happens next.
 
 ## The report: a hardware radio sets the bound
 
@@ -138,10 +138,9 @@ case that is not fair weather.
 
 ## The twin that got the equalizer
 
-This series' running thread is that P25 is a family of twins, and every twin
-pair is a place fixes drift apart. The weak-signal gap is that thread
-**inverted**: not a fix that missed one twin, but a capability that only ever
-landed on one.
+This series' running thread — P25 as a family of twins, each pair a place
+fixes drift apart — arrives here **inverted**: not a fix that missed one
+twin, but a capability that only ever landed on one.
 
 [Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})
 covered the linear path in full: the opt-in `DemodCQPSK` receiver carries a

--- a/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
+++ b/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
@@ -1,0 +1,351 @@
+---
+title: "P25 End to End, Part 12: The Weak-Signal Gap — P1 Voice's Missing Levers"
+description: Why P25 Phase 1 C4FM voice is GopherTrunk's least-equipped decode path — an FM-discriminator chain with no channel equalizer and hard-decision IMBE FEC, a measured ~24 dB gap to the coherent reference, and the weak-signal voice capture that gates the fix.
+category: deep-dives
+keywords: p25 weak signal decode, c4fm equalizer missing, p25 phase 1 voice decode, imbe hard decision fec, fm discriminator weak signal, p25 voice capture contribution, soft decision p25 tsbk, p25 marginal call frames, gophertrunk p25
+tags: [p25-end-to-end, p25, c4fm, weak-signal, imbe, equalizer, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 12
+---
+
+*Part 12 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice.
+[Part 11]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }})
+watched a whole system through one wide capture and met the twin pair — the
+wideband `DDCBank` versus the single-channel `Downconverter` — that let a fix
+land on one side and miss the other. This part is the one the opener promised:
+the honest inventory. On a marginal Phase 1 voice call, a hardware radio decodes
+clean audio while GopherTrunk recovers a handful of frames — and we know
+exactly which two stages are missing, why they haven't been built, and what
+single recording unblocks them.*
+
+> **TL;DR:** The default P25 Phase 1 **C4FM voice receiver**
+> (`internal/radio/p25/phase1/receiver/receiver.go`) is FM discriminator → spec
+> matched filter → `CoarseAFC` → Mueller-Müller timing → symbol AGC → 4-level
+> slicer → **hard** Golay/Hamming IMBE FEC — no channel equalizer, no
+> soft-decision voice FEC. The synthetic sweep
+> (`TestSweepImplementationLossBudget`) puts a number on the fragility: at 1%
+> symbol-error rate the C4FM path needs **~23.8 dB more Es/N0 than the coherent
+> 4-PAM reference**, while the CQPSK twin — which carries a T/2 blind equalizer
+> (the `fse` field in `cqpsk.go`) — sits ~3.85 dB off coherent QPSK. The two
+> missing levers are the same pair that roughly
+> [doubled TETRA's marginal yield]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }}).
+> The port is gated on a real weak C4FM **voice** capture;
+> `samples/p25/README.md` and `TestReplayP25RealCaptureMetrics` are the
+> baseline instrument waiting for it.
+
+**Key takeaways**
+
+- **The gap is structural, and it is measured.** Every stage of the C4FM voice
+  chain works as designed; the chain simply lacks the equalization and
+  soft-FEC stages the marginal regime demands, and the BER sweep quantifies
+  the headroom at roughly 20 dB against a reference the CQPSK path tracks
+  within 4 dB.
+- **This is the twin-path thread inverted.** Usually a fix lands on one twin
+  and misses the other; here a *capability* — the blind equalizer — was only
+  ever built on the CQPSK/LSM twin and on Phase 2, leaving default C4FM voice
+  the odd path out.
+- **The soft machinery is half-installed.** The C4FM receiver already emits
+  two log-likelihood ratios per dibit (`BitLLRSink`) and the control channel
+  consumes them for soft TSBK decode — but the IMBE Golay/Hamming decoders
+  never see a soft bit.
+- **No fix without a capture.** A green synthetic is not proof of an on-air
+  fix — the #764/#771 lesson this series keeps meeting. The highest-leverage
+  contribution to GopherTrunk's P25 support right now is a recording, not a
+  patch.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| C4FM voice chain (all hard) | discriminator → MF → AFC → M&M → AGC → slicer | `internal/radio/p25/phase1/receiver/receiver.go` (`DemodC4FM` branch) |
+| The equalizer next door | T/2 fractionally-spaced blind CMA on the linear path | `internal/radio/p25/phase1/receiver/cqpsk.go` (`fse *equalizer.FSE`) |
+| Soft plumbing, half-installed | per-dibit LLRs feed soft TSBKs, not IMBE | `receiver.go` (`BitLLRSink`) → `control.go` (`StashSoft`) |
+| Measured fragility | C4FM ~23.8 dB off coherent 4-PAM at 1% SER | `receiver/sweep_test.go` (`TestSweepImplementationLossBudget`) |
+| Baseline instrument | EVM / SNR / FSW-margin / NID / TSBK from a real capture | `cmd/gophertrunk/p25_realcapture_metrics_test.go` |
+| The ask | a weak C4FM voice `.cfile` + metadata sidecar | `samples/p25/README.md` (weak-signal voice section) |
+
+## In this post
+
+- **The report** — a hardware Astro Spectra sets the bound.
+- **The chain, audited** — what the C4FM voice path runs and what it discards.
+- **The twin that got the equalizer** — `fse`, Phase 2, and the inverted twin thread.
+- **The gap, measured** — what the BER sweep's loss budgets actually say.
+- **Why the port is parked** — proven levers, missing evidence.
+- **The instrument is waiting** — what to record and what happens next.
+
+## The report: a hardware radio sets the bound
+
+The report that defines this part is a controlled experiment an operator ran
+without meaning to. A marginal P25 Phase 1 voice call — fringe coverage, real
+terrain — decodes cleanly on a hardware **Astro Spectra**. The same call, on
+the same antenna, through GopherTrunk: about **4–5 IMBE frames** recovered
+from a whole transmission. Not silence, and not a failure to lock — a lock
+that extracts almost nothing, which is the signature of the
+[marginal regime]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
+in its purest form.
+
+The hardware radio matters because it bounds the problem: the information
+survived the antenna, so whatever is lost is lost after the ADC. There is a
+telling brush in the numbers, too — an LDU carries 9 IMBE frames in 180 ms,
+so 4–5 frames is under one LDU, well short of the `minAutotuneLDUs = 5`
+threshold in `internal/voice/composer/p25p1_voice.go` that skips the autotune
+measurement for calls too short or noisy to trust. The guard is correct; that
+real calls keep tripping it is the indictment.
+
+Commercial subscriber radios earn their weak-signal margin with exactly two
+tools: adaptive equalization and soft-decision error correction. So the first
+question is an audit — which of those does the default C4FM voice path run?
+
+## The chain, audited
+
+The receiver's own doc comment is the inventory:
+
+```go
+// internal/radio/p25/phase1/receiver/receiver.go (shape) — the C4FM branch
+//	DemodC4FM (default):
+//	  IQ
+//	    → FM discriminator (internal/dsp/demod.FM)
+//	    → spec P25 C4FM matched filter (demod.P25C4FMRxTaps — not RRC)
+//	    → coarse AFC: residual carrier-offset removal (demod.CoarseAFC)
+//	    → Mueller-Müller symbol clock recovery (sync.MuellerMuller)
+//	    → 4-level slicer → C4FM symbol → 0..3 dibit
+```
+
+Downstream, the LDU voice path
+([Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }}))
+runs `ExtractVoiceFrames` — hard
+[Golay]({{ '/reference/golay-code/' | relative_url }}) and
+[Hamming]({{ '/reference/hamming-code/' | relative_url }}) decoding of each
+IMBE subframe. Audit that against the marginal regime:
+
+- **No equalizer, anywhere on the C4FM path.** Between timing recovery and
+  the slicer there is no stage that inverts inter-symbol interference. A
+  multipath-smeared 4-level eye goes into symbol decisions smeared.
+- **A hard slicer feeding hard FEC.** The slicer collapses each symbol to a
+  dibit and throws away its distance from the thresholds — the exact
+  confidence a soft FEC would spend. The Golay/Hamming decoders then defend
+  a coin-flip bit as firmly as a certain one.
+- **The soft machinery exists — for the control channel.** Here is the
+  wrinkle the summary version misses: the C4FM receiver *already* derives two
+  log-likelihood ratios per dibit (`Options.BitLLRSink` — sign-axis distance
+  for the high bit, inner/outer-threshold distance for the low), and the
+  control channel's `StashSoft` path spends them on a per-bit soft Viterbi
+  for TSBKs, behind the `p25_phase1_soft_decision` config key. The plumbing
+  runs right past the voice path. IMBE's Golay and Hamming decoders take hard
+  bits, full stop.
+
+Nothing in that list is a bug. It is a fair-weather design — a clean
+implementation of the classical C4FM receiver, built for viable signals —
+meeting a use case that is not fair weather.
+
+## The twin that got the equalizer
+
+This series' running thread is that P25 is a family of twins, and every twin
+pair is a place fixes drift apart. The weak-signal gap is that thread
+**inverted**: not a fix that missed one twin, but a capability that only ever
+landed on one.
+
+[Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }})
+covered the linear path in full: the opt-in `DemodCQPSK` receiver carries a
+**T/2 fractionally-spaced blind equalizer**, and its configuration is worth
+re-reading with this part's eyes:
+
+```go
+// internal/radio/p25/phase1/receiver/cqpsk.go (shape)
+const (
+    cqpskFSESymbolSpan = 6     // 12 T/2 taps, centre tap on-time
+    cqpskFSEStep       = 0.025 // brisk CMA step — short captures must converge
+    cqpskFSELeak       = 5e-4  // pulls taps toward identity on clean input
+)
+/* … */
+fse: equalizer.NewFSE(cqpskFSESymbolSpan, cqpskFSEStep, 1.0, cqpskFSELeak),
+```
+
+The comments above those constants record why fractional spacing matters: a
+T/2 equalizer synthesizes the receive matched filter implicitly, so it opens
+both simulcast multipath ISI *and* pulse-shape mismatch — things a
+symbol-spaced equalizer cannot (issue #492's territory,
+[four acts of it]({{ '/blog/solution-postmortem/from-the-issue-tracker-06-cqpsk-four-acts/' | relative_url }})).
+P25 Phase 2 wires an equalizer as well
+([Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})).
+Default C4FM Phase 1 voice — the path that decodes the most systems in North
+America — is, literally, the odd path out.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two decode chains compared. Top row, the P25 Phase 1 C4FM voice chain: FM discriminator, matched filter, CoarseAFC, Mueller-Muller timing with AGC, hard 4-level slicer, hard Golay and Hamming IMBE FEC — with two dashed boxes marking the missing equalizer and missing soft FEC stages. Bottom row, the TETRA voice chain for contrast: RRC matched filter, Gardner timing, snapshot CMA equalizer, differential decode, soft LLRs, and soft Viterbi with CRC — every stage solid. A note says the dashed boxes are the two levers that roughly doubled TETRA's marginal yield.">
+  <text x="10" y="24" fill="currentColor" font-size="11" font-weight="bold">P25 Phase 1 C4FM voice (default)</text>
+  <rect x="10" y="36" width="86" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="53" y="53" text-anchor="middle" fill="currentColor" font-size="9">FM</text>
+  <text x="53" y="66" text-anchor="middle" fill="currentColor" font-size="9">discriminator</text>
+  <line x1="96" y1="55" x2="108" y2="55" stroke="currentColor"/>
+  <rect x="108" y="36" width="80" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="148" y="53" text-anchor="middle" fill="currentColor" font-size="9">matched filter</text>
+  <text x="148" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">+ CoarseAFC</text>
+  <line x1="188" y1="55" x2="200" y2="55" stroke="currentColor"/>
+  <rect x="200" y="36" width="88" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="244" y="53" text-anchor="middle" fill="currentColor" font-size="9">Mueller-Müller</text>
+  <text x="244" y="66" text-anchor="middle" fill="var(--fg-muted)" font-size="8">timing + AGC</text>
+  <rect x="300" y="30" width="96" height="24" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <text x="348" y="46" text-anchor="middle" fill="var(--accent)" font-size="8">equalizer — MISSING</text>
+  <line x1="288" y1="55" x2="420" y2="55" stroke="currentColor"/>
+  <rect x="420" y="36" width="70" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="455" y="53" text-anchor="middle" fill="currentColor" font-size="9">hard 4-level</text>
+  <text x="455" y="66" text-anchor="middle" fill="currentColor" font-size="9">slicer</text>
+  <line x1="490" y1="55" x2="502" y2="55" stroke="currentColor"/>
+  <rect x="502" y="36" width="94" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="549" y="53" text-anchor="middle" fill="currentColor" font-size="9">hard Golay/</text>
+  <text x="549" y="66" text-anchor="middle" fill="currentColor" font-size="9">Hamming IMBE</text>
+  <rect x="600" y="86" width="76" height="24" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <text x="638" y="102" text-anchor="middle" fill="var(--accent)" font-size="8">soft FEC — MISSING</text>
+  <line x1="602" y1="86" x2="580" y2="74" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <line x1="348" y1="54" x2="348" y2="55" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <text x="10" y="140" fill="currentColor" font-size="11" font-weight="bold">TETRA voice (for contrast — every stage built)</text>
+  <rect x="10" y="152" width="130" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="75" y="169" text-anchor="middle" fill="currentColor" font-size="9">RRC matched filter</text>
+  <text x="75" y="182" text-anchor="middle" fill="var(--fg-muted)" font-size="8">Gardner timing + AFC</text>
+  <line x1="140" y1="171" x2="154" y2="171" stroke="currentColor"/>
+  <rect x="154" y="152" width="110" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="209" y="169" text-anchor="middle" fill="var(--accent)" font-size="9">SnapshotCMA</text>
+  <text x="209" y="182" text-anchor="middle" fill="var(--accent)" font-size="8">equalizer</text>
+  <line x1="264" y1="171" x2="278" y2="171" stroke="currentColor"/>
+  <rect x="278" y="152" width="110" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="333" y="169" text-anchor="middle" fill="currentColor" font-size="9">differential decode</text>
+  <line x1="388" y1="171" x2="402" y2="171" stroke="currentColor"/>
+  <rect x="402" y="152" width="194" height="38" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="499" y="169" text-anchor="middle" fill="var(--accent)" font-size="9">soft LLRs → soft Viterbi → CRC</text>
+  <text x="340" y="226" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the two dashed boxes are the levers that roughly doubled TETRA's marginal yield —</text>
+  <text x="340" y="240" text-anchor="middle" fill="var(--fg-muted)" font-size="10">proven in this codebase, absent from this path</text>
+</svg>
+<figcaption>Side by side: the C4FM voice chain versus the TETRA voice chain. Every solid block on the P25 row works; the two dashed blocks are the diagnosis — and both already exist elsewhere in the tree.</figcaption>
+</figure>
+
+## The gap, measured
+
+"Noise-fragile" is not a vibe here; it is a committed CI number. The
+synthetic BER-vs-SNR sweep in `receiver/sweep_test.go` drives the **real
+receiver** on both demod paths across an injected-SNR ladder and gates the
+result against closed-form references:
+
+```go
+// internal/radio/p25/phase1/receiver/sweep_test.go (shape) — sweepGates
+// CQPSK lands ~3.85 dB off coherent QPSK at 1% SER;
+// C4FM ~23.8 dB off coherent 4-PAM. Budgets add ~2–3 dB of margin.
+{mode: DemodCQPSK, ref: metrics.SERCoherentQPSK, targetSER: 1e-2, lossBudgetDB: 6.0},
+{mode: DemodC4FM,  ref: metrics.SER4PAM,         targetSER: 1e-2, lossBudgetDB: 27.0},
+```
+
+Read the two numbers together. The linear path — coherent demod, equalizer,
+Gardner timing — reaches 1% symbol errors within ~4 dB of the coherent QPSK
+bound. The C4FM discriminator path needs ~24 dB more Es/N0 than coherent
+4-PAM. The honest caveat is in the test's own comment: coherent 4-PAM is a
+bound no FM discriminator reaches, and the budget "is a *regression ceiling*
+… NOT a claim that the gap is small" — part physics of non-coherent
+detection, part timing-slip behaviour the measurement folds in. But the
+ceiling stops the path silently getting worse, and it quantifies the headroom
+that justifies demod work. Twenty-plus dB of headroom is why a subscriber
+radio and GopherTrunk disagree so completely about the same marginal call.
+
+## Why the port is parked
+
+Both missing stages are proven technology *in this codebase*. The blind
+snapshot equalizer and soft-decision decoding
+([Weak-Signal Engineering Parts 4]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
+[and 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }}))
+roughly **doubled** TETRA's CRC-valid voice yield across six operator
+captures — 410 → 778 soft-decision TCH/S, with single calls going 4 → 207 —
+and the soft path recovered the ~70% of a marginal call's bursts the hard
+gate dropped. The physics doesn't care which trunking protocol rides on top.
+
+So why not port it this afternoon? Because the project has been burned,
+twice, by exactly that move. Issue
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was closed
+twice on fixes that were green against synthetic fixtures while the live
+symptom persisted (issue #771 is the receipt) — a synthetic channel exercises
+the impairments you *imagined*, and the operator's terrain exercises the ones
+you didn't. The rule that came out of it is the standing gate: a fix for a
+weak-signal symptom lands only with a baseline on a real capture and an A/B
+where **decode yield is the verdict** — never EVM, which
+[has lied to this project before]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }}).
+The sibling series has a full post on this exact path from the method's side
+([The Odd Path Out]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }}));
+this series adds the protocol context: it is the last unequipped twin.
+
+## The instrument is waiting
+
+Everything buildable without the capture is built.
+`TestReplayP25RealCaptureMetrics`
+(`cmd/gophertrunk/p25_realcapture_metrics_test.go`, tag `integration`)
+replays any `.cfile` dropped into `samples/p25/` through the production
+receiver and reports pre-FEC EVM, estimated SNR, the FSW sync-margin
+distribution, and NID/TSBK yields — with every bound in the metadata sidecar
+optional, so a capture can be measured before anyone commits to a pass/fail
+threshold. The pipeline is validated end to end: a live UHF C4FM
+control-channel capture (449.875 MHz, NAC 0x2C1) grades at EVM ≈ 12.7%,
+SNR ≈ 14.5 dB, NID trusted 31 / failed 0, TSBK decoded 36 / CRC-failed 0.
+
+What's missing is the **voice** capture. `samples/p25/README.md` spells out
+the ask: tune the *granted voice frequency* during a call that is genuinely
+weak or multipath-degraded — a strong, clean call cannot exercise a missing
+equalizer — note the hardware radio's contemporaneous decode in
+`tool_cross_check`, and drop the `.cfile` + `.metadata.json` pair in (the
+binary stays git-ignored; the sidecar is committed). From there the sequence
+is mechanical: baseline, port one lever — the capture's own numbers decide
+whether ISI says equalizer-first or a clean eye with FEC failures says
+soft-first — and A/B the LDU/IMBE yield.
+
+## Where this goes next
+
+A series that leans this hard on "the test that passes because both sides
+share the same bug" owes you the full testing story.
+[Part 13]({{ '/blog/deep-dives/p25-end-to-end-13-testing-p25/' | relative_url }})
+climbs the whole pyramid — literal byte vectors, impairment-swept synthetic
+streams, committed captures, and the on-air verification nothing below it can
+replace — using P25's own bugs as the case studies.
+
+## FAQ
+
+**Why can a hardware scanner decode a P25 call GopherTrunk can't?**
+Because commercial subscriber hardware ships the two stages this path lacks:
+adaptive equalization ahead of the symbol decisions and soft-decision error
+correction behind them. On clean signals the difference is invisible; in the
+marginal regime those stages are worth many dB of effective sensitivity —
+consistent with the measured ~24 dB regression ceiling on the C4FM sweep.
+
+**Is the P25 control channel affected the same way?**
+Less so. The control channel can already opt into per-bit soft TSBK decode
+(`p25_phase1_soft_decision`), fed by the same `BitLLRSink` LLRs the voice
+path ignores — and TSBKs repeat, so a missed block usually costs nothing. The
+gap that produces operator-visible symptoms is voice: IMBE frames don't
+repeat, and every hard-FEC failure is 20 ms of audio gone.
+
+**Couldn't I just run the CQPSK receiver on the weak C4FM site?**
+No. The equalizer lives on a *linear* demod chain that expects an LSM-style
+phase trajectory; the modulation on air is C4FM, and the two paths are not
+interchangeable (the
+[LSM myth postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }})
+covers why, and issue #935 covers when each applies). The equalizer has to
+come to the C4FM chain, not the signal to the equalizer.
+
+**What exactly should I record to help?**
+A P25 Phase 1 C4FM **voice-channel** IQ recording of a marginal call — the
+granted frequency, not the control channel — as a `.cfile` at ≥ 48 kHz, with
+a metadata sidecar per `samples/p25/README.md`, ideally noting what a
+hardware radio made of the same call. That one file converts a diagnosed,
+scoped, parked fix into a measurable A/B.
+
+**Does the 23.8 dB figure mean the C4FM demod is broken?**
+No — it means the reference is coherent and the demod is not, plus real
+implementation loss on top. The number's job is to be a ceiling (the gate
+fails if the path regresses past 27 dB) and a motivator: it is the measured
+size of the pool the equalizer and soft FEC would fish in.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: Wideband P25 — Watching the Whole System at Once]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }})
+· Next →
+[Part 13: Testing P25 Without a Tower]({{ '/blog/deep-dives/p25-end-to-end-13-testing-p25/' | relative_url }})

--- a/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
+++ b/docs/_posts/2026-09-14-p25-end-to-end-12-weak-signal-gap.md
@@ -14,13 +14,12 @@ series_part: 12
 dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
 recorded, named, multi-site voice.
 [Part 11]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }})
-watched a whole system through one wide capture and met the twin pair — the
-wideband `DDCBank` versus the single-channel `Downconverter` — that let a fix
-land on one side and miss the other. This part is the one the opener promised:
-the honest inventory. On a marginal Phase 1 voice call, a hardware radio decodes
-clean audio while GopherTrunk recovers a handful of frames — and we know
-exactly which two stages are missing, why they haven't been built, and what
-single recording unblocks them.*
+watched a whole system through one wide capture and met the twin pair that let
+a fix land on one side and miss the other. This part is the one the opener
+promised: the honest inventory. On a marginal Phase 1 voice call, a hardware
+radio decodes clean audio while GopherTrunk recovers a handful of frames — and
+we know exactly which two stages are missing, why they haven't been built, and
+what single recording unblocks them.*
 
 > **TL;DR:** The default P25 Phase 1 **C4FM voice receiver**
 > (`internal/radio/p25/phase1/receiver/receiver.go`) is FM discriminator → spec
@@ -28,34 +27,31 @@ single recording unblocks them.*
 > slicer → **hard** Golay/Hamming IMBE FEC — no channel equalizer, no
 > soft-decision voice FEC. The synthetic sweep
 > (`TestSweepImplementationLossBudget`) puts a number on the fragility: at 1%
-> symbol-error rate the C4FM path needs **~23.8 dB more Es/N0 than the coherent
-> 4-PAM reference**, while the CQPSK twin — which carries a T/2 blind equalizer
-> (the `fse` field in `cqpsk.go`) — sits ~3.85 dB off coherent QPSK. The two
-> missing levers are the same pair that roughly
-> [doubled TETRA's marginal yield]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }}).
-> The port is gated on a real weak C4FM **voice** capture;
-> `samples/p25/README.md` and `TestReplayP25RealCaptureMetrics` are the
-> baseline instrument waiting for it.
+> symbol-error rate the C4FM path needs **~23.8 dB more Es/N0 than the
+> coherent 4-PAM reference**, while the CQPSK twin — which carries a T/2 blind
+> equalizer (the `fse` field in `cqpsk.go`) — sits ~3.85 dB off coherent QPSK.
+> The missing levers are the pair that roughly
+> [doubled TETRA's marginal yield]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }});
+> the port is gated on a real weak C4FM **voice** capture, and
+> `samples/p25/README.md` + `TestReplayP25RealCaptureMetrics` are the baseline
+> instrument waiting for it.
 
 **Key takeaways**
 
-- **The gap is structural, and it is measured.** Every stage of the C4FM voice
-  chain works as designed; the chain simply lacks the equalization and
+- **The gap is structural, and it is measured.** Every stage of the C4FM
+  voice chain works as designed; it simply lacks the equalization and
   soft-FEC stages the marginal regime demands, and the BER sweep quantifies
-  the headroom at roughly 20 dB against a reference the CQPSK path tracks
-  within 4 dB.
+  the headroom against a reference the CQPSK path tracks within 4 dB.
 - **This is the twin-path thread inverted.** Usually a fix lands on one twin
   and misses the other; here a *capability* — the blind equalizer — was only
-  ever built on the CQPSK/LSM twin and on Phase 2, leaving default C4FM voice
-  the odd path out.
+  ever built on the CQPSK/LSM twin and on Phase 2.
 - **The soft machinery is half-installed.** The C4FM receiver already emits
   two log-likelihood ratios per dibit (`BitLLRSink`) and the control channel
-  consumes them for soft TSBK decode — but the IMBE Golay/Hamming decoders
-  never see a soft bit.
+  spends them on soft TSBK decode — but the IMBE Golay/Hamming decoders never
+  see a soft bit.
 - **No fix without a capture.** A green synthetic is not proof of an on-air
-  fix — the #764/#771 lesson this series keeps meeting. The highest-leverage
-  contribution to GopherTrunk's P25 support right now is a recording, not a
-  patch.
+  fix — the #764/#771 lesson. The highest-leverage contribution to
+  GopherTrunk's P25 support right now is a recording, not a patch.
 
 ## Cheat sheet
 
@@ -80,11 +76,11 @@ single recording unblocks them.*
 ## The report: a hardware radio sets the bound
 
 The report that defines this part is a controlled experiment an operator ran
-without meaning to. A marginal P25 Phase 1 voice call — fringe coverage, real
-terrain — decodes cleanly on a hardware **Astro Spectra**. The same call, on
-the same antenna, through GopherTrunk: about **4–5 IMBE frames** recovered
-from a whole transmission. Not silence, and not a failure to lock — a lock
-that extracts almost nothing, which is the signature of the
+without meaning to. A marginal P25 Phase 1 voice call decodes cleanly on a
+hardware **Astro Spectra**; the same call, on the same antenna, through
+GopherTrunk yields about **4–5 IMBE frames** from a whole transmission. Not
+silence, and not a failure to lock — a lock that extracts almost nothing, the
+signature of the
 [marginal regime]({{ '/blog/deep-dives/weak-signal-engineering-01-marginal-regime/' | relative_url }})
 in its purest form.
 
@@ -96,9 +92,9 @@ threshold in `internal/voice/composer/p25p1_voice.go` that skips the autotune
 measurement for calls too short or noisy to trust. The guard is correct; that
 real calls keep tripping it is the indictment.
 
-Commercial subscriber radios earn their weak-signal margin with exactly two
-tools: adaptive equalization and soft-decision error correction. So the first
-question is an audit — which of those does the default C4FM voice path run?
+Commercial subscriber radios earn their weak-signal margin with two tools:
+adaptive equalization and soft-decision error correction. Which does the
+default C4FM voice path run?
 
 ## The chain, audited
 
@@ -117,30 +113,28 @@ The receiver's own doc comment is the inventory:
 
 Downstream, the LDU voice path
 ([Part 8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }}))
-runs `ExtractVoiceFrames` — hard
+runs `ExtractVoiceFrames`: hard
 [Golay]({{ '/reference/golay-code/' | relative_url }}) and
-[Hamming]({{ '/reference/hamming-code/' | relative_url }}) decoding of each
-IMBE subframe. Audit that against the marginal regime:
+[Hamming]({{ '/reference/hamming-code/' | relative_url }}) decoding per IMBE
+subframe. Audited against the marginal regime:
 
-- **No equalizer, anywhere on the C4FM path.** Between timing recovery and
-  the slicer there is no stage that inverts inter-symbol interference. A
+- **No equalizer, anywhere on the C4FM path.** No stage between timing
+  recovery and the slicer inverts inter-symbol interference; a
   multipath-smeared 4-level eye goes into symbol decisions smeared.
 - **A hard slicer feeding hard FEC.** The slicer collapses each symbol to a
-  dibit and throws away its distance from the thresholds — the exact
-  confidence a soft FEC would spend. The Golay/Hamming decoders then defend
-  a coin-flip bit as firmly as a certain one.
-- **The soft machinery exists — for the control channel.** Here is the
-  wrinkle the summary version misses: the C4FM receiver *already* derives two
-  log-likelihood ratios per dibit (`Options.BitLLRSink` — sign-axis distance
-  for the high bit, inner/outer-threshold distance for the low), and the
-  control channel's `StashSoft` path spends them on a per-bit soft Viterbi
-  for TSBKs, behind the `p25_phase1_soft_decision` config key. The plumbing
-  runs right past the voice path. IMBE's Golay and Hamming decoders take hard
-  bits, full stop.
+  dibit and throws away its distance from the thresholds — the confidence a
+  soft FEC would spend. Golay/Hamming then defend a coin-flip bit as firmly
+  as a certain one.
+- **The soft machinery exists — for the control channel.** The C4FM receiver
+  *already* derives two log-likelihood ratios per dibit (`Options.BitLLRSink`
+  — sign-axis distance for the high bit, inner/outer-threshold distance for
+  the low), and the control channel's `StashSoft` path spends them on a
+  per-bit soft TSBK Viterbi behind the `p25_phase1_soft_decision` config key.
+  The plumbing runs right past the voice path: IMBE's Golay and Hamming
+  decoders take hard bits, full stop.
 
-Nothing in that list is a bug. It is a fair-weather design — a clean
-implementation of the classical C4FM receiver, built for viable signals —
-meeting a use case that is not fair weather.
+Nothing in that list is a bug. It is a fair-weather design meeting a use
+case that is not fair weather.
 
 ## The twin that got the equalizer
 
@@ -166,14 +160,13 @@ fse: equalizer.NewFSE(cqpskFSESymbolSpan, cqpskFSEStep, 1.0, cqpskFSELeak),
 ```
 
 The comments above those constants record why fractional spacing matters: a
-T/2 equalizer synthesizes the receive matched filter implicitly, so it opens
-both simulcast multipath ISI *and* pulse-shape mismatch — things a
-symbol-spaced equalizer cannot (issue #492's territory,
-[four acts of it]({{ '/blog/solution-postmortem/from-the-issue-tracker-06-cqpsk-four-acts/' | relative_url }})).
+T/2 equalizer synthesizes the receive matched filter implicitly, opening both
+simulcast multipath ISI *and* pulse-shape mismatch — things a symbol-spaced
+equalizer cannot (issue #492,
+[told in four acts]({{ '/blog/solution-postmortem/from-the-issue-tracker-06-cqpsk-four-acts/' | relative_url }})).
 P25 Phase 2 wires an equalizer as well
 ([Part 7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }})).
-Default C4FM Phase 1 voice — the path that decodes the most systems in North
-America — is, literally, the odd path out.
+Default C4FM Phase 1 voice is, literally, the odd path out.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="Two decode chains compared. Top row, the P25 Phase 1 C4FM voice chain: FM discriminator, matched filter, CoarseAFC, Mueller-Muller timing with AGC, hard 4-level slicer, hard Golay and Hamming IMBE FEC — with two dashed boxes marking the missing equalizer and missing soft FEC stages. Bottom row, the TETRA voice chain for contrast: RRC matched filter, Gardner timing, snapshot CMA equalizer, differential decode, soft LLRs, and soft Viterbi with CRC — every stage solid. A note says the dashed boxes are the two levers that roughly doubled TETRA's marginal yield.">
@@ -192,17 +185,16 @@ America — is, literally, the odd path out.
   <rect x="300" y="30" width="96" height="24" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
   <text x="348" y="46" text-anchor="middle" fill="var(--accent)" font-size="8">equalizer — MISSING</text>
   <line x1="288" y1="55" x2="420" y2="55" stroke="currentColor"/>
-  <rect x="420" y="36" width="70" height="38" rx="6" fill="none" stroke="currentColor"/>
-  <text x="455" y="53" text-anchor="middle" fill="currentColor" font-size="9">hard 4-level</text>
-  <text x="455" y="66" text-anchor="middle" fill="currentColor" font-size="9">slicer</text>
-  <line x1="490" y1="55" x2="502" y2="55" stroke="currentColor"/>
-  <rect x="502" y="36" width="94" height="38" rx="6" fill="none" stroke="currentColor"/>
-  <text x="549" y="53" text-anchor="middle" fill="currentColor" font-size="9">hard Golay/</text>
-  <text x="549" y="66" text-anchor="middle" fill="currentColor" font-size="9">Hamming IMBE</text>
-  <rect x="600" y="86" width="76" height="24" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
-  <text x="638" y="102" text-anchor="middle" fill="var(--accent)" font-size="8">soft FEC — MISSING</text>
-  <line x1="602" y1="86" x2="580" y2="74" stroke="var(--accent)" stroke-dasharray="3 3"/>
-  <line x1="348" y1="54" x2="348" y2="55" stroke="var(--accent)" stroke-dasharray="3 3"/>
+  <rect x="420" y="36" width="80" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="460" y="53" text-anchor="middle" fill="currentColor" font-size="9">hard 4-level</text>
+  <text x="460" y="66" text-anchor="middle" fill="currentColor" font-size="9">slicer</text>
+  <line x1="500" y1="55" x2="512" y2="55" stroke="currentColor"/>
+  <rect x="512" y="36" width="100" height="38" rx="6" fill="none" stroke="currentColor"/>
+  <text x="562" y="53" text-anchor="middle" fill="currentColor" font-size="9">hard Golay/</text>
+  <text x="562" y="66" text-anchor="middle" fill="currentColor" font-size="9">Hamming IMBE</text>
+  <rect x="560" y="86" width="110" height="24" rx="6" fill="none" stroke="var(--accent)" stroke-dasharray="5 4"/>
+  <text x="615" y="102" text-anchor="middle" fill="var(--accent)" font-size="8">soft FEC — MISSING</text>
+  <line x1="588" y1="86" x2="575" y2="74" stroke="var(--accent)" stroke-dasharray="3 3"/>
   <text x="10" y="140" fill="currentColor" font-size="11" font-weight="bold">TETRA voice (for contrast — every stage built)</text>
   <rect x="10" y="152" width="130" height="38" rx="6" fill="none" stroke="currentColor"/>
   <text x="75" y="169" text-anchor="middle" fill="currentColor" font-size="9">RRC matched filter</text>
@@ -256,21 +248,21 @@ snapshot equalizer and soft-decision decoding
 ([Weak-Signal Engineering Parts 4]({{ '/blog/deep-dives/weak-signal-engineering-04-blind-cma/' | relative_url }})
 [and 8]({{ '/blog/deep-dives/weak-signal-engineering-08-soft-decisions/' | relative_url }}))
 roughly **doubled** TETRA's CRC-valid voice yield across six operator
-captures — 410 → 778 soft-decision TCH/S, with single calls going 4 → 207 —
-and the soft path recovered the ~70% of a marginal call's bursts the hard
-gate dropped. The physics doesn't care which trunking protocol rides on top.
+captures (410 → 778 soft-decision TCH/S, one call going 4 → 207), and the
+soft path recovered the ~70% of a marginal call's bursts the hard gate
+dropped. The physics doesn't care which trunking protocol rides on top.
 
 So why not port it this afternoon? Because the project has been burned,
-twice, by exactly that move. Issue
+twice, by exactly that move: issue
 [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was closed
 twice on fixes that were green against synthetic fixtures while the live
-symptom persisted (issue #771 is the receipt) — a synthetic channel exercises
-the impairments you *imagined*, and the operator's terrain exercises the ones
-you didn't. The rule that came out of it is the standing gate: a fix for a
-weak-signal symptom lands only with a baseline on a real capture and an A/B
-where **decode yield is the verdict** — never EVM, which
+symptom persisted (issue #771 is the receipt). A synthetic channel exercises
+the impairments you *imagined*; the operator's terrain exercises the ones you
+didn't. The standing gate that came out of it: a weak-signal fix lands only
+with a baseline on a real capture and an A/B where **decode yield is the
+verdict** — never EVM, which
 [has lied to this project before]({{ '/blog/deep-dives/weak-signal-engineering-02-metrics-that-lie/' | relative_url }}).
-The sibling series has a full post on this exact path from the method's side
+The sibling series covers this path from the method's side
 ([The Odd Path Out]({{ '/blog/deep-dives/weak-signal-engineering-13-p25-c4fm-gap/' | relative_url }}));
 this series adds the protocol context: it is the last unequipped twin.
 
@@ -281,11 +273,11 @@ Everything buildable without the capture is built.
 (`cmd/gophertrunk/p25_realcapture_metrics_test.go`, tag `integration`)
 replays any `.cfile` dropped into `samples/p25/` through the production
 receiver and reports pre-FEC EVM, estimated SNR, the FSW sync-margin
-distribution, and NID/TSBK yields — with every bound in the metadata sidecar
-optional, so a capture can be measured before anyone commits to a pass/fail
-threshold. The pipeline is validated end to end: a live UHF C4FM
-control-channel capture (449.875 MHz, NAC 0x2C1) grades at EVM ≈ 12.7%,
-SNR ≈ 14.5 dB, NID trusted 31 / failed 0, TSBK decoded 36 / CRC-failed 0.
+distribution, and NID/TSBK yields — every metadata bound optional, so a
+capture can be measured before anyone commits to a pass/fail threshold. The
+pipeline is validated end to end: a live UHF C4FM control-channel capture
+(449.875 MHz, NAC 0x2C1) grades at EVM ≈ 12.7%, SNR ≈ 14.5 dB, NID trusted
+31 / failed 0, TSBK decoded 36 / CRC-failed 0.
 
 What's missing is the **voice** capture. `samples/p25/README.md` spells out
 the ask: tune the *granted voice frequency* during a call that is genuinely
@@ -303,8 +295,8 @@ A series that leans this hard on "the test that passes because both sides
 share the same bug" owes you the full testing story.
 [Part 13]({{ '/blog/deep-dives/p25-end-to-end-13-testing-p25/' | relative_url }})
 climbs the whole pyramid — literal byte vectors, impairment-swept synthetic
-streams, committed captures, and the on-air verification nothing below it can
-replace — using P25's own bugs as the case studies.
+streams, committed captures, on-air verification — using P25's own bugs as
+the case studies.
 
 ## FAQ
 
@@ -312,36 +304,34 @@ replace — using P25's own bugs as the case studies.
 Because commercial subscriber hardware ships the two stages this path lacks:
 adaptive equalization ahead of the symbol decisions and soft-decision error
 correction behind them. On clean signals the difference is invisible; in the
-marginal regime those stages are worth many dB of effective sensitivity —
-consistent with the measured ~24 dB regression ceiling on the C4FM sweep.
+marginal regime those stages are worth many dB of effective sensitivity.
 
 **Is the P25 control channel affected the same way?**
-Less so. The control channel can already opt into per-bit soft TSBK decode
+Less so. The control channel can opt into per-bit soft TSBK decode
 (`p25_phase1_soft_decision`), fed by the same `BitLLRSink` LLRs the voice
-path ignores — and TSBKs repeat, so a missed block usually costs nothing. The
-gap that produces operator-visible symptoms is voice: IMBE frames don't
-repeat, and every hard-FEC failure is 20 ms of audio gone.
+path ignores — and TSBKs repeat, so a missed block usually costs nothing.
+IMBE frames don't repeat: every hard-FEC failure is 20 ms of audio gone,
+which is why the operator-visible gap is voice.
 
 **Couldn't I just run the CQPSK receiver on the weak C4FM site?**
 No. The equalizer lives on a *linear* demod chain that expects an LSM-style
-phase trajectory; the modulation on air is C4FM, and the two paths are not
-interchangeable (the
+phase trajectory, and the two paths are not interchangeable (the
 [LSM myth postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-07-lsm-myth/' | relative_url }})
-covers why, and issue #935 covers when each applies). The equalizer has to
-come to the C4FM chain, not the signal to the equalizer.
+covers why; issue #935 covers when each applies). The equalizer has to come
+to the C4FM chain, not the signal to the equalizer.
 
 **What exactly should I record to help?**
 A P25 Phase 1 C4FM **voice-channel** IQ recording of a marginal call — the
-granted frequency, not the control channel — as a `.cfile` at ≥ 48 kHz, with
-a metadata sidecar per `samples/p25/README.md`, ideally noting what a
-hardware radio made of the same call. That one file converts a diagnosed,
-scoped, parked fix into a measurable A/B.
+granted frequency, not the control channel — as a `.cfile` at ≥ 48 kHz with a
+metadata sidecar per `samples/p25/README.md`, ideally noting what a hardware
+radio made of the same call. That one file converts a parked fix into a
+measurable A/B.
 
 **Does the 23.8 dB figure mean the C4FM demod is broken?**
-No — it means the reference is coherent and the demod is not, plus real
+No — the reference is coherent and the demod is not, plus real
 implementation loss on top. The number's job is to be a ceiling (the gate
-fails if the path regresses past 27 dB) and a motivator: it is the measured
-size of the pool the equalizer and soft FEC would fish in.
+fails past 27 dB) and a motivator: the measured size of the pool the
+equalizer and soft FEC would fish in.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
+++ b/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
@@ -1,0 +1,324 @@
+---
+title: "From Spec to Shipping, Part 13: Instruments, Not Logs"
+description: How GopherTrunk designs decoder diagnostics as instruments — counters on every branch including the failing ones, verdict lines written for operators, WARNs gated on persistence instead of one sampled blip, and health checks that never judge a channel by absolute dBFS.
+category: deep-dives
+keywords: designing diagnostics for dsp, decoder status line design, counters vs log messages, warn persistence gate, false warning transients, absolute dbfs trap, sdr health monitoring, structured logging go slog, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, diagnostics, logging, observability, methodology, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 13
+---
+
+*Part 13 of **From Spec to Shipping**, a 14-part series on how a protocol
+decoder actually gets written — from standards documents and independent
+references to code you can trust on air.
+[Part 12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})
+proved a fix with a test that fails first — once, on a fixture. This part is
+about what the shipped decoder says about itself afterwards, because the next
+investigation starts from its output. The rule: build **instruments**, not
+logs — counters on every branch including the failing ones, verdict lines an
+operator can act on, and WARNs that can tell a persistent condition from a
+sampled transient.*
+
+> **TL;DR:** A success-only log line carries no information — count every
+> branch. GopherTrunk's DMO decode-status line pairs `dnb_total` (a **noise
+> meter**: the burst correlator fires ~18×/s on an idle channel) with
+> `dnb_qualified` (slot-grid-confirmed traffic) so a huge gap between them
+> reads as *normal*, not alarming. Verdict lines flip their text on operator
+> knowledge (`GT_TETRA_DMO_CLEAR=1` turns "encrypted or decode defect" into
+> "decode defect — keep chasing"). WARNs carry persistence gates:
+> `carrierOffsetWarnPersist` (10 s, `internal/scanner/ccdecoder/decoder.go`)
+> ended the fake wrong-site warnings a sub-second AFC alias blip produced,
+> and `lowPowerDecodeGrace` (`internal/scanner/widebandt2/engine.go`) stops
+> a channel that is *decoding* from being called unhealthy at −56 dBFS. And
+> the MRC health line now WARNs when `updates` freezes while `holds` climbs —
+> the failure a plain INFO line reported as healthy for eleven minutes.
+
+**Key takeaways**
+
+- **Count every branch, especially the failing ones.** `dsb_total` next to
+  `dsb_schs_crc`, `dnb_total` next to `dnb_qualified`, `tch_crc` next to both
+  — ratios diagnose; lone success counters flatter.
+- **Name what a counter measures, not what you hope it means.** `dnb_total`
+  is a noise meter and the docs say so; and when `colour_known` could be true
+  without a verified recovery, it earned a separate `colourRecovered` flag —
+  a field must not claim more than the code checked.
+- **A WARN is a diagnosis, so it must outlast a transient.** The condition
+  the #815 carrier WARN names is persistent by nature; the estimate that
+  feeds it is not. Ten seconds of continuous excursion separates them.
+- **Never gate health on absolute power when decode evidence exists.**
+  dBFS is a gain-staging number; CRC-valid decodes are a health verdict.
+  Every absolute-power gate is a trap that re-fires on the next front end.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Branch-complete status line | `dsb_total/dsb_schs_crc`, `dnb_total/dnb_qualified`, `tch_crc`, `colour_known` | `internal/scanner/ccdecoder/pipelines_dmo.go` (`maybeLogStatus`) |
+| Noise-meter math | ~18 spurious DNB detections/s on an idle channel | `internal/radio/tetra/dmo_grid.go` (doc comment) |
+| Operator verdict line | `GT_TETRA_DMO_CLEAR=1` flips encrypted-vs-defect text | `cmd/gophertrunk/tetra_dmo_replay_test.go` |
+| WARN persistence gate | offset must sit over threshold 10 s continuously | `decoder.go` (`carrierOffsetWarnPersist`) |
+| Decode-evidence grace | recent decodes suppress the low-power WARN | `internal/scanner/widebandt2/engine.go` (`lowPowerDecodeGrace`) |
+| Staleness watchdog | WARN when `updates` freezes while `holds` climbs | `internal/sdr/soapyremote/mrc.go` (`mrcStaleUpdateIntervals`) |
+
+## In this post
+
+- **A success-only line carries no information** — the census principle,
+  built forward.
+- **Anatomy of one status line** — the DMO decode status, field by field.
+- **Verdict lines are written for the operator** — text that changes with
+  what the operator knows.
+- **A WARN must outlast a transient** — the persistence gate.
+- **Decode evidence beats absolute dBFS** — the grace that ended a false
+  health alarm.
+- **The counter that noticed its own silence** — staleness as a first-class
+  signal.
+
+## A success-only line carries no information
+
+[From the Issue Tracker Part 21]({{ '/blog/solution-postmortem/from-the-issue-tracker-21-census-everything/' | relative_url }})
+taught this as a postmortem: a pipeline that only announces what it decoded
+cannot tell you *why* it isn't decoding. Taught forward, the principle is
+about ratios. "Decoded 46 SCH/S" is a number; "46 CRC-valid of 54 detected"
+is a diagnosis — the detector works, the channel is mostly clean, the FEC is
+earning its keep. Every stage boundary in a decode chain is a place where
+work either survives or dies, and an instrument counts **both** outcomes at
+every boundary, because the failing count is usually the one that localises
+the fault.
+
+The DMO investigation ran on exactly this. The operator's log showed
+`dnb_total` climbing 1076→4541 over 185 seconds — 18.7 per second — while
+`dsb_schs_crc` sat frozen at 46. One counter racing while its CRC-gated
+neighbour stands still is not two facts, it's one conclusion: the raw
+detections are noise. That arithmetic, done in
+[Part 12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }}),
+became the fix; here it becomes the instrument.
+
+## Anatomy of one status line
+
+The DMO pipeline's periodic decode-status DEBUG line is the shape to copy:
+
+```go
+// internal/scanner/ccdecoder/pipelines_dmo.go (shape) — maybeLogStatus
+p.log.Debug("tetra dmo: decode status",
+    "locked", p.locked,
+    "carrier_off_hz", math.Round(p.rx.CarrierOffsetHz()*10)/10,
+    "dsb_total", p.dsbTotal,       // sync bursts detected
+    "dsb_schs_crc", p.dsbCRC,      // …of which CRC-valid — the lock evidence
+    "dnb_total", p.dnbTotal,       // raw traffic-burst detections: a NOISE METER
+    "dnb_qualified", p.dnbQualified, // …slot-grid-confirmed: the number that means traffic
+    "tch_crc", p.tchCRC,           // CRC-valid speech blocks
+    "distinct_fn", len(p.fnSeen),  // frame counter advancing = a genuine lock
+    "colour", p.colour, "colour_known", p.colourKnown,
+    "grant_active", p.grantActive,
+)
+```
+
+Every field is one side of a ratio or one liveness proof. `dsb_total` against
+`dsb_schs_crc` grades the channel; `distinct_fn` proves the lock is a
+transmission and not a chance CRC (a frame counter that advances cannot be
+faked by noise); and the pair at the centre carries the lesson:
+
+| Field pair | One is… | The other is… | A big gap means… |
+|---|---|---|---|
+| `dsb_total` / `dsb_schs_crc` | detections | CRC-verified syncs | marginal RF or wrong channel |
+| `dnb_total` / `dnb_qualified` | a noise meter (~18/s idle) | slot-grid-confirmed traffic | **nothing — this is normal** |
+| `dnb_qualified` / `tch_crc` | confirmed bursts | decoded speech | wrong colour code, or encryption |
+
+That middle row is the design point. The correlator that finds DMO traffic
+bursts is deliberately loose — 11 dibits at tolerance 2 under eight matched
+filters — so it fires ~18 times a second on an idle channel by construction
+(`internal/radio/tetra/dmo_grid.go` derives the number). Logging `dnb_total`
+alone would manufacture a permanent false alarm; logging only `dnb_qualified`
+would hide whether the correlator is alive at all. Logging **both, with the
+gap documented as normal**, turns a would-be scary number into the reference
+arm of a measurement — `dmo_grid.go`'s own comment says it in one line: *"a
+raw DNB count is not evidence of traffic — it is a noise meter."*
+`dnb_qualified` is the number that means traffic, and a large gap between
+them is not a fault.
+
+One more field earned its keep the hard way: `colour_known`. An early version
+set it `true` even when the recovery's confidence gate had *not* cleared, so
+a call that decoded nothing logged `colour=0 colour_known=true` — which reads
+as "recovered colour 0" and sends the investigation after the wrong thing.
+The flag was split from a separate `colourRecovered`. The rule generalises:
+**a diagnostic field must not claim more than the code actually verified**,
+because a wrong instrument is worse than no instrument.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 235" width="680" height="235" role="img" aria-label="One DMO decode-status log line annotated field by field. The line shows locked, dsb totals and CRC counts, dnb total and qualified, tch crc, distinct fn, and colour flags. Callouts group the fields: liveness proof, channel grade ratio, noise meter versus traffic, decode yield, and honest claim flags.">
+  <rect x="14" y="92" width="652" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="24" y="111" fill="currentColor" font-size="10" font-family="monospace">tetra dmo: decode status  locked=true  dsb_total=54 dsb_schs_crc=46  dnb_total=4541 dnb_qualified=212  tch_crc=196  distinct_fn=9  colour=3 colour_known=true</text>
+  <line x1="90" y1="92" x2="70" y2="58" stroke="var(--fg-muted)"/>
+  <text x="24" y="48" fill="var(--fg-muted)" font-size="9">liveness: the lock claim…</text>
+  <line x1="200" y1="92" x2="190" y2="58" stroke="var(--fg-muted)"/>
+  <text x="140" y="34" fill="currentColor" font-size="9">channel grade: 46/54 CRC-valid</text>
+  <text x="140" y="48" fill="var(--fg-muted)" font-size="9">detector AND verifier, side by side</text>
+  <line x1="360" y1="92" x2="370" y2="58" stroke="var(--accent)"/>
+  <text x="310" y="34" fill="var(--accent)" font-size="9">noise meter vs traffic: 4541 raw, 212 qualified</text>
+  <text x="310" y="48" fill="var(--accent)" font-size="9">the gap is DOCUMENTED as normal (~18 false/s)</text>
+  <line x1="480" y1="122" x2="470" y2="158" stroke="var(--fg-muted)"/>
+  <text x="380" y="176" fill="currentColor" font-size="9">yield: qualified bursts → CRC-valid speech</text>
+  <line x1="560" y1="122" x2="570" y2="158" stroke="var(--fg-muted)"/>
+  <text x="480" y="194" fill="var(--fg-muted)" font-size="9">…proved by an advancing frame counter (distinct_fn)</text>
+  <line x1="640" y1="122" x2="620" y2="205" stroke="var(--fg-muted)"/>
+  <text x="330" y="216" fill="currentColor" font-size="9">honest claims: colour_known split from colourRecovered — a flag may not claim more than the code verified</text>
+</svg>
+<figcaption>One line, five instruments: liveness proof, a CRC-graded ratio, a documented noise meter beside its qualified twin, decode yield, and flags that say only what was verified.</figcaption>
+</figure>
+
+## Verdict lines are written for the operator
+
+The replay harnesses from
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+end in **verdict lines** — prose conclusions computed from the counters,
+because the person running the test on their own capture is an operator, not
+the author of the decode chain. The DMO harness's verdict is the template
+(`cmd/gophertrunk/tetra_dmo_replay_test.go`): when signalling decodes well
+but speech sits at the ~1/256 chance floor, the honest conclusion is
+genuinely ambiguous — *either* air-interface encryption *or* a remaining
+clear-voice decode defect — and the line says exactly that, both branches.
+
+But the operator often knows something the code cannot: whether the radios
+are clear. `GT_TETRA_DMO_CLEAR=1` asserts it, and **flips the verdict text**
+— the same counters now print "this is a clear-voice DECODE defect to keep
+chasing … NOT encryption", with the next suspects named (DNB geometry, the
+DM colour code). That flip matters because the un-flipped reading already
+burned this project once: the chance floor was misread as encryption for
+weeks until the reporter confirmed TEA0-clear radios
+([the on-air gate]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})).
+A verdict line that encodes *what evidence would change the conclusion* is
+the difference between a diagnostic and a verdict you have to argue with.
+
+## A WARN must outlast a transient
+
+A WARN is a diagnosis addressed to a human, and a wrong one has a cost: the
+operator goes hunting for a condition that never existed. GopherTrunk's #815
+carrier-offset WARN — "your receiver may be locked onto a different site" —
+produced exactly that failure. A reporter filmed the mixer panel's carrier
+readout spiking to ~−5 kHz on a carrier really ~500 Hz off; the log said
+`offset_hz=5004`. The number itself carries the explanation: 5004 = 504 +
+4500, and 4500 Hz is exactly one AFC alias bucket (f_sym/4) — a sub-second
+estimator transient, not a carrier move. The old code diagnosed a
+*persistent* condition from **one per-chunk instantaneous sample**, so every
+blip became a scary wrong-site warning.
+
+```go
+// internal/scanner/ccdecoder/decoder.go (shape)
+// carrierOffsetWarnPersist is how long the total offset must sit
+// continuously over the WARN threshold before the first #815 line is
+// emitted. The condition the WARN diagnoses — locked onto an adjacent
+// site's carrier, or a grossly mistuned oscillator — is persistent by
+// nature, but the sampled AFC estimate is not […] 10 s cannot be crossed
+// by an estimator transient, while a genuine adjacent-site lock still
+// warns shortly after acquisition.
+const carrierOffsetWarnPersist = 10 * time.Second
+```
+
+The design rule is in that comment: **match the gate to the physics of the
+condition, not the cadence of the sampler.** The excursion clock resets when
+the offset dips back under threshold and on pipeline teardown, and the
+duration is a test-overridable field so
+`TestDecoderCarrierOffsetWarnRequiresPersistence` can pin the behaviour
+(failing-first, per Part 12). The AFC transient itself got a separate fix in
+the estimator — the WARN gate is not a bandage over it but an acknowledgment
+that *any* estimator blips, and a diagnosis should never be cheaper to emit
+than the condition it names. The full alias-bucket story is in
+[TETRA End to End Part 10]({{ '/blog/deep-dives/tetra-end-to-end-10-control-channel-sync-loss/' | relative_url }}).
+
+## Decode evidence beats absolute dBFS
+
+The sibling trap: judging health by absolute power. The wideband Tier II
+engine used to WARN "channel iq power very low" every 5 seconds — on a
+Tier III control channel that was **decoding every C_ALOHA** at −56 dBFS.
+Absolute dBFS is a gain-staging number, a function of front end, attenuation
+and configuration; it grades the installation, not the decode. Meanwhile the
+strongest possible health evidence — protocol decodes with valid CRCs — was
+sitting in the same process, ignored.
+
+`lowPowerDecodeGrace` (15 s, `internal/scanner/widebandt2/engine.go`) encodes
+the priority: any channel whose decode counters advanced recently is healthy
+*whatever its power gauge reads*, with the grace covering inter-beacon gaps
+so the WARN doesn't flap. It is the same lesson the MRC calibrator learned
+when an operator raised front-end gain 65→82 dB purely to push a number past
+a −40 dBFS software constant — chronicled in
+[Coherence, Not dBFS]({{ '/blog/tutorials/analog-edge-13-coherence-not-dbfs/' | relative_url }}) —
+generalised into a design rule: **never gate a health verdict on absolute
+power when scale-invariant evidence (decodes, CRC yield, coherence) exists.**
+Every absolute-power gate is a trap that re-fires on the next front end.
+
+## The counter that noticed its own silence
+
+The subtlest instrument failure is the line that keeps printing while its
+meaning quietly dies. The MRC diversity health line logged `updates`
+(accepted calibration windows) and `holds` (rejected ones) every interval —
+census-complete, both branches counted. An operator's field log then showed
+`updates` **frozen at 6682 for eleven minutes** while `holds` climbed ~6000
+per interval… at INFO, reported as healthy, because `calibrated` was still
+`true`. Every individual field was accurate. The line as a whole was a lie of
+omission: the combiner was applying a gain measured minutes ago to branches
+that no longer agreed, and nothing said so.
+
+The fix makes staleness itself a tracked quantity: the reporter
+(`internal/sdr/soapyremote/mrc.go`) remembers `lastUpdates` across intervals,
+and three consecutive intervals with no accepted window
+(`mrcStaleUpdateIntervals`, 90 s) escalates to a WARN naming the real state —
+locked once, coasting since. The generalisation closes the loop this series
+opened: counters catch what single events miss, but only **derivatives of
+counters** catch a system that stopped making progress while still running.
+An instrument isn't finished when it reports its state; it's finished when it
+can report that its state has stopped changing — designed, like everything in
+this part, for the *next* investigation rather than the last one.
+
+## Where this goes next
+
+Instruments tell you when a fix holds in the field — which is the last
+ingredient of the claim this series has been building toward: *the problem is
+gone*. [Part 14]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }}),
+the finale, defines that claim precisely — what "verified" means, the
+issue-closing policy that enforces it, the guard hook that asks a human
+before any close, and the full shipping checklist from Parts 1–13.
+
+## FAQ
+
+**Why log failure counters when nobody reads them until something breaks?**
+Because "until something breaks" is exactly when they're read, and they can't
+be added retroactively to a log you already collected. The DMO diagnosis ran
+on `dnb_total` racing while `dsb_schs_crc` froze — two counters that were
+"noise" right up until they were the whole answer.
+
+**Doesn't logging noise counters like `dnb_total` cause false alarms?**
+Only if logged alone. Paired with its qualified twin and documented — the
+status line's design says a large gap is normal — it becomes the reference
+arm of a measurement. Removing it would be worse: you could no longer tell a
+dead correlator from a silent channel.
+
+**How long should a WARN persistence gate be?**
+As long as the longest transient the underlying estimator can produce, and
+shorter than the time an operator would care about the real condition.
+`carrierOffsetWarnPersist` is 10 s because the AFC alias blip lasts well
+under a second while an adjacent-site lock lasts until someone fixes it —
+any value between those regimes works, and the constant's comment records
+the reasoning.
+
+**Should decoder diagnostics live at DEBUG or INFO?**
+GopherTrunk's split: periodic status lines at DEBUG (they're for
+investigations), state *transitions* at INFO, and conditions needing operator
+action at WARN — with the low-power WARN firing regardless of level because
+operator feedback is its whole point. The failure mode to avoid is a steady
+state logging identically forever; the Tier II engine moved parked channels
+to a 30 s summary cadence after a field report of "endless spam".
+
+**What's the fastest way to audit an existing log line?**
+Ask, for each field: what ratio is this one side of, and could it be true
+without the thing it implies being true? The second question is what caught
+`colour_known` — true without a verified recovery — and it generalises to
+any flag whose name promises more than its assignment checks.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: Failing First — The Regression Rule]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})
+· Next →
+[Part 14: The Definition of Verified]({{ '/blog/deep-dives/from-spec-to-shipping-14-definition-of-verified/' | relative_url }})

--- a/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
+++ b/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
@@ -149,7 +149,8 @@ because a wrong instrument is worse than no instrument.
 <figure class="lab-figure">
 <svg viewBox="0 0 680 235" width="680" height="235" role="img" aria-label="One DMO decode-status log line annotated field by field. The line shows locked, dsb totals and CRC counts, dnb total and qualified, tch crc, distinct fn, and colour flags. Callouts group the fields: liveness proof, channel grade ratio, noise meter versus traffic, decode yield, and honest claim flags.">
   <rect x="14" y="92" width="652" height="30" rx="6" fill="none" stroke="currentColor"/>
-  <text x="24" y="111" fill="currentColor" font-size="10" font-family="monospace">tetra dmo: decode status  locked=true  dsb_total=54 dsb_schs_crc=46  dnb_total=4541 dnb_qualified=212  tch_crc=196  distinct_fn=9  colour=3 colour_known=true</text>
+  <text x="24" y="104" fill="var(--fg-muted)" font-size="8" font-family="monospace">DEBUG tetra dmo: decode status</text>
+  <text x="24" y="116" fill="currentColor" font-size="9" font-family="monospace">locked=true dsb_total=54 dsb_schs_crc=46 dnb_total=4541 dnb_qualified=212 tch_crc=196 distinct_fn=9 colour=3</text>
   <line x1="90" y1="92" x2="70" y2="58" stroke="var(--fg-muted)"/>
   <text x="24" y="48" fill="var(--fg-muted)" font-size="9">liveness: the lock claim…</text>
   <line x1="200" y1="92" x2="190" y2="58" stroke="var(--fg-muted)"/>
@@ -264,12 +265,12 @@ The fix makes staleness itself a tracked quantity: the reporter
 (`internal/sdr/soapyremote/mrc.go`) remembers `lastUpdates` across intervals,
 and three consecutive intervals with no accepted window
 (`mrcStaleUpdateIntervals`, 90 s) escalates to a WARN naming the real state —
-locked once, coasting since. The generalisation closes the loop this series
-opened: counters catch what single events miss, but only **derivatives of
-counters** catch a system that stopped making progress while still running.
-An instrument isn't finished when it reports its state; it's finished when it
-can report that its state has stopped changing — designed, like everything in
-this part, for the *next* investigation rather than the last one.
+locked once, coasting since. The generalisation: counters catch what single
+events miss, but only **derivatives of counters** catch a system that stopped
+making progress while still running. An instrument isn't finished when it
+reports its state; it's finished when it can report that its state has
+stopped changing — designed, like everything here, for the *next*
+investigation rather than the last one.
 
 ## Where this goes next
 
@@ -295,12 +296,11 @@ arm of a measurement. Removing it would be worse: you could no longer tell a
 dead correlator from a silent channel.
 
 **How long should a WARN persistence gate be?**
-As long as the longest transient the underlying estimator can produce, and
+Longer than the longest transient the underlying estimator can produce,
 shorter than the time an operator would care about the real condition.
 `carrierOffsetWarnPersist` is 10 s because the AFC alias blip lasts well
 under a second while an adjacent-site lock lasts until someone fixes it —
-any value between those regimes works, and the constant's comment records
-the reasoning.
+any value between those regimes works.
 
 **Should decoder diagnostics live at DEBUG or INFO?**
 GopherTrunk's split: periodic status lines at DEBUG (they're for

--- a/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
+++ b/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
@@ -38,8 +38,8 @@ sampled transient.*
 **Key takeaways**
 
 - **Count every branch, especially the failing ones.** `dsb_total` next to
-  `dsb_schs_crc`, `dnb_total` next to `dnb_qualified`, `tch_crc` next to both
-  — ratios diagnose; lone success counters flatter.
+  `dsb_schs_crc`, `dnb_total` next to `dnb_qualified` — ratios diagnose;
+  lone success counters flatter.
 - **Name what a counter measures, not what you hope it means.** `dnb_total`
   is a noise meter and the docs say so; and when `colour_known` could be true
   without a verified recovery, it earned a separate `colourRecovered` flag —
@@ -64,8 +64,7 @@ sampled transient.*
 
 ## In this post
 
-- **A success-only line carries no information** — the census principle,
-  built forward.
+- **A success-only line carries no information** — the census principle.
 - **Anatomy of one status line** — the DMO decode status, field by field.
 - **Verdict lines are written for the operator** — text that changes with
   what the operator knows.
@@ -184,9 +183,9 @@ But the operator often knows something the code cannot: whether the radios
 are clear. `GT_TETRA_DMO_CLEAR=1` asserts it, and **flips the verdict text**
 — the same counters now print "this is a clear-voice DECODE defect to keep
 chasing … NOT encryption", with the next suspects named (DNB geometry, the
-DM colour code). That flip matters because the un-flipped reading already
-burned this project once: the chance floor was misread as encryption for
-weeks until the reporter confirmed TEA0-clear radios
+DM colour code). The flip matters because the un-flipped reading already
+burned this project: the chance floor was misread as encryption until the
+reporter confirmed TEA0-clear radios
 ([the on-air gate]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})).
 A verdict line that encodes *what evidence would change the conclusion* is
 the difference between a diagnostic and a verdict you have to argue with.
@@ -305,9 +304,9 @@ any value between those regimes works.
 GopherTrunk's split: periodic status lines at DEBUG (they're for
 investigations), state *transitions* at INFO, and conditions needing operator
 action at WARN — with the low-power WARN firing regardless of level because
-operator feedback is its whole point. The failure mode to avoid is a steady
-state logging identically forever; the Tier II engine moved parked channels
-to a 30 s summary cadence after a field report of "endless spam".
+operator feedback is its whole point. Avoid a steady state logging
+identically forever: the Tier II engine moved parked channels to a 30 s
+summary cadence after a field report of "endless spam".
 
 **What's the fastest way to audit an existing log line?**
 Ask, for each field: what ratio is this one side of, and could it be true

--- a/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
+++ b/docs/_posts/2026-09-15-from-spec-to-shipping-13-instruments-not-logs.md
@@ -31,9 +31,9 @@ sampled transient.*
 > `carrierOffsetWarnPersist` (10 s, `internal/scanner/ccdecoder/decoder.go`)
 > ended the fake wrong-site warnings a sub-second AFC alias blip produced,
 > and `lowPowerDecodeGrace` (`internal/scanner/widebandt2/engine.go`) stops
-> a channel that is *decoding* from being called unhealthy at −56 dBFS. And
-> the MRC health line now WARNs when `updates` freezes while `holds` climbs —
-> the failure a plain INFO line reported as healthy for eleven minutes.
+> a channel that is *decoding* from being called unhealthy at −56 dBFS. The
+> MRC health line now WARNs when `updates` freezes while `holds` climbs —
+> the failure a plain INFO line called healthy for eleven minutes.
 
 **Key takeaways**
 
@@ -82,10 +82,9 @@ taught this as a postmortem: a pipeline that only announces what it decoded
 cannot tell you *why* it isn't decoding. Taught forward, the principle is
 about ratios. "Decoded 46 SCH/S" is a number; "46 CRC-valid of 54 detected"
 is a diagnosis — the detector works, the channel is mostly clean, the FEC is
-earning its keep. Every stage boundary in a decode chain is a place where
-work either survives or dies, and an instrument counts **both** outcomes at
-every boundary, because the failing count is usually the one that localises
-the fault.
+earning its keep. Every boundary in a decode chain is a place where work
+either survives or dies, and an instrument counts **both** outcomes, because
+the failing count is usually the one that localises the fault.
 
 The DMO investigation ran on exactly this. The operator's log showed
 `dnb_total` climbing 1076→4541 over 185 seconds — 18.7 per second — while

--- a/docs/_posts/2026-09-15-operator-cookbook-13-naming-everything.md
+++ b/docs/_posts/2026-09-15-operator-cookbook-13-naming-everything.md
@@ -1,0 +1,360 @@
+---
+title: "The Operator's Cookbook, Part 13: Naming Everything — Aliases, Labels & Exports"
+description: Turn every talkgroup and radio ID on your GopherTrunk rig into a name — the real talkgroup_file and rid_alias_file CSV columns, naming things live from the web console with the labels layer, harvesting talker aliases off the air, and exporting the merged catalogue back to CSV.
+category: tutorials
+keywords: talkgroup csv format, radioreference talkgroup import, radio id alias file, scanner talkgroup names, talker alias decode, trunk recorder talkgroup file, gophertrunk talkgroup_file, sdr scanner alias csv, gophertrunk cookbook
+tags: [operator-cookbook, talkgroups, aliases, csv, web-console, metadata]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 13
+---
+
+*Part 13 of **The Operator's Cookbook**, a 14-part series of complete,
+copy-paste GopherTrunk builds — one working rig per part, antenna to browser.
+[Part 12]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }})
+finished the hardware story with the two-antenna diversity build. This part
+buys nothing and changes everything you look at: it turns `tg=9001` into
+`FIRE-DISP` everywhere — log lines, recordings tree, History searches, the
+live panels. The recipe is three layers deep: CSV files you own, a labels
+layer you edit from the browser, and names the air itself hands you. The
+running rule: **your most recent explicit act wins, and nothing you type gets
+silently lost.***
+
+> **TL;DR:** Per system, `talkgroup_file` and `rid_alias_file` load CSVs
+> keyed on a required **`Decimal`/`DEC`** column (RIDs also accept `ID`),
+> with optional case-insensitive columns — `Alpha Tag`, `Description`, `Tag`,
+> `Group`, `Priority` (a literal `L` means lockout), `Lockout`, `Scan`,
+> `Stream`, `Record`, `Mute`, `Icon` for talkgroups; `Alias`, `Owner`,
+> `Watch` for radios. Healthy startup logs
+> `daemon: talkgroups loaded system=… count=…`. Names applied live via the
+> web (behind `PATCH /api/v1/talkgroups/{id}` and `/api/v1/rids/{id}`)
+> persist in a SQLite **labels** table layered *over* the files — the label
+> wins, with a WARN when they disagree — and
+> `GET /api/v1/labels/export` folds the merged result back into a CSV that
+> loads as your next `talkgroup_file`.
+
+**Key takeaways**
+
+- **One column is mandatory, everything else is optional.** A CSV with just
+  `Decimal` and `Alpha Tag` headers works, and RadioReference-style exports
+  drop straight in. A missing `Decimal`/`DEC` header is the one hard error.
+- **The browser is a first-class editor, not a viewer.** Naming a radio that
+  just showed up live *creates* its catalogue entry — the daemon stopped
+  404-ing on unknown IDs precisely because the radios worth naming are the
+  ones not in any file yet.
+- **Labels layer over files; the label wins.** Files load first, persisted
+  labels apply on top, and a disagreement logs a WARN instead of a silent
+  overwrite — then the export endpoint lets you fold labels back into the
+  file and retire them.
+- **Some names come off the air for free.** Talker aliases, discovered
+  talkgroups and the affiliation tracker populate the rosters before you've
+  typed anything — [The Hunt Part 12]({{ '/blog/deep-dives/the-hunt-12-alias-harvesting/' | relative_url }})
+  is that story.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Talkgroup names | per-system CSV/JSON catalogue | `trunking.systems[].talkgroup_file` |
+| Radio-ID names | the per-RID equivalent | `trunking.systems[].rid_alias_file` |
+| Live naming | create/update names from web or API | `PATCH /api/v1/talkgroups/{id}`, `PATCH /api/v1/rids/{id}` |
+| Persistence | operator names survive restarts | labels table in `storage.path` (SQLite) |
+| Getting names out | merged catalogue back as loadable CSV | `GET /api/v1/labels/export?kind=…&scope=…` |
+| Names off the air | talker aliases on traffic channels | `signalling_taps` ([P25 talker alias]({{ '/reference/p25-talker-alias/' | relative_url }})) |
+| Whole-system exports | trunk-recorder / RadioReference / SigMF bundles | [The Hunt Part 13]({{ '/blog/deep-dives/the-hunt-13-exporting-your-finds/' | relative_url }}) |
+
+## In this post
+
+- **What you're building** — a naming layer over every number the rig shows.
+- **The files — real columns, verified** — both CSV formats from the actual loaders.
+- **Naming live from the browser** — the labels layer and its precedence rule.
+- **Names off the air** — talker aliases, discovered talkgroups, and one filing fix.
+- **First run — what healthy looks like** — the load counts and the divergence WARN.
+- **When it doesn't work** — symptom → cause → fix, then variations.
+
+## What you're building
+
+Nothing on the antenna side changes. What changes is every surface you read:
+recordings file under `<system>/<talkgroup>/` with the `{alpha}` token
+available in `filename_template`, the History panel becomes searchable by
+name, the Talkgroups and Radio IDs panels become rosters instead of number
+columns, and broadcast feeds carry proper labels. A
+[talkgroup]({{ '/reference/talkgroup/' | relative_url }}) or
+[radio ID]({{ '/reference/radio-id/' | relative_url }}) is just a number on
+the air — everything human about it is this recipe.
+
+Three sources feed one merged catalogue, in a strict order: **files** (loaded
+at startup, per system), then **labels** (your live edits, persisted to
+SQLite, applied over the files), with **on-air harvest** — talker aliases,
+discovered talkgroups — filling gaps around both. The precedence is the whole
+design: a label is your most recent explicit act, so it beats the file; the
+air never overwrites either.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Three naming layers feed one merged catalogue: talkgroup and RID alias files load at startup, the SQLite labels table applies operator edits over them and wins disagreements, and on-air harvest fills gaps; the catalogue feeds the web panels, recordings tree, history search and broadcast feeds, with an export loop back to CSV.">
+  <rect x="20" y="176" width="300" height="40" rx="5" fill="none" stroke="currentColor"/>
+  <text x="170" y="193" text-anchor="middle" fill="currentColor" font-size="10">files: talkgroup_file · rid_alias_file (CSV/JSON)</text>
+  <text x="170" y="207" text-anchor="middle" fill="var(--fg-muted)" font-size="9">loaded at startup, per system</text>
+  <rect x="20" y="118" width="300" height="40" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="170" y="135" text-anchor="middle" fill="var(--accent)" font-size="10">labels table (SQLite, storage.path)</text>
+  <text x="170" y="149" text-anchor="middle" fill="var(--fg-muted)" font-size="9">live web/API edits — label wins, WARN on disagreement</text>
+  <rect x="20" y="60" width="300" height="40" rx="5" fill="none" stroke="currentColor"/>
+  <text x="170" y="77" text-anchor="middle" fill="currentColor" font-size="10">on-air harvest: talker aliases · discovered TGs</text>
+  <text x="170" y="91" text-anchor="middle" fill="var(--fg-muted)" font-size="9">fills gaps; never overwrites your names</text>
+  <line x1="170" y1="176" x2="170" y2="158" stroke="currentColor"/><polygon points="166,164 170,156 174,164" fill="currentColor"/>
+  <line x1="170" y1="118" x2="170" y2="100" stroke="currentColor"/><polygon points="166,106 170,98 174,106" fill="currentColor"/>
+  <line x1="320" y1="90" x2="392" y2="110" stroke="var(--accent)"/><polygon points="384,108 396,112 386,116" fill="var(--accent)"/>
+  <rect x="396" y="88" width="150" height="48" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="471" y="108" text-anchor="middle" fill="var(--accent)" font-size="10">merged catalogue</text>
+  <text x="471" y="122" text-anchor="middle" fill="var(--fg-muted)" font-size="9">one roster per kind</text>
+  <line x1="546" y1="112" x2="586" y2="112" stroke="currentColor"/><polygon points="580,108 588,112 580,116" fill="currentColor"/>
+  <rect x="588" y="66" width="84" height="92" rx="5" fill="none" stroke="currentColor"/>
+  <text x="630" y="84" text-anchor="middle" fill="currentColor" font-size="9">web panels</text>
+  <text x="630" y="100" text-anchor="middle" fill="currentColor" font-size="9">recordings tree</text>
+  <text x="630" y="116" text-anchor="middle" fill="currentColor" font-size="9">history search</text>
+  <text x="630" y="132" text-anchor="middle" fill="currentColor" font-size="9">broadcast feeds</text>
+  <path d="M 460 136 C 440 210 240 232 174 220" fill="none" stroke="var(--fg-muted)" stroke-dasharray="4 3"/>
+  <polygon points="182,216 172,220 180,226" fill="var(--fg-muted)"/>
+  <text x="440" y="212" text-anchor="middle" fill="var(--fg-muted)" font-size="9">/api/v1/labels/export → CSV that loads as the file</text>
+</svg>
+<figcaption>Files load first, labels apply on top (and win), the air fills the gaps — and the export loop means the labels store is a convenience, never a lock-in.</figcaption>
+</figure>
+
+## The files — real columns, verified
+
+Both keys are per-system, and both loaders dispatch on extension (`.csv` or
+`.json`). Paths resolve relative to the folder containing `config.yaml`:
+
+```yaml
+trunking:
+  systems:
+    - name: "Metro-P25"
+      protocol: p25
+      control_channels:
+        - 857_262_500
+      talkgroup_file: "../config/talkgroups-p25.csv"
+      rid_alias_file: "../config/rids-p25.csv"
+```
+
+**The talkgroup CSV** requires one numeric `Decimal` (or `DEC`) column;
+everything else is optional and matched by header, case-insensitively:
+`Alpha Tag`, `Description`, `Mode`, `Tag`, `Group` (or `Category`),
+`Priority`, `Lockout`, `Scan` (or `Active`), `Stream`, `Record`, `Mute`,
+`Icon`. Two conventions worth knowing: a Priority of literal **`L`** sets
+lockout (matching common community CSVs), and the boolean columns default
+*permissive* — `Scan`, `Stream` and `Record` are on unless the cell says
+`n`/`no`/`false`/`0`/`off`, while `Lockout` and `Mute` are off unless it says
+`y`/`yes`/`true`/`1`:
+
+```
+Decimal,Alpha Tag,Description,Tag,Group,Priority,Stream
+9001,FIRE-DISP,Fire dispatch,Fire Dispatch,Fire,3,
+9002,PD-TAC2,Police tactical 2,Law Tac,Police,5,
+9060,PW-ROADS,Public works roads,Public Works,Services,,no
+9091,PD-ADMIN,Records desk,Law Talk,Police,L,
+```
+
+Row 3 stays recorded and scannable but never reaches a
+[broadcast feed]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }});
+row 4's `L` locks it out entirely. What each policy flag does at grant time —
+scan lists, priorities, lockout — is
+[Trunking Engine Part 6]({{ '/blog/deep-dives/trunking-engine-06-talkgroups-scan-modes/' | relative_url }})'s
+territory; this part is only about the file that feeds it.
+
+**The RID CSV** requires `Decimal`/`DEC`/`ID`, and accepts `Alias` (or
+`Alpha Tag`), `Description`, `Tag`, `Group` (or `Category`/`Agency`), `Owner`
+(or `User`/`Operator`), `Priority`, `Lockout`, `Watch` (or `Active`, default
+on), `Icon`:
+
+```
+Decimal,Alias,Description,Group,Owner
+7001234,ENG-51,Engine 51 mobile,Fire,Metro FD
+7005678,CAR-12,Patrol unit 12,Police,Metro PD
+```
+
+Where do the numbers come from? RadioReference for talkgroups (its CSV
+export's `Decimal`/`Alpha Tag`/`Description` headers load unmodified), your
+own History panel for radios — and if the system isn't catalogued anywhere,
+[`gophertrunk hunt`]({{ '/blog/deep-dives/the-hunt-11-naming-the-unknown/' | relative_url }})
+plus the import pipeline (`POST /api/v1/import` takes RadioReference PDFs and
+CSV bundles, previews, then commits) get you a starting file.
+
+## Naming live from the browser
+
+Files are for bulk; the browser is for the radio that keyed up *just now*.
+The Talkgroups and Radio IDs panels edit names in place (the TUI too), backed
+by two endpoints:
+
+```sh
+curl -X PATCH http://127.0.0.1:8080/api/v1/rids/7001234 \
+  -H 'Content-Type: application/json' \
+  -d '{"alias":"ENG-51","owner":"Metro FD"}'
+```
+
+Three behaviors make this layer trustworthy:
+
+- **Unknown IDs are created, not 404'd.** Requiring you to edit
+  `rid_alias_file` and restart before naming a radio defeats the point — the
+  radios worth naming are the ones showing up live, which by definition
+  aren't in the file yet. A synthesized entry behaves exactly like a loaded
+  one (and is deliberately *not* tagged as auto-discovered, so cleanup sweeps
+  of discovered entries can never delete your names).
+- **Names persist; policy doesn't.** The name fields
+  (alias/description/tag/group/owner/icon) write to the **labels** table in
+  `storage.path` and re-apply over the files at every startup. The policy
+  fields — priority, lockout, scan, watch — stay in-memory, exactly as
+  before; making those durable is a separate decision the daemon doesn't
+  take for you.
+- **The label wins, loudly.** At startup, files load first, then labels apply
+  on top. If your label and the file disagree, the label is your most recent
+  explicit act — it wins, and the daemon logs a WARN naming both so you can
+  reconcile.
+
+Reconciling is one request — the export endpoint emits the *merged* catalogue
+as a CSV whose columns are pinned by round-trip tests against the loader:
+
+```sh
+curl -o talkgroups-merged.csv \
+  "http://127.0.0.1:8080/api/v1/labels/export?kind=talkgroup&system=Metro-P25&scope=all"
+```
+
+Point `talkgroup_file` at the result, delete the labels
+(`DELETE /api/v1/labels/{kind}/{id}`), and you're back to one hand-edited
+file — the store is a convenience, never a lock-in. (`scope=labels`, the
+default, exports only the ids you've actually labelled; `kind=rid` does the
+same for radios, headers `Decimal,Alias,…,Watch,Icon`.) These are mutation
+routes, so off-loopback they need the
+[auth token]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }})
+like every other write.
+
+## Names off the air
+
+Some names arrive without you typing anything:
+
+- **Talker aliases.** Many radios transmit their own name on the traffic
+  channel; GopherTrunk decodes it and shows it in the Radio IDs roster
+  (`talker_alias` in the API) alongside your catalogue alias. On busy P25
+  Phase 2 systems most grants never get a voice tap, so the alias decode in
+  the voice chain rarely runs — set `signalling_taps: 2` on the wideband
+  device to harvest aliases from the signalling stream instead (issue
+  [#376](https://github.com/MattCheramie/GopherTrunk/issues/376); the
+  full story, including the encrypted-alias cryptanalysis, is
+  [The Hunt Parts 11–12]({{ '/blog/deep-dives/the-hunt-12-alias-harvesting/' | relative_url }})).
+- **Discovered talkgroups.** Talkgroups seen on grants but absent from your
+  file appear in the roster tagged as discovered, so the panel is a live
+  census of what actually talks — usually the fastest way to find what your
+  CSV is missing.
+- **Affiliations.** The
+  [affiliation tracker]({{ '/blog/deep-dives/trunking-engine-08-affiliation-tracking/' | relative_url }})
+  surfaces radios as they register, populating the RID roster with sightings
+  even with no `rid_alias_file` configured at all.
+
+One filing fix worth knowing if you run DMR: an earlier build reclassified a
+group call as *individual* whenever the talkgroup number happened to equal a
+known radio ID — valid logic on TETRA, where group and individual IDs never
+overlap, but DMR shares one 24-bit space for both, so group calls got
+misfiled under `individual/<TG>/` and corrupted the roster's Last Talkgroup
+column. That mechanism is now scoped to TETRA only; DMR's own call-type
+signalling is authoritative, pinned by a regression test.
+
+## First run — what healthy looks like
+
+Restart after adding the files and watch startup:
+
+```
+INF daemon: talkgroups loaded system=Metro-P25 count=214
+INF daemon: rids loaded system=Metro-P25 count=87
+INF daemon: operator labels applied updated=12 created=3
+```
+
+The counts are your first sanity check — a `count=0` on a file you know has
+rows means the header didn't parse (see the table below). If you've labelled
+things that also live in the file, you may also see the divergence WARN,
+which is informational by design:
+
+```
+WRN daemon: operator label overrides the alias file's name kind=talkgroup id=9001 file=FD-DISP label=FIRE-DISP
+```
+
+Then let a call come in: the recorder line now shows the folder tree using
+your talkgroup number with the alias visible everywhere the UI renders it,
+History filters accept the name, and a search by `FIRE-DISP` in the
+Talkgroups panel lands on 9001. The names also flow outward — call webhooks
+and [broadcast uploads]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})
+carry the metadata, and a talkgroup with `stream: no` never leaves the box.
+
+## When it doesn't work
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `trunking: csv missing required Decimal/DEC column` | the header row lacks a `Decimal`/`DEC` column (RIDs also take `ID`) | rename the ID column; everything else is optional |
+| WARN `talkgroup_file … failed to load … no alpha tags` | wrong path — paths resolve relative to the folder containing `config.yaml` | fix the relative path or use an absolute one |
+| `talkgroups loaded count=0` on a non-empty file | rows whose Decimal cell is blank/non-numeric are skipped silently | check for stray header rows or hex-only IDs; `Decimal` must be base-10 |
+| Names applied in the web vanish after restart | no `storage.path` configured — the labels table needs SQLite | set `storage.path` (Part 1's config has it); export with `scope=all` still works meanwhile |
+| PATCH returns 403 | mutations gated by `api.auth` off loopback | use the token, or a `trusted_networks` entry — [auth posture]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }}) |
+| WARN `operator label overrides the alias file's name` every startup | label and file disagree — deliberate, not an error | fold labels into the file via `/api/v1/labels/export`, then delete the label |
+| DMR group calls filed under `individual/` | the old cross-protocol reclassification bug | fixed — classification is TETRA-scoped now; update your build |
+| Radio roster shows no Last Talkgroup for some radios | those radios only made individual calls, which the column excludes by design | nothing to fix — check History with the RID filter instead |
+
+### Variations
+
+- **JSON instead of CSV** — both loaders take a `.json` array of objects
+  (`{"id": 9001, "alpha_tag": "FIRE-DISP", …}`); same fields, same defaults.
+- **Per-system files** — every system gets its own `talkgroup_file` /
+  `rid_alias_file`, and the label store keys on `(kind, system, target_id)`
+  so the CSV export can emit one file per system.
+- **Conventional channels too** — a scanner-list channel can pin an explicit
+  `talkgroup_id` so its roster row (and any names you attach) survive
+  re-ordering of the channel list.
+- **Templates that use the names** — `filename_template` accepts `{alpha}`,
+  so recordings can carry the alias in the filename itself
+  ([naming & sidecars]({{ '/blog/deep-dives/recording-streaming-06-segmentation-naming-sidecars/' | relative_url }})).
+
+## Where this goes next
+
+That's the last recipe with a job of its own. [Part
+14]({{ '/blog/tutorials/operator-cookbook-14-kitchen-sink-config/' | relative_url }})
+is the finale: the kitchen-sink `config.yaml`, walked section by section and
+annotated with which part of this series owns each block — plus the decision
+table that turns "what do I want?" into "which part do I read?".
+
+## FAQ
+
+**Can I use a RadioReference talkgroup export directly?**
+Yes — the loader keys on the `Decimal` column and matches `Alpha Tag`,
+`Description`, `Tag` and `Category` headers case-insensitively, which covers
+the RadioReference CSV shape. Trunk-recorder-style files load too; the
+`Priority`-of-`L` lockout convention is supported for community files.
+
+**Why did the name I set in the web UI disappear after a restart?**
+Almost always: no `storage.path`, so there was no SQLite database for the
+labels table to persist into. Set it, re-apply the name, and look for
+`daemon: operator labels applied` on the next startup. If storage *is* set,
+check the startup log for `operator labels not applied` with an error.
+
+**What's the difference between the labels table and the CSV files?**
+Scope and authorship. The files are your bulk, hand-maintained catalogue,
+loaded at startup; labels are individual edits made live, persisted
+separately, and applied over the files — winning any disagreement because
+they're your most recent explicit act. The export endpoint merges the two
+back into a file whenever you want a single source of truth again.
+
+**Does GopherTrunk name talkgroups automatically?**
+Partially. Radios that transmit talker aliases get named from the air, and
+unknown talkgroups appear in the roster as discovered — a census, not a
+naming. Actual alpha tags for talkgroups still come from you or a database
+like RadioReference; the roster just makes the gaps obvious.
+
+**Why does the Radio IDs panel show two names for one radio?**
+They're different columns: your catalogue alias (file or label) and the
+talker alias the radio itself transmitted. They often disagree —
+fleet-programmed aliases can be stale or cryptic — and GopherTrunk shows
+both rather than guessing which you trust.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: Two Antennas, One Signal — A Diversity Build]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }})
+· Next →
+[Part 14: The Kitchen-Sink Config, Annotated]({{ '/blog/tutorials/operator-cookbook-14-kitchen-sink-config/' | relative_url }})

--- a/docs/_posts/2026-09-15-operator-cookbook-13-naming-everything.md
+++ b/docs/_posts/2026-09-15-operator-cookbook-13-naming-everything.md
@@ -182,8 +182,8 @@ CSV bundles, previews, then commits) gets you a starting file.
 ## Naming live from the browser
 
 Files are for bulk; the browser is for the radio that keyed up *just now*.
-The Talkgroups and Radio IDs panels edit names in place (the TUI too), backed
-by two endpoints:
+The web Talkgroups and Radio IDs panels edit names in place, backed by two
+endpoints:
 
 ```sh
 curl -X PATCH http://127.0.0.1:8080/api/v1/rids/7001234 \

--- a/docs/_posts/2026-09-15-operator-cookbook-13-naming-everything.md
+++ b/docs/_posts/2026-09-15-operator-cookbook-13-naming-everything.md
@@ -77,19 +77,18 @@ silently lost.***
 
 Nothing on the antenna side changes. What changes is every surface you read:
 recordings file under `<system>/<talkgroup>/` with the `{alpha}` token
-available in `filename_template`, the History panel becomes searchable by
-name, the Talkgroups and Radio IDs panels become rosters instead of number
-columns, and broadcast feeds carry proper labels. A
+available in `filename_template`, History becomes searchable by name, the
+Talkgroups and Radio IDs panels become rosters instead of number columns, and
+broadcast feeds carry proper labels. A
 [talkgroup]({{ '/reference/talkgroup/' | relative_url }}) or
 [radio ID]({{ '/reference/radio-id/' | relative_url }}) is just a number on
 the air — everything human about it is this recipe.
 
-Three sources feed one merged catalogue, in a strict order: **files** (loaded
-at startup, per system), then **labels** (your live edits, persisted to
-SQLite, applied over the files), with **on-air harvest** — talker aliases,
-discovered talkgroups — filling gaps around both. The precedence is the whole
-design: a label is your most recent explicit act, so it beats the file; the
-air never overwrites either.
+Three sources feed one merged catalogue, in strict order: **files** (loaded
+at startup, per system), then **labels** (live edits, persisted to SQLite,
+applied over the files), with **on-air harvest** filling gaps around both.
+The precedence is the whole design: a label is your most recent explicit
+act, so it beats the file; the air never overwrites either.
 
 <figure class="lab-figure">
 <svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="Three naming layers feed one merged catalogue: talkgroup and RID alias files load at startup, the SQLite labels table applies operator edits over them and wins disagreements, and on-air harvest fills gaps; the catalogue feeds the web panels, recordings tree, history search and broadcast feeds, with an export loop back to CSV.">
@@ -157,10 +156,10 @@ Decimal,Alpha Tag,Description,Tag,Group,Priority,Stream
 
 Row 3 stays recorded and scannable but never reaches a
 [broadcast feed]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }});
-row 4's `L` locks it out entirely. What each policy flag does at grant time —
-scan lists, priorities, lockout — is
+row 4's `L` locks it out entirely. What each policy flag does at grant time
+is
 [Trunking Engine Part 6]({{ '/blog/deep-dives/trunking-engine-06-talkgroups-scan-modes/' | relative_url }})'s
-territory; this part is only about the file that feeds it.
+territory; this part is about the file that feeds it.
 
 **The RID CSV** requires `Decimal`/`DEC`/`ID`, and accepts `Alias` (or
 `Alpha Tag`), `Description`, `Tag`, `Group` (or `Category`/`Agency`), `Owner`
@@ -174,11 +173,11 @@ Decimal,Alias,Description,Group,Owner
 ```
 
 Where do the numbers come from? RadioReference for talkgroups (its CSV
-export's `Decimal`/`Alpha Tag`/`Description` headers load unmodified), your
-own History panel for radios — and if the system isn't catalogued anywhere,
+headers load unmodified), your own History panel for radios — and if the
+system isn't catalogued anywhere,
 [`gophertrunk hunt`]({{ '/blog/deep-dives/the-hunt-11-naming-the-unknown/' | relative_url }})
 plus the import pipeline (`POST /api/v1/import` takes RadioReference PDFs and
-CSV bundles, previews, then commits) get you a starting file.
+CSV bundles, previews, then commits) gets you a starting file.
 
 ## Naming live from the browser
 
@@ -194,25 +193,23 @@ curl -X PATCH http://127.0.0.1:8080/api/v1/rids/7001234 \
 
 Three behaviors make this layer trustworthy:
 
-- **Unknown IDs are created, not 404'd.** Requiring you to edit
-  `rid_alias_file` and restart before naming a radio defeats the point — the
-  radios worth naming are the ones showing up live, which by definition
-  aren't in the file yet. A synthesized entry behaves exactly like a loaded
-  one (and is deliberately *not* tagged as auto-discovered, so cleanup sweeps
-  of discovered entries can never delete your names).
+- **Unknown IDs are created, not 404'd.** Requiring an edit to
+  `rid_alias_file` and a restart before naming a radio defeats the point —
+  the radios worth naming are the ones showing up live, which by definition
+  aren't in the file yet. A synthesized entry behaves like a loaded one (and
+  is deliberately *not* tagged auto-discovered, so cleanup sweeps of
+  discovered entries can never delete your names).
 - **Names persist; policy doesn't.** The name fields
   (alias/description/tag/group/owner/icon) write to the **labels** table in
-  `storage.path` and re-apply over the files at every startup. The policy
-  fields — priority, lockout, scan, watch — stay in-memory, exactly as
-  before; making those durable is a separate decision the daemon doesn't
-  take for you.
-- **The label wins, loudly.** At startup, files load first, then labels apply
-  on top. If your label and the file disagree, the label is your most recent
-  explicit act — it wins, and the daemon logs a WARN naming both so you can
-  reconcile.
+  `storage.path` and re-apply over the files at startup. The policy fields —
+  priority, lockout, scan, watch — stay in-memory as before; making those
+  durable is a separate decision the daemon doesn't take for you.
+- **The label wins, loudly.** Files load first, labels apply on top. When
+  they disagree, the label — your most recent explicit act — wins, and the
+  daemon logs a WARN naming both so you can reconcile.
 
-Reconciling is one request — the export endpoint emits the *merged* catalogue
-as a CSV whose columns are pinned by round-trip tests against the loader:
+Reconciling is one request — the export emits the *merged* catalogue as a
+CSV whose columns are pinned by round-trip tests against the loader:
 
 ```sh
 curl -o talkgroups-merged.csv \
@@ -222,9 +219,8 @@ curl -o talkgroups-merged.csv \
 Point `talkgroup_file` at the result, delete the labels
 (`DELETE /api/v1/labels/{kind}/{id}`), and you're back to one hand-edited
 file — the store is a convenience, never a lock-in. (`scope=labels`, the
-default, exports only the ids you've actually labelled; `kind=rid` does the
-same for radios, headers `Decimal,Alias,…,Watch,Icon`.) These are mutation
-routes, so off-loopback they need the
+default, exports only the ids you've labelled; `kind=rid` does radios.) The
+writes are mutation routes, so off-loopback they need the
 [auth token]({{ '/blog/deep-dives/running-it-for-real-02-auth-posture/' | relative_url }})
 like every other write.
 
@@ -233,13 +229,12 @@ like every other write.
 Some names arrive without you typing anything:
 
 - **Talker aliases.** Many radios transmit their own name on the traffic
-  channel; GopherTrunk decodes it and shows it in the Radio IDs roster
-  (`talker_alias` in the API) alongside your catalogue alias. On busy P25
-  Phase 2 systems most grants never get a voice tap, so the alias decode in
-  the voice chain rarely runs — set `signalling_taps: 2` on the wideband
-  device to harvest aliases from the signalling stream instead (issue
-  [#376](https://github.com/MattCheramie/GopherTrunk/issues/376); the
-  full story, including the encrypted-alias cryptanalysis, is
+  channel; GopherTrunk decodes it into the Radio IDs roster (`talker_alias`
+  in the API) alongside your catalogue alias. On busy P25 Phase 2 systems
+  most grants never get a voice tap, so set `signalling_taps: 2` on the
+  wideband device to harvest aliases from the signalling stream instead
+  (issue [#376](https://github.com/MattCheramie/GopherTrunk/issues/376); the
+  full story, encrypted-alias cryptanalysis included, is
   [The Hunt Parts 11–12]({{ '/blog/deep-dives/the-hunt-12-alias-harvesting/' | relative_url }})).
 - **Discovered talkgroups.** Talkgroups seen on grants but absent from your
   file appear in the roster tagged as discovered, so the panel is a live
@@ -250,13 +245,13 @@ Some names arrive without you typing anything:
   surfaces radios as they register, populating the RID roster with sightings
   even with no `rid_alias_file` configured at all.
 
-One filing fix worth knowing if you run DMR: an earlier build reclassified a
-group call as *individual* whenever the talkgroup number happened to equal a
-known radio ID — valid logic on TETRA, where group and individual IDs never
-overlap, but DMR shares one 24-bit space for both, so group calls got
-misfiled under `individual/<TG>/` and corrupted the roster's Last Talkgroup
-column. That mechanism is now scoped to TETRA only; DMR's own call-type
-signalling is authoritative, pinned by a regression test.
+One filing fix worth knowing on DMR: an earlier build reclassified a group
+call as *individual* whenever the talkgroup number equalled a known radio
+ID — valid on TETRA, where group and individual IDs never overlap, but DMR
+shares one 24-bit space, so group calls got misfiled under `individual/<TG>/`
+and corrupted the roster's Last Talkgroup column. The mechanism is now scoped
+to TETRA only; DMR's own call-type signalling is authoritative, pinned by a
+regression test.
 
 ## First run — what healthy looks like
 
@@ -268,19 +263,18 @@ INF daemon: rids loaded system=Metro-P25 count=87
 INF daemon: operator labels applied updated=12 created=3
 ```
 
-The counts are your first sanity check — a `count=0` on a file you know has
-rows means the header didn't parse (see the table below). If you've labelled
-things that also live in the file, you may also see the divergence WARN,
-which is informational by design:
+The counts are the first sanity check — `count=0` on a file you know has
+rows means the header didn't parse (table below). If a label and the file
+both name the same id, you'll also see the divergence WARN, informational by
+design:
 
 ```
 WRN daemon: operator label overrides the alias file's name kind=talkgroup id=9001 file=FD-DISP label=FIRE-DISP
 ```
 
-Then let a call come in: the recorder line now shows the folder tree using
-your talkgroup number with the alias visible everywhere the UI renders it,
-History filters accept the name, and a search by `FIRE-DISP` in the
-Talkgroups panel lands on 9001. The names also flow outward — call webhooks
+Then let a call come in: the alias renders everywhere the UI shows the
+talkgroup, History filters accept the name, and a search for `FIRE-DISP` in
+the Talkgroups panel lands on 9001. Names also flow outward — call webhooks
 and [broadcast uploads]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }})
 carry the metadata, and a talkgroup with `stream: no` never leaves the box.
 
@@ -334,23 +328,23 @@ labels table to persist into. Set it, re-apply the name, and look for
 check the startup log for `operator labels not applied` with an error.
 
 **What's the difference between the labels table and the CSV files?**
-Scope and authorship. The files are your bulk, hand-maintained catalogue,
-loaded at startup; labels are individual edits made live, persisted
-separately, and applied over the files — winning any disagreement because
-they're your most recent explicit act. The export endpoint merges the two
-back into a file whenever you want a single source of truth again.
+Authorship and scope. Files are the bulk, hand-maintained catalogue loaded at
+startup; labels are individual live edits, persisted separately and applied
+over the files — winning any disagreement as your most recent explicit act.
+The export endpoint merges the two back into a file whenever you want one
+source of truth again.
 
 **Does GopherTrunk name talkgroups automatically?**
 Partially. Radios that transmit talker aliases get named from the air, and
 unknown talkgroups appear in the roster as discovered — a census, not a
-naming. Actual alpha tags for talkgroups still come from you or a database
-like RadioReference; the roster just makes the gaps obvious.
+naming. Alpha tags for talkgroups still come from you or RadioReference; the
+roster just makes the gaps obvious.
 
 **Why does the Radio IDs panel show two names for one radio?**
-They're different columns: your catalogue alias (file or label) and the
-talker alias the radio itself transmitted. They often disagree —
-fleet-programmed aliases can be stale or cryptic — and GopherTrunk shows
-both rather than guessing which you trust.
+Different columns: your catalogue alias (file or label) and the talker alias
+the radio itself transmitted. They often disagree — fleet-programmed aliases
+can be stale or cryptic — and GopherTrunk shows both rather than guessing
+which you trust.
 
 ## Series navigation
 

--- a/docs/_posts/2026-09-15-p25-end-to-end-13-testing-p25.md
+++ b/docs/_posts/2026-09-15-p25-end-to-end-13-testing-p25.md
@@ -1,0 +1,335 @@
+---
+title: "P25 End to End, Part 13: Testing P25 Without a Tower"
+description: How GopherTrunk tests a P25 decoder with no transmitter in reach — literal byte vectors that catch what round-trips cannot, impairment-swept synthetic carriers with a hard CI loss budget, committed real-air capture fixtures, and rate-invariance tests that prove where a bug is not.
+category: deep-dives
+keywords: testing p25 decoder, p25 test vectors, sdr regression testing, synthetic iq impairments, p25 capture fixture, round trip test trap, ber snr sweep ci, replay testing sdr, gophertrunk p25
+tags: [p25-end-to-end, p25, testing, replay, fixtures, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 13
+---
+
+*Part 13 of **P25 End to End**, a 14-part deep dive that follows North America's
+dominant trunking protocol through GopherTrunk — from a raw C4FM carrier to
+recorded, named, multi-site voice.
+[Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})
+ended with a fix deliberately parked behind a capture — which only makes sense
+if tests have sharply different powers of proof. This part lays out that
+hierarchy for P25: four layers of testing, what each can and cannot catch,
+and the bugs that define each boundary. The villain of the whole series —
+the test that passes because both sides share the same wrong assumption —
+gets its full anatomy here.*
+
+> **TL;DR:** GopherTrunk tests P25 in four layers. **Literal vectors** pin
+> wire layouts against independent references — the TSBK SCCB (0x39) parser
+> read channel B one byte early and its round-trip test *passed*, because the
+> assembler encoded the same wrong layout; the hand-built byte vector in
+> `TestParseSecondaryControlChannelBroadcastLayout` fails against the bug.
+> **Synthetic streams** add honest RF impairments (`demod.Impairments`:
+> multipath FIR, carrier offset + drift, DC spike, IQ imbalance, AWGN) under
+> a hard BER-sweep gate with committed loss budgets. **Committed captures**
+> (`testdata/mmr-s9-cc.cfile`, `samples/p25/`) are field truth in CI. And
+> **rate-invariance tests** (`internal/scanner/ccdecoder/ddc_highrate_test.go`)
+> prove where a defect is *not* — the control that settled
+> [#764](https://github.com/MattCheramie/GopherTrunk/issues/764). None of
+> them prove on-air behaviour, which is why the issue-closing policy demands
+> a verified symptom, not a green suite.
+
+**Key takeaways**
+
+- **A round-trip test validates consistency, not correctness.** Encoder and
+  decoder written by the same hand share the same misreading of the spec —
+  the SCCB byte-offset bug rode a green round-trip into production.
+- **Synthetic streams are only as honest as their impairments.** An ideal
+  modulator output hides gain sensitivity, carrier-offset bias and multipath
+  failure; `demod.Impairments` puts the RTL-SDR's sins back in.
+- **A committed capture is a regression test with the real world inside it.**
+  One second of real control channel (~400 KB) catches level bugs, filter
+  mismatches and timing-loop defects no synthetic ever tripped.
+- **Some tests exist to prove where a bug is NOT.** The rate-invariance suite
+  pins the verified conclusion that the DDC neither creates nor hides an SNR
+  deficit, so the next #764-shaped report starts at the right suspect.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| Literal wire vectors | pins the 0x39 SCCB layout against SDRTrunk offsets | `internal/radio/p25/phase1/mbt_test.go` (`TestParseSecondaryControlChannelBroadcastLayout`) |
+| On-air vector | a real captured TSBK must parse forever | `phase1/tsbk_test.go` (`TestTSBKAcceptsMtAnakieOnAirVector`) |
+| RF impairment model | multipath, offset, drift, DC, IQ imbalance, AWGN | `internal/dsp/demod/impair.go` (`demod.Impairments`) |
+| Hard demod gate | BER-vs-SNR sweep with committed loss budgets | `phase1/receiver/sweep_test.go` (`TestSweepImplementationLossBudget`) |
+| Capture fixtures | real CC slices replayed in CI | `cmd/gophertrunk/replay_realcapture_test.go` (`TestReplayMMRSite9DecodesRealP25`) |
+| Drop-in field truth | skip-gated metrics on any contributed capture | `cmd/gophertrunk/p25_realcapture_metrics_test.go` |
+| Where a bug is NOT | DDC level/SNR invariance across capture rates | `internal/scanner/ccdecoder/ddc_highrate_test.go` |
+
+## In this post
+
+- **The trap at the bottom** — why round-trips lie, via the SCCB bug.
+- **Literal vectors** — independent references, on-air frames.
+- **Synthetic streams** — honest impairments and the hard sweep gate.
+- **Committed captures** — field truth as a permanent regression.
+- **Rate invariance** — tests that prove where a defect is not.
+- **The top of the pyramid** — what only air can verify.
+
+## The trap at the bottom: why round-trips lie
+
+Start with the bug
+[Part 3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }})
+introduced — the cleanest specimen of the failure class this whole part is
+armour against. The TSBK Secondary Control Channel Broadcast (opcode 0x39)
+parser read channel B from payload bytes 4–5; the correct layout puts it at
+bytes 5–7, so the old code spliced service class A into the channel field.
+And the round-trip test **passed**, for the oldest reason in the book:
+`AssembleSecondaryControlChannelBroadcast` encoded the same wrong layout, so
+parse(assemble(x)) == x held perfectly while every real site's SCCB decoded
+to a phantom channel.
+
+That is the self-consistent-synthetic trap, and it is not a P25 quirk — the
+same shape produced the RRC-matched-filter model that passed every synthetic
+test while leaving ISI on every real capture (issue #275,
+[Part 1]({{ '/blog/deep-dives/p25-end-to-end-01-c4fm-carrier/' | relative_url }})),
+and it recurs often enough to have earned
+[its own postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-20-self-consistent-trap/' | relative_url }}).
+A test whose two sides share an assumption validates it against nothing.
+
+## Literal vectors: bytes that cannot agree with you
+
+The countermeasure is structural: at least one test per wire format whose
+expected bytes were produced by something that is *not your code*. The SCCB
+regression is the template —
+
+```go
+// internal/radio/p25/phase1/mbt_test.go (shape)
+// Pins the 0x39 payload layout against SDRTrunk's bit offsets (RFSS 16-23,
+// SITE 24-31, CH A 32-47, SC A 48-55, CH B 56-71, SC B 72-79). The previous
+// parser read channel B from bytes 4-5 — one byte early — and its
+// round-trip test passed because the assembler encoded the same wrong
+// layout. A literal byte vector cannot be fooled that way.
+func TestParseSecondaryControlChannelBroadcastLayout(t *testing.T) {
+    p := [8]byte{0x01, 0x01, 0x26, 0x9C, 0x70, 0x2D, 0x0E, 0x50}
+    s := ParseSecondaryControlChannelBroadcast(p)
+    if s.ChannelBID != 2 || s.ChannelBNumber != 3342 {
+        t.Errorf("channel B = %d-%d, want 2-3342 (old layout read bytes 4-5: 7-45)",
+            s.ChannelBID, s.ChannelBNumber)
+    }
+    /* … RFSS/site, channel A, both service classes, assemble round-trip … */
+}
+```
+
+The vector's provenance is the point: those offsets come from SDRTrunk, an
+independent implementation proven on air. The test *fails against the old
+parser* — the failing-first property every bug fix here must have — and no
+future refactor can drift the layout without tripping it.
+
+One rung up sits the even better vector: bytes that came off the air.
+`TestTSBKAcceptsMtAnakieOnAirVector` feeds the TSBK pipeline a block a real
+transmitter emitted, pinning trellis decode, deinterleave and CRC-CCITT16 to
+the world rather than the spec-reading. The same philosophy anchors
+[Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }})'s
+MBT/AMBT decoder to OP25's `process_PDU`, and it is the founding rule of
+[From Spec to Shipping]({{ '/blog/series/from-spec-to-shipping/' | relative_url }}):
+a spec plus an independent decoder beats a spec plus your own inverse.
+
+## Synthetic streams with honest impairments
+
+Literal vectors test parsers, not demodulators. For those you need signal —
+and naive "generate a carrier, decode it" re-creates the trap one layer
+down, because a mathematically ideal modulator output is a channel no real
+capture resembles. GopherTrunk models the sins explicitly:
+
+```go
+// internal/dsp/demod/impair.go (shape)
+type Impairments struct {
+    Multipath         []complex64 // complex channel FIR — simulcast ISI
+    FreqOffsetHz      float64     // tuner ppm error
+    FreqDriftHzPerSec float64     // LO warm-up wander (issue #492)
+    DCOffset          complex64   // the R820T2/E4000 centre spike
+    IQGainImbalance   float64     // analog quadrature mismatch
+    IQPhaseSkewRad    float64
+    SNRdB             float64     // AWGN, seeded for reproducibility
+    Scale             float64     // front-end gain level
+}
+```
+
+Each field is a war story. `Scale` exists because the CQPSK path once locked
+only in a narrow RTL-SDR gain window (issue #275's regression report);
+`FreqDriftHzPerSec` because a fixed coarse carrier seed cannot track a
+warming LO (issue #492); `Multipath` because a flat-fading model cannot
+produce simulcast ISI. The harness in `receiver/harness_test.go` modulates a
+canonical control-channel stream (`ModulateP25C4FM`, NAC 0x293 at the
+production 48 kHz rate), applies an `Impairments`, and runs the **real
+receiver** — never an idealised stand-in.
+
+On top of that sits the hard gate from
+[Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }}):
+`TestSweepImplementationLossBudget` sweeps injected SNR from 2 to 40 dB on
+both demod paths, measures symbol-error rate against closed-form references,
+and fails CI if either path regresses past its committed loss budget (6 dB
+for CQPSK against coherent QPSK, 27 dB for C4FM against coherent 4-PAM).
+The sweep cannot prove the demod is good, but it guarantees it never
+silently gets worse — and it validates the SNR *estimator* alongside the
+demod, so the diagnostic numbers operators see are themselves under test.
+
+## Committed captures: field truth in the repo
+
+The third layer embeds the real world in CI. `testdata/mmr-s9-cc.cfile` is a
+~1.09 s slice of a real P25 control channel — small enough to commit, long
+enough for several FSW+NID+TSBK frames — and
+`TestReplayMMRSite9DecodesRealP25` replays it through the production chain
+asserting decode-yield floors. A second fixture, `mmr-city-cc.cfile`
+(420.0125 MHz, NAC 0x164 — the issue #402 site), pins the clean-decode case.
+Both are reproducible from their raw recordings via `TestGenerateP25Fixture`
+(`p25_make_fixture_test.go`), so fixture generation is itself tested rather
+than a one-off script.
+
+For captures the repo can't commit, `samples/p25/` is the drop point:
+`TestReplayP25RealCaptureMetrics` (tag `integration`) skips when empty and,
+when a `.cfile` + `.metadata.json` pair appears, reports pre-FEC EVM,
+estimated SNR, FSW sync-margin and NID/TSBK yields — asserting only the
+bounds the metadata declares. This is the instrument Part 12's weak-signal
+ask feeds, and the general pattern
+[Protocol Decoders Part 12]({{ '/blog/deep-dives/protocol-decoders-12-testing-decoders-without-radios/' | relative_url }})
+surveys across every protocol GopherTrunk speaks.
+
+What captures caught that synthetics never did, from this series alone: the
+matched filter's ~sps× level mismatch that collapsed the slicer to outer
+symbols (issue #275 — invisible when the synthetic pre-scales its levels),
+the Gardner gain that only locked on symbol-aligned input (issue #492 —
+fixtures start aligned; real captures never do), and the eye asymmetry that
+made the adaptive slicer *worse* on the #402 site.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 250" width="680" height="250" role="img" aria-label="A four-layer test pyramid for P25. The base layer is literal vectors, pinning wire layouts against independent references. Above it, synthetic streams with modelled RF impairments and a hard BER sweep gate. Above that, committed real-air captures replayed in CI. The apex is on-air verification with an operator. An arrow up the side is labelled increasing power of proof, and an arrow down the other side is labelled increasing cost and scarcity. A note at the base recalls that round-trip tests alone validated the SCCB bug.">
+  <polygon points="340,18 620,222 60,222" fill="none" stroke="var(--fg-muted)"/>
+  <line x1="130" y1="172" x2="550" y2="172" stroke="var(--fg-muted)"/>
+  <line x1="200" y1="120" x2="480" y2="120" stroke="var(--fg-muted)"/>
+  <line x1="270" y1="70" x2="410" y2="70" stroke="var(--fg-muted)"/>
+  <text x="340" y="52" text-anchor="middle" fill="var(--accent)" font-size="10" font-weight="bold">on-air A/B</text>
+  <text x="340" y="64" text-anchor="middle" fill="var(--fg-muted)" font-size="8">operator's own signal</text>
+  <text x="340" y="96" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">committed captures</text>
+  <text x="340" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">mmr-s9-cc.cfile · samples/p25/</text>
+  <text x="340" y="146" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">synthetic streams + impairments</text>
+  <text x="340" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="8">demod.Impairments · BER sweep hard gate</text>
+  <text x="340" y="196" text-anchor="middle" fill="currentColor" font-size="10" font-weight="bold">literal vectors</text>
+  <text x="340" y="210" text-anchor="middle" fill="var(--fg-muted)" font-size="8">independent references · on-air bytes · failing-first</text>
+  <line x1="52" y1="210" x2="130" y2="40" stroke="var(--accent)"/>
+  <polygon points="124,44 132,34 133,46" fill="var(--accent)"/>
+  <text x="30" y="120" fill="var(--accent)" font-size="9" transform="rotate(-65 30 120)">power of proof →</text>
+  <line x1="550" y1="40 " x2="628" y2="210" stroke="var(--fg-muted)"/>
+  <polygon points="622,204 630,214 618,214" fill="var(--fg-muted)"/>
+  <text x="600" y="90" fill="var(--fg-muted)" font-size="9" transform="rotate(65 600 90)">cost &amp; scarcity →</text>
+  <text x="340" y="242" text-anchor="middle" fill="var(--fg-muted)" font-size="9">a round-trip test lives below the base — it proved the SCCB bug "correct"</text>
+</svg>
+<figcaption>Four layers, each catching what the one below cannot — and the round-trip test sits underneath them all, able to validate only its own consistency.</figcaption>
+</figure>
+
+## Rate invariance: proving where a defect is not
+
+The fourth kind of test is the strangest and, in this repo's history, one of
+the most valuable: tests whose job is to *exonerate* a component.
+`internal/scanner/ccdecoder/ddc_highrate_test.go` exists because of the
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764)/#771 saga —
+the same P25 site locking from a 2.5 MS/s capture and failing from a
+10 MS/s one, in pure offline replay. Three tests pin what the investigation
+proved:
+
+| Test | Pins |
+|---|---|
+| `TestDownconverterC4FMLevelRateInvariant` | the same C4FM channel reaches the receiver at the same symbol-domain level from 2.5 and 10 MS/s (the reported failure was a 10–20× AGC level gap) |
+| `TestDownconverterRejectsWidebandNeighbours` | strong off-channel carriers and a DC spike at 10 MS/s must not fold into the ±24 kHz output |
+| `TestDownconverterSNRInvariantAcrossRate` | a noisy channel decimated 4:1 by an *independent* resampler shows the same in-channel SNR as the native path |
+
+The third is the decisive control in miniature: on the real captures,
+decimating the failing 10 MS/s file with an independent resampler and
+replaying it through the proven 2.5 MS/s path reproduced the *same* ~9.5 dB
+SNR — the deficit was baked into the samples (front-end phase noise at the
+Airspy's native clock), not GopherTrunk's DDC. The suite holds that
+conclusion permanently, so the next capture-rate mystery starts at the right
+suspect — the "prove it's the signal" method the
+[weak-signal series formalised]({{ '/blog/deep-dives/weak-signal-engineering-12-proving-signal/' | relative_url }}),
+kin to the hardware-free rigs of
+[RF Front End Part 13]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }}).
+
+## The top of the pyramid: what only air can prove
+
+Every layer below the apex has a blind spot the layer above covers, and the
+apex's blind spot is covered by nothing but a transmitter and an operator.
+The project learned this the expensive way: #764 was closed twice on
+unverified fixes while the symptom was still live, and the repo carries the
+scar as policy — a hook asks for human confirmation before any
+close-as-completed, PRs prefer `Refs #N` over `Closes #N` until a fix is
+verified, and "verified" means a failing-first regression *plus* the reporter
+confirming, or the original symptom reproduced and shown resolved. Green CI,
+at any layer of this pyramid, is not that.
+
+That is why Part 12's equalizer port waits for a capture, and why the
+[testing learn module]({{ '/learn/testing/' | relative_url }}) and this
+series keep repeating one sentence: **green synthetic ≠ on-air correct**.
+The pyramid doesn't eliminate the need for air; it minimises how often you
+need it and maximises what each on-air session proves.
+
+### How the pyramid shaped the Go code
+
+- **Assemblers are exported for tests, and distrusted by policy.** Every
+  `Assemble*` has a `Parse*` round-trip — *and* at least one literal-vector
+  test per format family, because the round-trip alone once cost a real bug.
+- **The impairment model is shared, not per-test.** One `demod.Impairments`
+  serves the sweep, harness and regressions, so a new field (like
+  `FreqDriftHzPerSec`) upgrades every consumer's honesty at once.
+- **Capture tests skip, never rot.** With no capture present the harness
+  skips cleanly, so contributed field truth slots into an existing socket.
+- **Exonerating tests carry their issue numbers.** `ddc_highrate_test.go`
+  names #764/#771 in its comments — the next investigator finds the verdict,
+  not just the assertion.
+
+## Where this goes next
+
+Thirteen parts down, one to go.
+[Part 14]({{ '/blog/deep-dives/p25-end-to-end-14-playbook/' | relative_url }})
+folds the series into what you actually want at the bench: the full layer
+map from antenna to WAV, a failure-signature quick reference, and an honest
+list of what remains open.
+
+## FAQ
+
+**How do I test a P25 decoder without owning a P25 system?**
+In layers: pin wire formats with literal vectors cross-checked against an
+independent implementation (OP25, SDRTrunk), synthesise carriers with
+realistic impairments through the production receiver, and replay real
+captures — your own or contributed ones from `samples/p25/`. GopherTrunk
+ships all three, runnable with `make vet test` plus the `integration`-tagged
+replay suite.
+
+**Why isn't a passing round-trip test good enough for a protocol parser?**
+Because both directions were written from the same reading of the spec. If
+the reading is wrong, encoder and decoder agree with each other and disagree
+with the air — the SCCB 0x39 bug shipped exactly that way. A literal vector
+from an independent source breaks the symmetry.
+
+**What makes a good capture fixture?**
+Short, real, annotated: ~1 second of on-channel IQ (about 400 KB as a 48 kHz
+`.cfile`) covers several sync/NID/TSBK cycles, and a metadata sidecar with
+sample rate, NAC and expected yields turns it into a permanent regression.
+Larger contributions go through the git-ignored `samples/` route with
+committed sidecars.
+
+**Can synthetic tests measure demod quality, or just catch regressions?**
+Both, carefully. The BER sweep measures real implementation loss against
+closed-form references — that's where the ~3.85 dB (CQPSK) and ~23.8 dB
+(C4FM) figures come from. But its *gate* is deliberately a ceiling, not a
+target: it proves the demod never gets worse, while improvement claims are
+reserved for capture A/Bs.
+
+**What can only on-air testing prove?**
+That a fix addresses the reporter's actual conditions — the impairments you
+didn't think to model, the traffic your synthetic never generated, the
+hardware you don't own. That's why issue-closing is gated on a verified
+symptom, not a green suite.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: The Weak-Signal Gap — P1 Voice's Missing Levers]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})
+· Next →
+[Part 14: The P25 Playbook]({{ '/blog/deep-dives/p25-end-to-end-14-playbook/' | relative_url }})

--- a/docs/_posts/2026-09-15-p25-end-to-end-13-testing-p25.md
+++ b/docs/_posts/2026-09-15-p25-end-to-end-13-testing-p25.md
@@ -216,7 +216,7 @@ made the adaptive slicer *worse* on the #402 site.
   <line x1="52" y1="210" x2="130" y2="40" stroke="var(--accent)"/>
   <polygon points="124,44 132,34 133,46" fill="var(--accent)"/>
   <text x="30" y="120" fill="var(--accent)" font-size="9" transform="rotate(-65 30 120)">power of proof →</text>
-  <line x1="550" y1="40 " x2="628" y2="210" stroke="var(--fg-muted)"/>
+  <line x1="550" y1="40" x2="628" y2="210" stroke="var(--fg-muted)"/>
   <polygon points="622,204 630,214 618,214" fill="var(--fg-muted)"/>
   <text x="600" y="90" fill="var(--fg-muted)" font-size="9" transform="rotate(65 600 90)">cost &amp; scarcity →</text>
   <text x="340" y="242" text-anchor="middle" fill="var(--fg-muted)" font-size="9">a round-trip test lives below the base — it proved the SCCB bug "correct"</text>

--- a/docs/_posts/2026-09-16-from-spec-to-shipping-14-definition-of-verified.md
+++ b/docs/_posts/2026-09-16-from-spec-to-shipping-14-definition-of-verified.md
@@ -1,0 +1,297 @@
+---
+title: "From Spec to Shipping, Part 14: The Definition of Verified"
+description: The finale — closing an issue is a claim the problem is gone, and GopherTrunk defines exactly when that claim is earned. The issue-closing policy, the guard hook that asks a human before any close, Refs versus Closes, and the full shipping checklist from spec to verified.
+category: deep-dives
+keywords: when to close a bug as fixed, verified fix definition, issue closing policy, refs vs closes github, regression test plus reporter confirmation, pretooluse guard hook, protocol decoder shipping checklist, gophertrunk from spec to shipping
+tags: [from-spec-to-shipping, verification, issues, process, methodology, testing]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "From Spec to Shipping"
+series_part: 14
+---
+
+*Part 14 — the last — of **From Spec to Shipping**, a 14-part series on how a
+protocol decoder actually gets written — from standards documents and
+independent references to code you can trust on air. We have read the spec,
+chosen references, pinned parsers with literal vectors, built conformance
+harnesses, refereed disagreements with captures, made tests that can
+disagree, gated claims on the air, failed first, and — in
+[Part 13]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})
+— instrumented the result. One act remains, and it is the one this project
+got wrong in public: saying the problem is *gone*. This finale defines
+"verified," shows the machinery that enforces the definition, and folds the
+whole series into one shipping checklist.*
+
+> **TL;DR:** Closing an issue is a **claim that the reported problem is
+> gone**, and GopherTrunk's policy (`CLAUDE.md`, "Issue-closing policy")
+> defines when that claim is earned: a **failing-first regression test now
+> passes AND the reporter has confirmed it** — or you reproduced the original
+> symptom yourself and showed the change resolves it. The policy exists
+> because [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) was
+> closed **twice** on an unverified fix while the symptom stayed live
+> ([#771](https://github.com/MattCheramie/GopherTrunk/issues/771)); a
+> PreToolUse guard (`.claude/hooks/guard-issue-close.py`) now asks for human
+> confirmation before any close-as-completed. Until verification lands, PRs
+> say **`Refs #N`, not `Closes #N`** — so a merge can't auto-close an
+> unverified issue — and every reply addresses the reporter's **latest
+> follow-up**, never a re-post of the original fix description.
+
+**Key takeaways**
+
+- **"Fixed" and "verified" are different states, and only one closes an
+  issue.** A merged fix is a hypothesis with good syntax; verification is a
+  failing-first test passing *plus* the symptom demonstrably gone — ideally
+  in the reporter's own confirmation.
+- **When you can't verify, leave it open.** A concise status comment — what
+  you found, what's blocking — is a better artifact than an optimistic close,
+  and it's what the policy requires.
+- **Process failures get engineering fixes too.** The same project that pins
+  parsers with literal vectors pins its own closing behaviour with a guard
+  hook — an "ask" gate, not a hard block, on exactly the risky action.
+- **The whole series is one pipeline of gates.** Constants cited, vectors
+  pinned, conformance bit-identical, synthetics faithful, captures refereeing,
+  regressions failing first, instruments counting — and at the end, a human
+  confirming the claim. No stage substitutes for another.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| The policy | close = verified claim; unverified stays open with a status comment | `CLAUDE.md` ("Issue-closing policy") |
+| The guard | asks a human before any close-as-completed; `not_planned`/`duplicate` pass freely | `.claude/hooks/guard-issue-close.py` |
+| PR linking | `Refs #N` until verified, so a merge can't auto-close | `CLAUDE.md`; PR convention |
+| The cautionary tale | closed twice unverified; symptom still live | [#764](https://github.com/MattCheramie/GopherTrunk/issues/764) / [#771](https://github.com/MattCheramie/GopherTrunk/issues/771) |
+| Follow-up discipline | answer the latest comment, not the original report | `CLAUDE.md` (policy + daily issue review) |
+| The reporter loop | env-gated replay tests + verdict lines the reporter runs | [Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }}), [Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }}) |
+
+## In this post
+
+- **A close is a claim** — the policy, stated precisely.
+- **The issue that was closed twice** — how #764 became #771, and why.
+- **The guard at the gate** — a hook that makes the risky action ask.
+- **Refs, not Closes — and answer the latest follow-up** — the small habits
+  that carry the policy.
+- **The shipping checklist** — Parts 1–13 as one table of gates.
+
+## A close is a claim
+
+Strip the tooling away and closing an issue is a speech act: *the problem you
+reported is gone.* Everything in this series has been about not making claims
+above their evidence — a constant is cited or it's a
+[placeholder]({{ '/blog/solution-postmortem/from-the-issue-tracker-17-placeholder-constants/' | relative_url }});
+a decoder is synthetic-green, capture-verified, or on-air-verified and never
+more ([Part 10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})).
+The close is simply the last claim in the chain, and it gets the same
+treatment. GopherTrunk's policy defines the evidence that earns it:
+
+- **A failing-first regression test now passes** — the
+  [Part 12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})
+  artifact — **and the reporter has confirmed the fix**; or you reproduced
+  the original symptom yourself and showed this change resolves it.
+- **When you can't verify, leave it open** — post a concise status comment
+  saying what you found and what's blocking (a capture, a config, the
+  reporter's hardware), rather than closing.
+- Closing as `not_planned` or `duplicate` is fine and ungated — those are
+  claims about *scope*, not about the problem being gone.
+
+Note what the definition refuses to accept: a merged PR, a green CI run, a
+plausible root-cause narrative, or the author's confidence. Every one of
+those was present, twice, in the story that created the policy.
+
+## The issue that was closed twice
+
+[#764](https://github.com/MattCheramie/GopherTrunk/issues/764) reported a
+decode deficit on high-sample-rate captures. A fix was written, tests were
+green, the issue was closed. The symptom persisted; it was reopened, fixed
+again, closed again — and the symptom was *still* live, resurfacing as
+[#771](https://github.com/MattCheramie/GopherTrunk/issues/771). The
+mechanical cause was a twin-path trap this project has since learned to name:
+`gophertrunk replay -tune-hz` uses the single-channel
+`ccdecoder.Downconverter`, **not** the wideband `DDCBank` — two separate
+down-converter paths, so a fix to one does not touch the other, and the #764
+"fix" missed the #771 replay symptom entirely.
+
+The deeper cause was epistemic: nobody had watched the symptom die. Both
+closes re-posted the fix description as their justification — a claim about
+the *code*, when a close is a claim about the *symptom*. When #764 finally
+did close for good, it closed the right way: the reporter's own captures were
+replayed, the deficit was shown to be **baked into the samples** (the same
+~9.5 dB through an independent resampler and the proven decode path), and
+`TestDownconverterSNRInvariantAcrossRate` pinned the conclusion. The
+verification didn't just permit the close — it produced the actual root
+cause, which the two premature closes had gotten wrong.
+
+## The guard at the gate
+
+Policies decay; gates don't. So the policy got what every other rule in this
+series got — enforcement machinery on exactly the risky action. A PreToolUse
+hook intercepts issue writes before they execute, lets everything harmless
+through, and turns a close-as-completed into a question a human must answer:
+
+```python
+# .claude/hooks/guard-issue-close.py (shape)
+# Stops a GitHub issue being closed as *completed* ("fixed") without a
+# human in the loop — because #764 was closed twice with a comment that
+# merely repeated the fix description while the symptom was still live.
+is_close_completed = (
+    ti.get("method") == "update"
+    and ti.get("state") == "closed"
+    and ti.get("state_reason") in (None, "", "completed")
+)
+if not is_close_completed:
+    return 0  # allow: comments, labels, reopens, not_planned, duplicate
+# Otherwise: emit an "ask" decision — the close proceeds only once a human
+# confirms the fix is genuinely verified.
+```
+
+Three design choices are worth stealing. It gates **only** the dangerous
+verb — closing as completed — so it never trains anyone to click through it
+on routine work. It **asks** rather than blocks: the reason text restates the
+verification bar and offers the alternative (cancel, post a status comment,
+leave it open), keeping the human's judgment in the loop rather than
+replacing it. And it fails open — always exits 0 on malformed input — because
+*a guard must never become a hard failure that blocks work*, or it gets
+removed. The parallel to Part 13 is exact: this is a WARN with a human as the
+persistence gate.
+
+## Refs, not Closes — and answer the latest follow-up
+
+Two small habits carry the policy day to day. First, **PRs say `Refs #764`,
+not `Closes #764`, until the fix is verified** — because GitHub auto-closes
+on merge, and auto-close is precisely the unverified claim the policy
+forbids, made by a robot on your behalf. `Closes` is earned at the same
+moment the close itself is.
+
+Second, **address the latest follow-up, not the original report**. Both bad
+#764 closes re-posted the initial fix description — a reply to a comment
+nobody had just made. The daily issue review bakes the discipline in: each
+pass surfaces issues *updated since the prior day* and distinguishes genuine
+new reporter responses from maintainer replies, so the thing being answered
+is always the newest evidence. A reporter's follow-up is field data —
+[Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})'s
+most valuable input — and answering an old comment instead is how a thread
+ships the same wrong claim twice.
+
+## The shipping checklist
+
+Fourteen parts, one pipeline. Each stage produces an artifact, and each
+artifact has a gate it must pass before the next claim is allowed:
+
+| Stage | Artifact | Gate |
+|---|---|---|
+| Read the spec ([1]({{ '/blog/deep-dives/from-spec-to-shipping-01-reading-a-radio-standard/' | relative_url }})) | named constants: sync, CRC, offsets | every constant carries its section citation |
+| Choose references ([2]({{ '/blog/deep-dives/from-spec-to-shipping-02-choosing-references/' | relative_url }})) | a reference stable with known authority | proven on air beats popular |
+| Pin the parser ([3]({{ '/blog/deep-dives/from-spec-to-shipping-03-literal-vectors/' | relative_url }})) | literal byte vectors | cross-checked against an independent decoder |
+| Conform ([4]({{ '/blog/deep-dives/from-spec-to-shipping-04-conformance-harness/' | relative_url }})) | skip-guarded reference harness | bit-identical output, at two layers |
+| Stay clean ([5]({{ '/blog/deep-dives/from-spec-to-shipping-05-clean-room-rules/' | relative_url }})) | oracle comparisons, license hygiene | outputs compared; source never translated |
+| Referee disputes ([6]({{ '/blog/deep-dives/from-spec-to-shipping-06-when-references-disagree/' | relative_url }}), [11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})) | a measurement on a real capture | the right answer wins by a wide margin — or no pick |
+| Harden the tests ([7]({{ '/blog/deep-dives/from-spec-to-shipping-07-tests-that-can-disagree/' | relative_url }})) | unconditional encodes, strict fakes, faithful synthetics | the test is *able* to disagree with you |
+| Pin the wire ([8]({{ '/blog/deep-dives/from-spec-to-shipping-08-smartnet-rebuild/' | relative_url }}), [9]({{ '/blog/deep-dives/from-spec-to-shipping-09-wire-protocols-without-schemas/' | relative_url }})) | framing and opcodes from upstream literals | reference-literal tests catch constant drift |
+| Stage the claim ([10]({{ '/blog/deep-dives/from-spec-to-shipping-10-the-on-air-gate/' | relative_url }})) | a status: synthetic-green / capture-verified / on-air-verified | no claim above its evidence |
+| Fix bugs ([12]({{ '/blog/deep-dives/from-spec-to-shipping-12-failing-first/' | relative_url }})) | a failing-first regression | fails without the fix, passes with it |
+| Instrument ([13]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})) | branch-complete counters, persistent WARNs | designed for the *next* investigation |
+| Close (this part) | the verified claim | regression passes **and** the reporter confirms — a human says so |
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 200" width="680" height="200" role="img" aria-label="The shipping pipeline as five gates in sequence: spec-cited constants, reference-pinned parser, faithful synthetics green, capture verified, on-air verified with reporter confirmation — then a human-confirmation diamond guarding the final closed state. A side note marks not-planned and duplicate closes as bypassing the guard, and a label under each gate names the claim allowed at that stage.">
+  <rect x="14" y="52" width="102" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="65" y="69" text-anchor="middle" fill="currentColor" font-size="9">spec-cited</text>
+  <text x="65" y="82" text-anchor="middle" fill="currentColor" font-size="9">constants</text>
+  <line x1="116" y1="72" x2="136" y2="72" stroke="currentColor"/><polygon points="134,68 142,72 134,76" fill="currentColor"/>
+  <rect x="144" y="52" width="102" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="195" y="69" text-anchor="middle" fill="currentColor" font-size="9">reference-pinned</text>
+  <text x="195" y="82" text-anchor="middle" fill="currentColor" font-size="9">parser + vectors</text>
+  <line x1="246" y1="72" x2="266" y2="72" stroke="currentColor"/><polygon points="264,68 272,72 264,76" fill="currentColor"/>
+  <rect x="274" y="52" width="102" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="325" y="69" text-anchor="middle" fill="currentColor" font-size="9">faithful synthetics</text>
+  <text x="325" y="82" text-anchor="middle" fill="currentColor" font-size="9">green</text>
+  <line x1="376" y1="72" x2="396" y2="72" stroke="currentColor"/><polygon points="394,68 402,72 394,76" fill="currentColor"/>
+  <rect x="404" y="52" width="102" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="455" y="69" text-anchor="middle" fill="var(--accent)" font-size="9">capture-verified</text>
+  <text x="455" y="82" text-anchor="middle" fill="var(--accent)" font-size="9">(replay A/B)</text>
+  <line x1="506" y1="72" x2="526" y2="72" stroke="currentColor"/><polygon points="524,68 532,72 524,76" fill="currentColor"/>
+  <rect x="534" y="52" width="130" height="40" rx="6" fill="none" stroke="var(--accent)" stroke-width="2"/>
+  <text x="599" y="69" text-anchor="middle" fill="var(--accent)" font-size="9">on-air-verified +</text>
+  <text x="599" y="82" text-anchor="middle" fill="var(--accent)" font-size="9">reporter confirms</text>
+  <text x="65" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">claim: "transcribed"</text>
+  <text x="195" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">claim: "matches refs"</text>
+  <text x="325" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">claim: "should work"</text>
+  <text x="455" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">claim: "works on this capture"</text>
+  <text x="599" y="110" text-anchor="middle" fill="var(--fg-muted)" font-size="8">claim: "the problem is gone"</text>
+  <line x1="599" y1="92" x2="599" y2="128" stroke="var(--accent)"/><polygon points="595,126 599,134 603,126" fill="var(--accent)"/>
+  <path d="M 599 134 L 641 154 L 599 174 L 557 154 Z" fill="none" stroke="var(--accent)"/>
+  <text x="599" y="151" text-anchor="middle" fill="var(--accent)" font-size="8">guard hook:</text>
+  <text x="599" y="162" text-anchor="middle" fill="var(--accent)" font-size="8">human confirms</text>
+  <line x1="557" y1="154" x2="500" y2="154" stroke="currentColor"/><polygon points="502,150 494,154 502,158" fill="currentColor"/>
+  <rect x="404" y="140" width="90" height="28" rx="6" fill="none" stroke="currentColor"/>
+  <text x="449" y="158" text-anchor="middle" fill="currentColor" font-size="9">CLOSED</text>
+  <text x="290" y="158" text-anchor="middle" fill="var(--fg-muted)" font-size="8">not_planned / duplicate: ungated (claims about scope, not the symptom)</text>
+</svg>
+<figcaption>Each gate licenses exactly one claim — and the last claim, "the problem is gone," passes through a human before it becomes a closed issue.</figcaption>
+</figure>
+
+The through-line, one last time: the running villain of this series was the
+test that passes because both sides share the same assumption, and every gate
+above is a way of importing a fact from *outside* the loop — a spec section,
+an independent decoder, a reference codec, a capture, an operator, and
+finally a reporter saying "it works now." Verification is not a phase at the
+end. It is the habit of never letting your own assumption referee itself.
+
+## Where to go from here
+
+This series taught the method forward; its source material runs the other
+way. [From the Issue Tracker]({{ '/blog/series/from-the-issue-tracker/' | relative_url }})
+tells the same lessons as postmortems — the fabricated framing, the
+self-consistent traps, the two-pipelines drift — with the scars visible.
+[P25 End to End Part 13]({{ '/blog/deep-dives/p25-end-to-end-13-testing-p25/' | relative_url }})
+applies this discipline to P25's twin decode paths, literal vectors to
+capture metrics. The
+[testing learn module]({{ '/learn/testing/' | relative_url }}) covers the
+underlying craft — including capture-gated verification — from first
+principles. And if you'd rather *run* the thing all this rigor produced, the
+[Operator's Cookbook]({{ '/blog/series/operator-cookbook/' | relative_url }})
+starts from a config file instead of a spec. Best of all: contribute a
+capture. Half the open items in this project are blocked on evidence, not
+effort, and [Part 11]({{ '/blog/deep-dives/from-spec-to-shipping-11-capture-driven-development/' | relative_url }})
+shows exactly what to record.
+
+## FAQ
+
+**Why not close an issue as soon as the fix is merged?**
+Because merging proves the code changed, not that the symptom died — and
+those came apart, twice, on the same issue. The #764 fix was merged, green,
+and wrong about the root cause; only replaying the reporter's captures
+produced the real one. `Refs` on the PR plus a verified close later costs one
+extra click and prevents shipping a claim you can't back.
+
+**What if the reporter never responds to confirm?**
+The policy's second branch covers it: reproduce the original symptom yourself
+and show the change resolves it — a capture replayed through a failing-first
+harness is a reporter-independent verification. If you can do neither, the
+issue stays open with a status comment; an open issue that's honest beats a
+closed one that's optimistic.
+
+**Isn't a guard hook overkill for a process rule?**
+It's proportionate to the failure it prevents: the same mistake made twice on
+one issue by people who knew better. Rules that live in documents decay under
+deadline pressure; the hook re-states the bar at the exact moment of the
+risky action, gates nothing else, and asks rather than blocks — the cheapest
+intervention that actually changes behaviour.
+
+**Does the gate apply to closing as not_planned or duplicate?**
+No — those pass through freely, by design. They claim "we won't do this" or
+"this is tracked elsewhere," which requires judgment but not verification.
+Only `completed` claims the reported problem is gone, and only that claim
+needs evidence of the symptom's death.
+
+**What's the single habit to adopt from this series?**
+Before any confident claim — this parser is correct, this fix works, this
+issue is done — ask *what fact from outside my own loop says so?* A cited
+section, an independent decoder, a capture, a reporter. If the answer is
+"my test agrees with my code," you have the series villain, not evidence.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: Instruments, Not Logs]({{ '/blog/deep-dives/from-spec-to-shipping-13-instruments-not-logs/' | relative_url }})
+· [Back to the series index]({{ '/blog/series/from-spec-to-shipping/' | relative_url }})

--- a/docs/_posts/2026-09-16-operator-cookbook-14-kitchen-sink-config.md
+++ b/docs/_posts/2026-09-16-operator-cookbook-14-kitchen-sink-config.md
@@ -14,12 +14,11 @@ series_part: 14
 complete, copy-paste GopherTrunk builds — one working rig per part, antenna to
 browser. Thirteen recipes ago the rig was one $40 dongle and four config
 blocks; along the way it learned trunked DMR and TETRA, analog and tone-out,
-grew extra dongles and remote radios, started streaming, archiving, running
-headless, combining two antennas, and calling everything by name. This
-closing part is the map of the territory: one kitchen-sink `config.yaml`
-walked top to bottom, every block stamped with the part that owns it, plus
-the decision table that turns "what do I want?" into "which part do I read?"
-— and the hygiene habits that keep a config this grown-up honest.*
+grew remote radios and a second antenna, started streaming, archiving,
+running headless, and calling everything by name. This closing part is the
+map: one kitchen-sink `config.yaml` walked top to bottom, every block stamped
+with the part that owns it, plus the decision table that turns "what do I
+want?" into "which part do I read?".*
 
 > **TL;DR:** A full GopherTrunk config is about ten top-level sections, and
 > the cookbook covered each where it mattered: `sdr` (Parts 1–2, 7–8, 12),

--- a/docs/_posts/2026-09-16-operator-cookbook-14-kitchen-sink-config.md
+++ b/docs/_posts/2026-09-16-operator-cookbook-14-kitchen-sink-config.md
@@ -1,0 +1,338 @@
+---
+title: "The Operator's Cookbook, Part 14: The Kitchen-Sink Config, Annotated"
+description: "The series finale: one full GopherTrunk config.yaml walked section by section — sdr to systems to recordings to broadcast to api — each block annotated with the cookbook part that owns it, a decision table from goal to recipe, and the config hygiene that keeps a growing rig maintainable."
+category: tutorials
+keywords: gophertrunk config.yaml reference, sdr scanner configuration guide, trunking scanner config example, config.example.yaml annotated, sdr config best practices, scanner software setup guide, gophertrunk full config, config hygiene sdr daemon, gophertrunk cookbook
+tags: [operator-cookbook, config, reference, finale, operations]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "The Operator's Cookbook"
+series_part: 14
+---
+
+*Part 14 — the last — of **The Operator's Cookbook**, a 14-part series of
+complete, copy-paste GopherTrunk builds — one working rig per part, antenna to
+browser. Thirteen recipes ago the rig was one $40 dongle and four config
+blocks; along the way it learned trunked DMR and TETRA, analog and tone-out,
+grew extra dongles and remote radios, started streaming, archiving, running
+headless, combining two antennas, and calling everything by name. This
+closing part is the map of the territory: one kitchen-sink `config.yaml`
+walked top to bottom, every block stamped with the part that owns it, plus
+the decision table that turns "what do I want?" into "which part do I read?"
+— and the hygiene habits that keep a config this grown-up honest.*
+
+> **TL;DR:** A full GopherTrunk config is about ten top-level sections, and
+> the cookbook covered each where it mattered: `sdr` (Parts 1–2, 7–8, 12),
+> `trunking.systems` (Parts 1–5), `scanner`/`tone_out` (Part 6),
+> `recordings`/`retention`/`baseband` (Part 10), `broadcast` (Part 9),
+> `api`/`web` (Parts 1, 11), `storage` + alias files (Part 13). Most keys
+> should stay at their defaults — the authoritative, commented reference is
+> `config.example.yaml`, with `internal/config/config.go` behind it. The
+> golden rules: paths resolve **relative to the folder containing
+> config.yaml**, `gain` is in **tenths of a dB**, secrets go in `token_file`
+> and environment variables, and every change is one knob at a time with the
+> log watched.
+
+**Key takeaways**
+
+- **The config is organized by subsystem; your goals aren't.** That's what
+  this series was for — the decision table below maps intent to recipe, and
+  the annotated config maps each block back to its part.
+- **Defaults are load-bearing.** Per-protocol FEC is on without any YAML;
+  timeouts, hangtime and the DSP knobs ship at values earned on real
+  captures. The `*_mode: "off"` opt-outs exist for pre-stripped test
+  fixtures, not for tuning.
+- **`config.example.yaml` is the source of truth.** Every key in this series
+  exists there with a comment; if a blog post, forum tip or old gist
+  disagrees with it, the example file wins.
+- **A config is maintainable when every line is explainable.** The starter
+  rig had three numbers you chose. Keep that property as it grows: know which
+  part of this series justifies each block you've added.
+
+## Cheat sheet
+
+| Config section | What it owns | Cookbook part |
+|---|---|---|
+| `sdr` | dongles, roles, wideband channels, remote radios, diversity | [1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}), [7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }}), [8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }}), [12]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }}) |
+| `trunking.systems` | protocols, control channels, band plans, per-system policy | [1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})–[5]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }}) |
+| `scanner`, `tone_out` | conventional channels, scan modes, paging tones | [6]({{ '/blog/tutorials/operator-cookbook-06-analog-fm-tone-out/' | relative_url }}), [7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }}) |
+| `recordings`, `retention`, `baseband` | formats, FLAC, sweeper, IQ captures | [10]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }}) |
+| `broadcast` | Broadcastify, Rdio Scanner, OpenMHz, Icecast, webhooks | [9]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }}) |
+| `api`, `web`, `audio` | HTTP/auth posture, tabs, live audio | [1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}), [11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }}) |
+| `storage` + alias files | call log, labels, talkgroup/RID names | [10]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }}), [13]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }}) |
+
+## In this post
+
+- **The map** — the kitchen-sink config, block by block, part by part.
+- **The decision table** — what do you want? → which part.
+- **Knobs that matter, defaults to leave alone** — where tuning helps and where it hurts.
+- **Config hygiene** — paths, units, secrets, and the web's write mode.
+- **Where to go from here** — the series wrap, and what to read next.
+
+## The map
+
+Here is a rig that has absorbed all thirteen recipes, abridged to the keys
+that carry weight. Every key exists in `config.example.yaml`; every `← Part`
+note is a link target in this series:
+
+```yaml
+log:
+  level: info                       # debug adds per-call audio-quality lines
+
+storage:
+  path: "../data/calls.db"          # call log + labels  ← Parts 10, 13
+
+recordings:
+  dir: "../recordings"
+  format: flac                      # lossless, ~half of WAV  ← Part 10
+  mbe_files: false                  # DSD-FME sidecars       ← Part 10
+  enhance:
+    enabled: false                  # faithful by default; OP25-ish when on
+
+retention:
+  call_log_days: 30                 # the sweeper            ← Part 10
+  files_days: 14
+  interval: "1h"
+
+sdr:
+  sample_rate: 2_400_000
+  autotune: false                   # ppm suggester           ← Part 1
+  devices:
+    - serial: "00000001"            # the original $40 stick  ← Part 1
+      role: wideband
+      gain: "auto"                  # TENTHS of a dB if fixed
+      center_freq_hz: 858_000_000
+      voice_taps: 2
+      channels:
+        - frequency_hz: 857_262_500
+          system: "Metro-P25"
+    - serial: "00000002"            # spill-over voice        ← Part 7
+      role: voice
+      gain: "auto"
+  rtl_tcp: []                       # radios far away         ← Part 8
+  soapy_remote: []                  # USRP-class + diversity  ← Parts 8, 12
+
+trunking:
+  voice_hangtime_ms: 3500           # leave alone (see below)
+  systems:
+    - name: "Metro-P25"
+      protocol: p25                 #                         ← Part 1
+      control_channels: [857_262_500, 858_487_500]
+      talkgroup_file: "../config/talkgroups-p25.csv"   # ← Part 13
+      rid_alias_file: "../config/rids-p25.csv"         # ← Part 13
+    - name: "Regional-DMR"
+      protocol: dmr                 # Tier III + band plan    ← Part 2
+      control_channels: [851_037_500]
+      # dmr_band_plan omitted → learned off the air
+
+scanner:
+  scan_mode: all                    # all | list              ← Part 7
+  conventional: []                  # analog FM channels      ← Part 6
+
+tone_out:
+  profiles: []                      # two-tone fire paging    ← Part 6
+
+broadcast:                          # outbound feeds          ← Part 9
+  min_duration_ms: 0
+  # broadcastify: / rdioscanner: / openmhz: / icecast: / webhook:
+
+baseband:                           # IQ capture & replay     ← Part 10
+  # record: / replay: / auto_record:
+
+audio:
+  enabled: false                    # live speakers, off headless
+
+api:
+  http_addr: "127.0.0.1:8080"       #                         ← Part 1
+  auth:
+    mode: "auto"                    # LAN posture             ← Part 11
+    # token_file: "../config/api-token"
+
+metrics:
+  enabled: true                     # /metrics for the watchdogs ← Part 11
+```
+
+Two structural observations that only show up at this altitude. First, the
+config has a **radio half and an output half** — `sdr` + `trunking` decide
+what gets decoded; `recordings`/`broadcast`/`api` decide where it goes — and
+they scale independently, which is why Part 7's many-systems build and Part
+9's streaming build never stepped on each other. Second, **systems are the
+join point**: a `channels:` entry on a dongle, a `system:` filter on a feed,
+and an alias file all reference `trunking.systems[].name` — keep those names
+stable, because half the config points at them.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 235" width="680" height="235" role="img" aria-label="The kitchen-sink config drawn as a map: a radio half containing the sdr block labelled parts 1, 7, 8 and 12 and the trunking systems block labelled parts 1 through 5, joined by system names to an output half containing recordings and retention labelled part 10, broadcast labelled part 9, api and web labelled parts 1 and 11, and alias files labelled part 13; scanner and tone_out sit with the radio half labelled part 6.">
+  <rect x="14" y="30" width="310" height="190" rx="8" fill="none" stroke="var(--fg-muted)" stroke-dasharray="5 4"/>
+  <text x="169" y="48" text-anchor="middle" fill="var(--fg-muted)" font-size="10">radio half — what gets decoded</text>
+  <rect x="30" y="60" width="130" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="95" y="80" text-anchor="middle" fill="currentColor" font-size="10">sdr</text>
+  <text x="95" y="96" text-anchor="middle" fill="var(--accent)" font-size="9">Parts 1 · 7 · 8 · 12</text>
+  <rect x="178" y="60" width="130" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="243" y="80" text-anchor="middle" fill="currentColor" font-size="10">trunking.systems</text>
+  <text x="243" y="96" text-anchor="middle" fill="var(--accent)" font-size="9">Parts 1–5</text>
+  <rect x="30" y="140" width="130" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="95" y="160" text-anchor="middle" fill="currentColor" font-size="10">scanner · tone_out</text>
+  <text x="95" y="176" text-anchor="middle" fill="var(--accent)" font-size="9">Part 6 (· 7)</text>
+  <rect x="178" y="140" width="130" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="243" y="160" text-anchor="middle" fill="currentColor" font-size="10">alias files</text>
+  <text x="243" y="176" text-anchor="middle" fill="var(--accent)" font-size="9">Part 13</text>
+  <line x1="324" y1="118" x2="368" y2="118" stroke="var(--accent)" stroke-width="2"/>
+  <polygon points="362,113 372,118 362,123" fill="var(--accent)"/>
+  <text x="347" y="106" text-anchor="middle" fill="var(--accent)" font-size="9">system names</text>
+  <rect x="372" y="30" width="294" height="190" rx="8" fill="none" stroke="var(--fg-muted)" stroke-dasharray="5 4"/>
+  <text x="519" y="48" text-anchor="middle" fill="var(--fg-muted)" font-size="10">output half — where it goes</text>
+  <rect x="388" y="60" width="128" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="452" y="80" text-anchor="middle" fill="currentColor" font-size="10">recordings · retention</text>
+  <text x="452" y="96" text-anchor="middle" fill="var(--accent)" font-size="9">Part 10</text>
+  <rect x="530" y="60" width="120" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="590" y="80" text-anchor="middle" fill="currentColor" font-size="10">broadcast</text>
+  <text x="590" y="96" text-anchor="middle" fill="var(--accent)" font-size="9">Part 9</text>
+  <rect x="388" y="140" width="128" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="452" y="160" text-anchor="middle" fill="currentColor" font-size="10">api · web · audio</text>
+  <text x="452" y="176" text-anchor="middle" fill="var(--accent)" font-size="9">Parts 1 · 11</text>
+  <rect x="530" y="140" width="120" height="52" rx="5" fill="none" stroke="currentColor"/>
+  <text x="590" y="160" text-anchor="middle" fill="currentColor" font-size="10">storage</text>
+  <text x="590" y="176" text-anchor="middle" fill="var(--accent)" font-size="9">Parts 10 · 13</text>
+</svg>
+<figcaption>The config at map scale: a radio half and an output half joined by system names — and every block stamped with the cookbook part that explains it.</figcaption>
+</figure>
+
+## The decision table
+
+The series was organized by goal; here is the whole thing as a lookup:
+
+| What do you want? | Read | The load-bearing keys |
+|---|---|---|
+| Hear a local P25 system for ~$40 | [Part 1]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }}) | `role: wideband`, `voice_taps`, `control_channels` |
+| Trunked DMR (Tier III) | [Part 2]({{ '/blog/tutorials/operator-cookbook-02-dmr-tier3/' | relative_url }}) | `protocol: dmr`, `dmr_band_plan` (or let it learn) |
+| Two conversations off one DMR repeater | [Part 3]({{ '/blog/tutorials/operator-cookbook-03-conventional-dmr-two-slots/' | relative_url }}) | `protocol: dmr-tier2`, `dmr_interleaved_voice` |
+| TETRA, infrastructure or direct mode | [Part 4]({{ '/blog/tutorials/operator-cookbook-04-tetra-tmo/' | relative_url }}) / [Part 5]({{ '/blog/tutorials/operator-cookbook-05-tetra-dmo/' | relative_url }}) | `protocol: tetra` / `tetra-dmo`, `tetra_mcc`/`tetra_mnc` |
+| Analog FM, marine, fire tone-out | [Part 6]({{ '/blog/tutorials/operator-cookbook-06-analog-fm-tone-out/' | relative_url }}) | `scanner.conventional`, `tone_out.profiles` |
+| Several systems on one box | [Part 7]({{ '/blog/tutorials/operator-cookbook-07-multi-system-pool/' | relative_url }}) | device roles, `scan_mode`, priorities |
+| Antenna far from the decoder | [Part 8]({{ '/blog/tutorials/operator-cookbook-08-remote-radios/' | relative_url }}) | `rtl_tcp`, `soapy_remote`, `ka9q_radio` |
+| Feed Broadcastify / Rdio / OpenMHz | [Part 9]({{ '/blog/tutorials/operator-cookbook-09-sharing-the-feed/' | relative_url }}) | `broadcast.*` backends |
+| Keep everything, forever, small | [Part 10]({{ '/blog/tutorials/operator-cookbook-10-archival-rig/' | relative_url }}) | `recordings.format: flac`, `retention` |
+| Run 24/7 in a closet | [Part 11]({{ '/blog/tutorials/operator-cookbook-11-closet-appliance/' | relative_url }}) | `api.auth`, `metrics`, systemd/Docker |
+| A second antenna against fading | [Part 12]({{ '/blog/tutorials/operator-cookbook-12-diversity-mrc/' | relative_url }}) | `diversity: mrc`, `antenna:`, `diversity_capture` |
+| Names instead of numbers | [Part 13]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }}) | `talkgroup_file`, `rid_alias_file`, labels |
+
+## Knobs that matter, defaults to leave alone
+
+**Worth setting deliberately:** the handful of numbers each recipe made you
+choose. Device serials, `center_freq_hz` and `sample_rate` (your spectrum),
+`gain` (staged, in tenths, per
+[The Analog Edge]({{ '/blog/tutorials/analog-edge-03-gain-staging/' | relative_url }})),
+`control_channels` (all the alternates), `voice_taps` (your concurrency),
+the storage/recordings paths and retention windows (your disk), and
+`api.auth.mode` the moment the daemon binds off loopback.
+
+**Leave alone until a symptom names them:**
+
+- **The FEC opt-outs** (`motorola_bch_mode`, `tetra_channel_coding`,
+  `p25_phase2_trellis_mode`, …). Per-protocol FEC is **on by default with no
+  YAML at all**; these keys exist for pre-stripped capture fixtures. Turning
+  one "off" on a live system just breaks decode.
+- **`call_timeout_ms` / `voice_hangtime_ms`** — 30 s and 3.5 s were chosen
+  against real systems; shorten them only for a documented reason
+  ([call assembly]({{ '/blog/deep-dives/recording-streaming-03-assembling-a-call/' | relative_url }})).
+- **`recordings.equalizer` / `enhance` internals** — the corners and targets
+  mirror OP25-class defaults; toggle `enhance.enabled`, don't sculpt filters
+  before listening.
+- **`watchdog_interval_ms`, `tuner_strategy: auto`, `cc_hunt` backoffs** —
+  operational machinery with field-tested defaults.
+- **Demod mode overrides** (`p25_phase1_demod_mode: cqpsk` and friends) —
+  empirical switches, not preferences. The config file itself warns at length:
+  don't set CQPSK because a site is "simulcast"; set it only when a strong,
+  clean signal won't lock in C4FM.
+
+## Config hygiene
+
+Habits that kept every build in this series debuggable:
+
+- **`config.example.yaml` is the reference, not the internet.** Every
+  accepted key lives there with a comment, and `internal/config/config.go`
+  is the authoritative list behind it. When in doubt, open the example file —
+  it ships beside the binary.
+- **Paths are relative to the config file's folder.** `../recordings` lands
+  beside the config directory, not your shell's cwd — the number-one moved-rig
+  surprise. Absolute paths and environment variables are taken as-is.
+- **Units bite twice.** `gain` is tenths of a dB (`"496"` = 49.6 dB);
+  frequencies are Hz with `_` separators encouraged. When translating from
+  SDRTrunk/OP25 numbers, convert deliberately.
+- **Secrets stay out of the file.** `api.auth.token_file` beats an inline
+  token (and re-reads on every request, so you can rotate without a restart);
+  broadcast API keys make a config unshareable, so strip them before pasting
+  a config into an issue.
+- **The web can edit the file for you.** Settings changes go through
+  `PATCH /api/v1/settings`, which writes back to `config.yaml` *preserving
+  comments and formatting* and hot-applies what it can — the
+  [write-mode]({{ '/blog/deep-dives/operator-cockpit-10-write-mode/' | relative_url }})
+  and [reflect-driven form]({{ '/blog/deep-dives/operator-cockpit-13-reflect-driven-config-form/' | relative_url }})
+  deep dives show how. For building a config from scratch, `gophertrunk
+  config` launches the Config Builder in the terminal (`config serve` for
+  the web version).
+- **One knob at a time, log watched.** The Part 1 rule scales all the way up:
+  when a change misbehaves, the diff *is* the suspect list.
+
+## Where to go from here
+
+The cookbook told you *what* to do; the rest of this blog is *why it works*.
+Three natural next reads:
+
+- **Operations depth** — hardening, TLS, metrics, watchdogs, staying up:
+  the [Running It For Real series]({{ '/blog/series/running-it-for-real/' | relative_url }})
+  is the production companion to Parts 9–11.
+- **One protocol, all the way down** — the new
+  [P25 End to End series]({{ '/blog/series/p25-end-to-end/' | relative_url }})
+  follows the Part 1 rig's protocol from C4FM symbols to recorded IMBE, the
+  deep-dive twin of this series' starter recipe.
+- **How the sausage is made** —
+  [From Spec to Shipping]({{ '/blog/series/from-spec-to-shipping/' | relative_url }})
+  is the methodology series: how a protocol document becomes tested decode
+  code, including the verification discipline this cookbook kept citing.
+
+And when a rig misbehaves in ways no troubleshooting table here covered:
+[The Hunt]({{ '/blog/series/the-hunt/' | relative_url }}) for discovery,
+[The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}) for
+everything before the ADC. The decoder can only be as good as the samples —
+that rule opened this series, and it's still the best first question.
+
+## FAQ
+
+**Is there one config file I can copy for everything?**
+Deliberately not — a kitchen-sink config running paging, ADS-B, six systems
+and four feeds on hardware that doesn't exist would just fail validation.
+Start from Part 1's four blocks, then add sections from the part that matches
+your next goal; the map above is the merge guide.
+
+**How do I know a key I found online is still valid?**
+Check `config.example.yaml` in your installed version — it is the maintained,
+commented reference, and `internal/config/config.go` behind it is
+authoritative. This series verified every key it printed against that file,
+but configs age; the example file ships with the release you actually run.
+
+**What's the minimal working config?**
+Part 1's: `storage.path`, `recordings.dir`, one `sdr.devices` entry, and one
+`trunking.systems` entry with `protocol` and `control_channels`. Everything
+else in this finale is optional and defaulted — which is the real headline of
+the config design.
+
+**Should I edit config.yaml by hand or through the web UI?**
+Both are first-class. The web Settings form is generated from the config
+schema itself and preserves your file's comments when it writes; hand
+editing is faster for bulk changes and works headless over SSH. Whichever
+you use, keep the file backed up — it is the one artifact that reproduces
+your entire rig.
+
+**Do I need to restart after every config change?**
+No — settings changed through the API hot-apply where the daemon knows how
+to reload them in-process, and the response tells you per-field what applied
+and what needs a restart. Structural changes (new devices, new systems) want
+a clean restart; watch the startup lines each part taught you.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: Naming Everything — Aliases, Labels & Exports]({{ '/blog/tutorials/operator-cookbook-13-naming-everything/' | relative_url }})
+· [Back to the series index]({{ '/blog/series/operator-cookbook/' | relative_url }})

--- a/docs/_posts/2026-09-16-p25-end-to-end-14-playbook.md
+++ b/docs/_posts/2026-09-16-p25-end-to-end-14-playbook.md
@@ -1,0 +1,281 @@
+---
+title: "P25 End to End, Part 14: The P25 Playbook"
+description: "The finale — the whole P25 stack folded into one layer map from antenna to WAV: which symptom points at which layer, the instrument that confirms it, the failure signatures operators actually report, the twin-path ledger, and the honest list of what's still open."
+category: deep-dives
+keywords: p25 troubleshooting guide, p25 decoder playbook, p25 locks but no voice, p25 grants wrong frequency, p25 failure diagnosis, p25 layer map, p25 twin paths, trunking scanner debugging, gophertrunk p25
+tags: [p25-end-to-end, p25, playbook, troubleshooting, methodology, go]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "P25 End to End"
+series_part: 14
+---
+
+*Part 14 — the last — of **P25 End to End**, a 14-part deep dive that follows
+North America's dominant trunking protocol through GopherTrunk — from a raw
+C4FM carrier to recorded, named, multi-site voice. Thirteen parts ago we
+started with four frequency levels on a deviation ladder; since then we've
+climbed through frame sync, TSBKs, multi-block trunking, band plans, two
+physical layers, two phases, voice, encryption, roaming, wideband, and the
+testing discipline holding it all together. This closing part compresses the
+climb into what you actually need at the bench: one layer map from symptom to
+part, the failure signatures operators actually report, the ledger of twin
+paths where fixes drift apart, and an honest list of what remains open.*
+
+> **TL;DR:** Debugging P25 in GopherTrunk is deciding **which layer** a
+> symptom lives in, then reaching for that layer's instrument. Never locks →
+> demod/sync (eye diagram, sync margin — Parts 1–2). Locks but no activity →
+> TSBK/MBT (decode counters — Parts 3–4). Grants tune to nothing → band plan
+> arithmetic (Part 5). Simulcast garble → the C4FM/CQPSK twin (Part 6,
+> `p25_phase1_demod_mode`). Silent recordings → encryption policy (Part 9),
+> not the demod. Short 4-frame calls on a marginal site → the weak-signal gap
+> (Part 12), where the fix is parked behind a capture — still the
+> highest-leverage contribution this series can name. The recurring trap at
+> every layer is the **twin pair**: C4FM/CQPSK, Phase 1/Phase 2,
+> single-channel/wideband, live/replay — the
+> [Two Pipelines lesson]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }}),
+> which this playbook bakes into its checklist.
+
+**Key takeaways**
+
+- **Locate the layer before touching anything.** Every layer has a distinct
+  symptom and a distinct instrument; the costliest debugging mistake in this
+  series' history was working the wrong layer with great skill.
+- **Ask "which twin am I on?" early.** Half the confusing P25 reports —
+  #764/#771, #882, #935 — were one twin path behaving differently from its
+  sibling. A fix or a config that touched only one twin is the first
+  hypothesis, not the last.
+- **Absence of data is data.** A missing WACN, one lonely neighbour site, or
+  a grant with no voice each points at a specific decoder gap this series
+  covered — and two of them were real shipped bugs.
+- **The open items are gated on evidence, not effort.** The C4FM
+  equalizer/soft-FEC port waits on a weak voice capture; the levers, the
+  harness and the ask are all merged and idle.
+
+## Cheat sheet
+
+| Concern | What it does | Where it lives |
+|---|---|---|
+| "Never locks" triage | demod + sync layer first, RF second | [Part 1]({{ '/blog/deep-dives/p25-end-to-end-01-c4fm-carrier/' | relative_url }}), [Part 2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }}) |
+| "Locks, no voice" triage | encryption policy → demod twin → band plan | [Part 9]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }}), [Part 6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }}), [Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }}) |
+| Missing WACN / neighbours | AMBT-form broadcasts (once dropped as PDU noise) | [Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }}), `phase1/mbt.go` |
+| Weak-signal 4-frame calls | the missing levers + the capture ask | [Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }}), `samples/p25/README.md` |
+| Twin-path checklist | which sibling path did the fix/config touch? | [Part 11]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }}), the ledger below |
+| Proof discipline | pyramid: vectors → synthetics → captures → air | [Part 13]({{ '/blog/deep-dives/p25-end-to-end-13-testing-p25/' | relative_url }}) |
+
+## In this post
+
+- **The layer map** — the whole stack, one table, symptom → instrument → part.
+- **Failure signatures** — the reports operators actually file, decoded.
+- **The twin ledger** — every pair where fixes have drifted, with receipts.
+- **What's still open** — the honest punch list, each item at a named gate.
+
+## The layer map
+
+The series in one table. When a P25 system misbehaves, find the row whose
+symptom matches, use its instrument, and only then open the code — the
+instruments exist so the layer diagnosis is a measurement, not a guess.
+
+| Layer | Symptom when broken | Instrument | Part |
+|---|---|---|---|
+| C4FM demod | never locks; dibit stream random | eye diagram scope, BER sweep, EVM/SNR | [1]({{ '/blog/deep-dives/p25-end-to-end-01-c4fm-carrier/' | relative_url }}) |
+| FSW + NID | no lock, or NAC flapping | FSW sync margin, NID trusted/failed counters | [2]({{ '/blog/deep-dives/p25-end-to-end-02-sync-nid-lock/' | relative_url }}) |
+| TSBK | locked but no grants; mislabelled opcodes | TSBK decoded / trellis-failed / CRC-failed | [3]({{ '/blog/deep-dives/p25-end-to-end-03-tsbk-workhorse/' | relative_url }}) |
+| MBT / AMBT | missing WACN, one neighbour site | `MBT data CRC failed` line + Viterbi metric | [4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }}) |
+| Band plan | grants tune to static | (id, channel) → Hz worked by hand | [5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }}) |
+| CQPSK / LSM twin | simulcast garble through the C4FM chain | constellation scope, CMA error | [6]({{ '/blog/deep-dives/p25-end-to-end-06-cqpsk-lsm/' | relative_url }}) |
+| Phase 2 TDMA | one slot missing; `trellis=0` in the log | MAC PDU counters, chain-start log line | [7]({{ '/blog/deep-dives/p25-end-to-end-07-phase2-tdma/' | relative_url }}) |
+| IMBE voice | short, scratchy or missing audio | LDU yield, uncorrectable-LDU count | [8]({{ '/blog/deep-dives/p25-end-to-end-08-imbe-voice/' | relative_url }}) |
+| Encryption | calls recorded silent or skipped | ALGID/KID metadata in the call log | [9]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }}) |
+| Sites / roaming | camped on a fading site | adjacency table, hunt/roam logs | [10]({{ '/blog/deep-dives/p25-end-to-end-10-sites-roaming/' | relative_url }}) |
+| Wideband | one channel decodes, its twin doesn't | per-tap counters vs single-channel replay | [11]({{ '/blog/deep-dives/p25-end-to-end-11-wideband/' | relative_url }}) |
+| Weak signal | locks, 4-frame calls | `TestReplayP25RealCaptureMetrics` baseline | [12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }}) |
+
+<figure class="lab-figure">
+<svg viewBox="0 0 680 240" width="680" height="240" role="img" aria-label="The P25 decode stack from antenna to WAV, each block annotated with the series part that covers it: antenna and SDR feed the DDC channelizer from Part 11, then the C4FM or CQPSK demodulator from Parts 1 and 6, then frame sync and NID from Part 2, then TSBK and AMBT control decode from Parts 3 and 4, then the band plan lookup from Part 5 that tunes a voice grant, then IMBE or Phase 2 voice decode from Parts 8 and 7, then encryption policy from Part 9, ending in a recorded WAV. Below the chain, three spanning braces mark sites and roaming from Part 10 across the control section, the weak-signal gap from Part 12 across the voice section, and testing from Part 13 across everything.">
+  <rect x="6" y="50" width="66" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="39" y="67" text-anchor="middle" fill="currentColor" font-size="9">antenna</text>
+  <text x="39" y="80" text-anchor="middle" fill="currentColor" font-size="9">+ SDR</text>
+  <line x1="72" y1="70" x2="84" y2="70" stroke="currentColor"/>
+  <rect x="84" y="50" width="58" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="113" y="67" text-anchor="middle" fill="currentColor" font-size="9">DDC</text>
+  <text x="113" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P11</text>
+  <line x1="142" y1="70" x2="154" y2="70" stroke="currentColor"/>
+  <rect x="154" y="50" width="76" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="192" y="67" text-anchor="middle" fill="currentColor" font-size="9">C4FM / CQPSK</text>
+  <text x="192" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P1 · P6</text>
+  <line x1="230" y1="70" x2="242" y2="70" stroke="currentColor"/>
+  <rect x="242" y="50" width="70" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="277" y="67" text-anchor="middle" fill="currentColor" font-size="9">FSW + NID</text>
+  <text x="277" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P2</text>
+  <line x1="312" y1="70" x2="324" y2="70" stroke="currentColor"/>
+  <rect x="324" y="50" width="82" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="365" y="67" text-anchor="middle" fill="currentColor" font-size="9">TSBK / AMBT</text>
+  <text x="365" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P3 · P4</text>
+  <line x1="406" y1="70" x2="418" y2="70" stroke="currentColor"/>
+  <rect x="418" y="50" width="66" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="451" y="67" text-anchor="middle" fill="currentColor" font-size="9">band plan</text>
+  <text x="451" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P5</text>
+  <line x1="484" y1="70" x2="496" y2="70" stroke="currentColor"/>
+  <rect x="496" y="50" width="86" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="539" y="67" text-anchor="middle" fill="currentColor" font-size="9">voice: IMBE / P2</text>
+  <text x="539" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P8 · P7</text>
+  <line x1="582" y1="70" x2="594" y2="70" stroke="currentColor"/>
+  <rect x="594" y="50" width="80" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="634" y="67" text-anchor="middle" fill="currentColor" font-size="9">policy → WAV</text>
+  <text x="634" y="80" text-anchor="middle" fill="var(--accent)" font-size="8">P9</text>
+  <path d="M 242 108 L 242 120 L 484 120 L 484 108" fill="none" stroke="var(--fg-muted)"/>
+  <text x="363" y="136" text-anchor="middle" fill="var(--fg-muted)" font-size="9">sites, WACN &amp; roaming — P10</text>
+  <path d="M 154 152 L 154 164 L 674 164 L 674 152" fill="none" stroke="var(--fg-muted)"/>
+  <text x="414" y="180" text-anchor="middle" fill="var(--fg-muted)" font-size="9">the weak-signal gap: equalizer + soft FEC missing on default C4FM voice — P12</text>
+  <path d="M 6 196 L 6 208 L 674 208 L 674 196" fill="none" stroke="var(--accent)"/>
+  <text x="340" y="226" text-anchor="middle" fill="var(--accent)" font-size="9">testing: literal vectors → synthetics → captures → on-air — P13</text>
+</svg>
+<figcaption>Antenna to WAV with part numbers attached — and the three spans that cut across every block: site topology, the weak-signal gap, and the testing pyramid.</figcaption>
+</figure>
+
+## Failure signatures
+
+The layer map is for methodical triage; these are the shortcuts — the
+symptoms operators actually report, matched to their usual cause.
+
+**"It locks, but no voice ever records."** Three suspects, in order of how
+often they're guilty. First, **encryption policy**: check the call log's
+ALGID/KID metadata before blaming the DSP — an encrypted system faithfully
+decoded still yields nothing listenable, and the policy knobs decide whether
+it's skipped or logged ([Part 9]({{ '/blog/deep-dives/p25-end-to-end-09-encryption/' | relative_url }})).
+Second, the **demod twin**: an LSM/simulcast site pushed through the FM
+discriminator produces near-random dibits (issue #275's original symptom) —
+set the per-channel `p25_phase1_demod_mode` (issue #935). Third, the **band
+plan**: the grant may be tuning somewhere the call isn't.
+
+**"Grants tune to nothing."** Band-plan arithmetic, almost always
+([Part 5]({{ '/blog/deep-dives/p25-end-to-end-05-channels-band-plans/' | relative_url }})).
+Work one grant by hand: base + spacing × channel, minus the identifier
+table's tx offset where applicable — and remember the AMBT rule that an
+*explicit* uplink channel already encodes the uplink frequency, so it takes
+**no** tx offset. A wrong IDEN_UP row moves every voice channel at once,
+which is the tell distinguishing it from a per-channel RF problem.
+
+**"Only one neighbour site, and no WACN."** The signature of a system that
+broadcasts Network Status and Adjacent Status only in **AMBT** form. Old
+GopherTrunk logged each one as `non-control DUID duid=PDU` and dropped it;
+since `mbt.go` landed ([Part 4]({{ '/blog/deep-dives/p25-end-to-end-04-mbt-ambt/' | relative_url }}))
+those decode. On this symptom today, check the version first. And a `MBT
+data CRC failed` line whose identity fields look perfectly decoded is **two
+frames, not a contradiction** — the header carries its own CRC and decoded
+clean; a data block failed its CRC-32 on RF residuals. The broadcast
+repeats; don't chase a parser bug from that log pair.
+
+**"Wideband decodes the control channel, but voice is wrong."** The twin
+ledger's territory: the wideband path once silently dropped the Phase 2 FEC
+options — `trellis=0` in the chain-start log line is the tell — and stamped
+no demod mode onto its grants, so voice always ran the C4FM chain regardless
+of config (issues #882, #935). Both fixed; both are the pattern to suspect
+when *one pipeline* of a pair misbehaves.
+
+**"It locks and grants, but marginal calls yield a few frames."** The
+weak-signal gap ([Part 12]({{ '/blog/deep-dives/p25-end-to-end-12-weak-signal-gap/' | relative_url }})).
+No config key fixes this today; the levers are diagnosed and parked behind a
+weak C4FM voice capture. If your site produces this symptom, you hold the
+unblock.
+
+## The twin ledger
+
+The series' running thread, settled as a checklist. Every entry is a real
+divergence with a receipt — ask which side of each pair you're on before
+concluding anything:
+
+| Twin pair | The drift, when it happened |
+|---|---|
+| C4FM ↔ CQPSK | the blind FSE equalizer exists only on the CQPSK path; default C4FM voice has no equalizer at all (Parts 6, 12) |
+| single-channel ↔ wideband DDC | the #764 "fix" landed on one down-converter and missed the #771 replay symptom in the other (Part 11) |
+| Phase 1 ↔ Phase 2 | the wideband pipeline forwarded Phase 1 options but dropped Phase 2's FEC knobs — `trellis=0` (#882) |
+| control ↔ voice chain | soft-decision LLRs feed the TSBK trellis but never the IMBE FEC; the DC blocker is voice-only by design (Part 12) |
+| live ↔ replay | prevented drift: replay builds its DDC from the same exported `DDCTargetForProtocol` the live path uses (Part 1) |
+
+The general lesson graduated into
+[its own postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }}):
+when two code paths implement one concept, every fix needs an explicit
+answer to "and the twin?" — in the PR, not in the next bug report.
+
+## What's still open
+
+An honest playbook ends with its open items, each parked at a named gate:
+
+- **The C4FM voice equalizer + soft IMBE FEC** — diagnosed, scoped, proven
+  next door; gated on a weak C4FM **voice** capture landing in
+  `samples/p25/` (Part 12). The baseline harness runs today.
+- **The decision-directed AFC** (`EnableDecisionDirectedAFC`) — built,
+  gated, and **off by default**: on the issue #402 capture it stably held a
+  wrong offset that CoarseAFC-alone recovered. It waits on the eye-skew root
+  cause and a real lock signal to gate its handoff.
+- **The adaptive C4FM slicer** (`EnableAdaptiveC4FMSlicer`) — also off by
+  default, honestly: on the same #402 capture the fixed thresholds beat
+  every adaptive variant, because the eye asymmetry is an RF-domain effect
+  the slicer cannot fix. Kept for A/B experimentation.
+- **On-air breadth** — every decoder here is pinned to references and
+  captures from a handful of systems; each new system an operator runs is a
+  fresh verification, and `samples/p25/` is how its lessons persist.
+
+Every item is blocked on evidence, not effort — the same sentence the
+[weak-signal playbook]({{ '/blog/deep-dives/weak-signal-engineering-14-playbook/' | relative_url }})
+closed on, because it is the project's actual operating principle.
+
+## Where to go from here
+
+The natural next reads depend on which thread of this series hooked you.
+For the same protocol-length treatment of the *other* great trunking family
+— phase transitions instead of amplitudes, and the carrier most of this
+project's hardest lessons came from — cross to
+[TETRA End to End]({{ '/blog/series/tetra-end-to-end/' | relative_url }}).
+For the method behind Parts 12–13 in full — the four regimes, the levers,
+the metrics that lie —
+[Weak-Signal Engineering]({{ '/blog/series/weak-signal-engineering/' | relative_url }})
+is the theory course. For how a wire format goes from a standards PDF to
+shipped, pinned Go —
+[From Spec to Shipping]({{ '/blog/series/from-spec-to-shipping/' | relative_url }}).
+And to put all of this on your own desk, the
+[Operator's Cookbook]({{ '/blog/series/operator-cookbook/' | relative_url }})
+starts with a
+[$40 P25 rig]({{ '/blog/tutorials/operator-cookbook-01-forty-dollar-p25-rig/' | relative_url }})
+that runs every layer this series just mapped.
+
+## FAQ
+
+**My P25 system won't decode — where do I start?**
+At the bottom of the layer map, with instruments: does the eye diagram look
+like four levels? Does the FSW sync margin show hits? Is NID trusted
+climbing? A "no" at any row names your layer, and the linked part covers it.
+Working top-down from "no audio" wastes hours in layers that are fine.
+
+**What's the single most common cause of "locks but no voice"?**
+Encryption, followed by the demod-mode twin. Check ALGID/KID metadata in the
+call log before touching DSP settings — a correctly-decoded encrypted call
+and a broken voice chain look identical from the speaker, and only one of
+them is a bug.
+
+**Is Phase 2 harder to receive than Phase 1?**
+Different, not strictly harder: H-DQPSK demands the differential machinery
+TETRA pioneered (and shares its `PiOver4DQPSK` core), but Phase 2 also wires
+an equalizer where default Phase 1 C4FM doesn't. The practical Phase 2 traps
+in this series were configuration plumbing (#882), not modulation.
+
+**How can I contribute if I can't write DSP code?**
+Captures — this series has asked three times and means it. A weak C4FM
+voice call per `samples/p25/README.md` unblocks the biggest open item; any
+control-channel capture with a metadata sidecar becomes a permanent
+regression; and a report that says *which layer's instrument* showed the
+anomaly is halfway to a fix on arrival.
+
+**Does this playbook transfer to DMR or NXDN?**
+Largely. The 4800-baud C4FM-family physical layer is shared machinery, the
+layer-map method is protocol-agnostic, and the twin-pair discipline applies
+anywhere two pipelines implement one concept. The protocol-specific rows —
+band plans, AMBT, ESS — have DMR/NXDN analogues covered in the
+[Protocol Decoders survey]({{ '/blog/deep-dives/protocol-decoders-05-dmr-tier-2-3/' | relative_url }}).
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: Testing P25 Without a Tower]({{ '/blog/deep-dives/p25-end-to-end-13-testing-p25/' | relative_url }})
+· [Back to the series index]({{ '/blog/series/p25-end-to-end/' | relative_url }})

--- a/docs/blog/series/from-spec-to-shipping.md
+++ b/docs/blog/series/from-spec-to-shipping.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: "From Spec to Shipping: how a protocol decoder actually gets written"
+description: A 14-part series on turning standards documents and independent references into decoder code you can trust on air — reading ETSI and TIA specs, literal test vectors over round-trips, conformance harnesses, clean-room rules, the on-air verification gate, capture-driven development, and what "verified" really means.
+keywords: how to write a protocol decoder, reading etsi standards, tia-102 p25 spec, reference implementation testing, conformance test harness, clean room implementation, regression test failing first, capture driven development, software verification discipline, gophertrunk engineering
+nav_group: Blog
+permalink: /blog/series/from-spec-to-shipping/
+---
+
+**From Spec to Shipping** is a 14-part series on how a protocol decoder
+actually gets written — the method
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) follows to go from
+an ETSI or TIA PDF to code that decodes real signals on air.
+[From the Issue Tracker]({{ '/blog/series/from-the-issue-tracker/' | relative_url }})
+taught these lessons as postmortems: the round-trip test that validates its own
+bug, the placeholder constant that became a fabricated protocol, the RPC opcode
+nothing ever checked. This series teaches the same discipline **forward** —
+reading standards, choosing reference implementations you can trust, pinning
+parsers with literal byte vectors, building bit-identical conformance
+harnesses, staying clean-room, letting operator captures referee when
+references disagree, and gating every claim behind on-air verification.
+
+The recurring villain is the test that passes because both sides share the same
+assumption; the recurring hero is the **independent reference** — another
+implementation, a reference codec, a reporter's capture. Every part closes with
+rules that transfer to any wire format, not just radio.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+code for the deep read.
+
+New here? The [Testing]({{ '/learn/testing/' | relative_url }}) module covers
+the fundamentals this series builds on.
+
+{%- assign parts = site.posts | where: "series", "From Spec to Shipping" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Deep dives</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/deep-dives/' | relative_url }}">deep dives</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>

--- a/docs/blog/series/operator-cookbook.md
+++ b/docs/blog/series/operator-cookbook.md
@@ -1,0 +1,63 @@
+---
+layout: page
+title: "The Operator's Cookbook: complete GopherTrunk builds, one rig per part"
+description: A 14-part series of copy-paste GopherTrunk recipes — a $40 P25 starter rig, DMR Tier III and two-slot conventional DMR, TETRA TMO and Direct Mode, analog FM and tone-out, multi-SDR pools, remote radios, Broadcastify streaming, a FLAC archival rig, a headless Pi appliance, a two-antenna diversity build, and the fully annotated kitchen-sink config.
+keywords: gophertrunk setup guide, rtl-sdr p25 scanner setup, dmr scanner config, tetra sdr setup, raspberry pi police scanner, broadcastify feed setup, sdr trunking recipes, police scanner software config, gophertrunk cookbook
+nav_group: Blog
+permalink: /blog/series/operator-cookbook/
+---
+
+**The Operator's Cookbook** is a 14-part series of complete, copy-paste
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) builds — one working
+rig per part, antenna to browser. Every other tutorial series on this blog is
+organized by subsystem; this one is organized by **what you're trying to
+build**. Each part is a full recipe: the hardware list, a working
+`config.yaml`, the first-run verification (the exact log lines and web panels
+that mean it's working), a troubleshooting table, and variations to grow into.
+
+The recipes run from a **$40 P25 starter rig** through DMR Tier III, two-slot
+conventional DMR, TETRA TMO and Direct Mode, analog FM with tone-out paging,
+multi-dongle SDR pools, remote radios over the network, streaming to
+Broadcastify and friends, a FLAC-everything archival rig, a headless
+Raspberry Pi appliance, and a two-antenna diversity build — ending with the
+kitchen-sink config, annotated line by line. The cookbook tells you **what**
+to do; [The Hunt]({{ '/blog/series/the-hunt/' | relative_url }}),
+[Running It For Real]({{ '/blog/series/running-it-for-real/' | relative_url }}),
+[Recording, Composition & Streaming]({{ '/blog/series/recording-streaming/' | relative_url }})
+and [The Analog Edge]({{ '/blog/series/analog-edge/' | relative_url }}) tell
+you **why** it works.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+configs for the deep read.
+
+New here? Start with
+[What do I need for GopherTrunk?]({{ '/what-do-i-need-for-gophertrunk/' | relative_url }})
+for the hardware basics, then pick the recipe that matches your area.
+
+{%- assign parts = site.posts | where: "series", "The Operator's Cookbook" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Tutorials</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/tutorials/' | relative_url }}">tutorials</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>

--- a/docs/blog/series/p25-end-to-end.md
+++ b/docs/blog/series/p25-end-to-end.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: "P25 End to End: from a C4FM carrier to recorded, named, multi-site voice"
+description: A 14-part deep dive into GopherTrunk's P25 stack — C4FM and the NID, TSBKs and Multi-Block Trunking, band plans, the CQPSK/LSM linear path, Phase 2 TDMA, IMBE voice, encryption signalling, multi-site roaming, wideband decoding, and the weak-signal gap that still needs your captures.
+keywords: p25 decoder, c4fm demodulation, p25 tsbk, multi-block trunking ambt, p25 phase 2 tdma, imbe vocoder, p25 band plan, cqpsk lsm simulcast, p25 trunking scanner, gophertrunk p25
+nav_group: Blog
+permalink: /blog/series/p25-end-to-end/
+---
+
+**P25 End to End** is a 14-part deep dive into the
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) P25 stack — the
+protocol GopherTrunk locks more often than any other, followed from a raw
+4800-symbol-per-second C4FM carrier all the way to recorded, named,
+multi-site-tracked voice. Where
+[Protocol Decoders]({{ '/blog/series/protocol-decoders/' | relative_url }})
+surveyed P25 across three episodes, this series walks every layer at full
+depth: frame sync and the NID, TSBKs and the trellis, **Multi-Block Trunking**
+(the PDU that used to be dropped as noise), channel identifiers and band
+plans, the **CQPSK/LSM** linear path, Phase 2 TDMA, IMBE voice, encryption
+signalling and policy, sites and roaming, and the wideband engine that watches
+a whole system at once.
+
+The running thread is that P25 in GopherTrunk is a family of **twin paths** —
+Phase 1 and Phase 2, C4FM and CQPSK, single-channel and wideband, live and
+replay — and every twin pair is a place where a fix can land on one side and
+silently miss the other, the lesson the
+[Two Pipelines postmortem]({{ '/blog/solution-postmortem/from-the-issue-tracker-22-two-pipelines/' | relative_url }})
+taught the hard way. The series ends honestly: Part 12 is about the
+**weak-signal gap** in the Phase 1 C4FM voice path and the capture
+contributions that would close it.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose with real
+code for the deep read.
+
+New here? Start with the
+[Digital Trunking]({{ '/learn/digital-trunking/' | relative_url }}) module for
+how a trunked system is laid out, then come back for the P25 specifics.
+
+{%- assign parts = site.posts | where: "series", "P25 End to End" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Deep dives</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/deep-dives/' | relative_url }}">deep dives</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
P25 End to End and From Spec to Shipping (deep dives) and The
Operator's Cookbook (tutorials) — index pages under /blog/series/ and
Blog nav-group entries. Posts land in follow-up commits.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qhfn6huLaZqg9dXZCEVBQ3