### PR TITLE
tetra: bound MAC PDUs by their length/fill fields and enforce fragment continuity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
             exit 1
           fi
       - run: go build ./...
-      - run: go test -race -count=1 ./...
+      # -timeout raised from go test's 10m default: the heaviest DSP package
+      # (internal/radio/p25/phase1/receiver) measures ~6 min under -race on a
+      # fast machine and crossed 10m on a slow hosted runner (run 2394), where
+      # the per-PACKAGE alarm kills the run even though no single test hangs.
+      - run: go test -race -count=1 -timeout 25m ./...
       - run: make integration
 
   # The pure-Go USB transport (internal/sdr/rtlsdr/usb) lands platform-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,7 +454,25 @@ confirmation before any close-as-completed.
   systems report's "Neighbor sites"; cells surface only after the SAME content decodes twice —
   the 6-bit PD+type gate lets a rare corrupted-but-CRC-passing TL-SDU parse plausibly (one-shot
   surfaced 18 "neighbours"; the repeating 8 were real: carriers 467.99-470.00 MHz, LAs 1021-1089,
-  `TestTETRANeighbourReportReplay` is the skip-guarded harness). Related dedup in the same pass:
+  `TestTETRANeighbourReportReplay` is the skip-guarded harness). **Follow-up (Sep 3): the operator's
+  "totally bogus entries in the neighbours list, like a 1.5 GHz one" — confirmed-twice garbage — was
+  TWO MORE MAC boundary holes, both deterministic (so identical corruption repeats and the
+  confirm-twice gate cannot help): (1) `tmSDU`/`macFragmentPayload` handed everything to the BLOCK
+  end — the MAC length indication (total PDU octets; osmo rx_resrc `macpdu_length*8`, tetra-kit
+  `decodeLength(li)*8 - pos`) was parsed but never applied and the fill-bit indication never
+  stripped fill ('1' then '0's, §23.4.3.2) — so fill/multiplexed tail bits leaked into the TL-SDU
+  and D-NWRK-BROADCAST's trailing P-bit reads turned them into phantom optionals (band bits 1111 ⇒
+  a 1.5 GHz "neighbour"); prefix-reading parsers never noticed, which is why everything else looked
+  fine. (2) fragment reassembly had NO continuity check — a MAC-END spliced onto however-old a start
+  fragment across lost blocks; now pieces must be stream-adjacent (`fragMaxGapDibits`, the NCDB
+  detector's dibit position plumbed through `decodeDownlinkSlot`) and an AACH-confirmed control slot
+  that decodes nothing abandons the chain (osmo-sq5bpf ages fragslots the same way). Test builders
+  used to write a PLACEHOLDER length indication the decoder ignored — honouring the field made them
+  encode real lengths (`stampMACResourceLength`), the encoder/decoder-drift trap in yet another
+  dress. `plausibleNeighbourCell` (carrier≠0, band 1..9) is defence-in-depth behind those fixes, and
+  the neighbour log/StatusFlags now print MCC/MNC/LA (and the newly surfaced §18.5.17 status
+  optionals — raw values; their spec bit maps stay un-named until capture-confirmed, per the
+  CommsType rule) only when present, so "mcc=0" can no longer mean "absent".** Related dedup in the same pass:
   retransmitted D-RELEASE/D-DISCONNECT now publish ONE `call.release` per teardown (`releaseSeen`,
   re-armed by a fresh grant) — the "release spam" report, same family as `grantSeen`/`lastTalker`.
 - **The "sausages" in the operator's TETRA waterfall are the BS toggling discontinuous-downlink

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 dist: web-build siglab-web-build rfscope-web-build configbuilder-web-build build
 
 test:
-	$(GO) test -tags "$(TAGS)" -race -count=1 $(PKGS)
+	$(GO) test -tags "$(TAGS)" -race -count=1 -timeout 25m $(PKGS)
 
 # test-dvsi runs the DVSI hardware-backend tests under the -tags dvsi
 # build. The Vocoder + Transport + USB-enumeration codepath is gated

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2751,6 +2751,13 @@ func (d *Daemon) buildAPIServer(cfg config.Config, version string, log *slog.Log
 				log.Warn("daemon: baseband.auto_record enabled but no IQ broker for the control SDR; auto-record disabled",
 					"control_serial", d.controlSerial)
 			}
+		} else if cfg.Baseband.AutoRecord.Enabled {
+			// Previously this case was SILENT: auto_record enabled with no
+			// single-channel control SDR (e.g. a wideband-engine-only rig, or
+			// cc_hunt disabled) simply never wired the recorder, and the
+			// operator's only evidence was the absence of capture files.
+			log.Warn("daemon: baseband.auto_record enabled but no single-channel control SDR is configured; auto-record disabled " +
+				"(it captures the control SDR's IQ, which requires the cc_hunt + control-role decode path)")
 		}
 		if d.bookmarks != nil {
 			opts.Bookmarks = bookmarkProvider{store: d.bookmarks}

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -593,15 +593,21 @@ func (c *ControlChannel) TopologySnapshot() *trunking.TopologySnapshot {
 	return snap
 }
 
-// neighbourStatusFlags renders a neighbour cell's sync state and optional
-// identity as the human-readable StatusFlags string the report and web UI
-// already display for P25 neighbours (CFVA words there; sync + identity here).
+// neighbourStatusFlags renders a neighbour cell's sync state, advertised load
+// and optional identity/status fields as the human-readable StatusFlags string
+// the report and web UI already display for P25 neighbours (CFVA words there).
+// Absent optional fields are omitted — never rendered as zeros — and the
+// unconfirmed-semantics fields (BS service details, subscriber class, …) are
+// rendered raw (see the NeighbourCell field docs).
 func neighbourStatusFlags(cell NeighbourCell) string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 8)
 	if cell.Synchronized {
 		parts = append(parts, "synced")
 	} else {
 		parts = append(parts, "unsynced")
+	}
+	if cell.CellServiceLevel != 0 { // 0 = load unknown; noise to print
+		parts = append(parts, "load="+CellLoadName(cell.CellServiceLevel))
 	}
 	if cell.HasMCC {
 		parts = append(parts, fmt.Sprintf("mcc=%d", cell.MCC))
@@ -612,7 +618,32 @@ func neighbourStatusFlags(cell NeighbourCell) string {
 	if cell.HasLA {
 		parts = append(parts, fmt.Sprintf("la=%d", cell.LA))
 	}
+	if cell.HasServiceDetails {
+		parts = append(parts, fmt.Sprintf("bs_svc=0x%03x", cell.ServiceDetails))
+	}
+	if cell.HasTimeshare {
+		parts = append(parts, fmt.Sprintf("timeshare=0x%02x", cell.Timeshare))
+	}
 	return strings.Join(parts, ",")
+}
+
+// plausibleNeighbourCell rejects neighbour cells whose decoded content is
+// physically impossible for a TETRA network — the last line of defence against
+// a corrupted-but-CRC-passing TL-SDU that parses as a plausible broadcast. A
+// main carrier of 0 is not a real cell, and the deployed carrier numbering
+// (TS 100 392-15, base = band × 100 MHz) covers the 100–999 MHz allocations
+// only: a frequency-band field of 0 or ≥10 renders as a sub-100 MHz or ≥1 GHz
+// "neighbour" (an operator's field report showed a confirmed 1.5 GHz entry —
+// band bits 1111 read from leaked tail bits), which no TETRA allocation
+// occupies.
+func plausibleNeighbourCell(cell NeighbourCell) bool {
+	if cell.MainCarrier == 0 {
+		return false
+	}
+	if cell.HasExtension && (cell.FreqBand == 0 || cell.FreqBand > 9) {
+		return false
+	}
+	return true
 }
 
 // publishSiteIdentity emits a KindSiteUpdate carrying the decoded TETRA identity
@@ -914,7 +945,15 @@ func (c *ControlChannel) learnNeighbourCells(nb DNwrkBroadcast) {
 		c.neighbours = make(map[uint8]NeighbourCell)
 		c.neighboursPending = make(map[uint8]NeighbourCell)
 	}
+	var implausible []NeighbourCell
 	for _, cell := range nb.Neighbours {
+		if !plausibleNeighbourCell(cell) {
+			// Log outside the lock; the sibling cells still get their chance —
+			// a genuinely corrupt list's other cells must also pass this gate
+			// AND confirm twice before surfacing.
+			implausible = append(implausible, cell)
+			continue
+		}
 		if cur, seen := c.neighbours[cell.CellID]; seen && cur == cell {
 			continue // steady-state rebroadcast of a confirmed cell
 		}
@@ -929,20 +968,62 @@ func (c *ControlChannel) learnNeighbourCells(nb DNwrkBroadcast) {
 		c.neighboursPending[cell.CellID] = cell
 	}
 	c.mu.Unlock()
+	for _, cell := range implausible {
+		c.log.Debug("tetra: dropping implausible d-nwrk-broadcast neighbour cell",
+			"system", c.systemName,
+			"cell_id", cell.CellID,
+			"main_carrier", cell.MainCarrier,
+			"has_ext", cell.HasExtension,
+			"band", cell.FreqBand)
+	}
 	if len(confirmed) == 0 {
 		return
 	}
 	for _, cell := range confirmed {
 		dl, ul := c.neighbourFrequencies(cell)
-		c.log.Debug("tetra: d-nwrk-broadcast neighbour cell",
+		// Optional fields are logged only when the broadcast carried them, so an
+		// absent MCC/MNC/LA is distinguishable from a genuine zero (the field
+		// report that motivated this read unconditional "mcc=0 mnc=0" as a
+		// decode defect). The unconfirmed-semantics status fields are raw.
+		args := []any{
 			"system", c.systemName,
 			"cell_id", cell.CellID,
 			"main_carrier", cell.MainCarrier,
 			"downlink_hz", dl,
 			"uplink_hz", ul,
 			"synced", cell.Synchronized,
+			"cell_load", CellLoadName(cell.CellServiceLevel),
+			"reselect_types", cell.ReselectTypes,
 			"has_ext", cell.HasExtension,
-			"mcc", cell.MCC, "mnc", cell.MNC, "la", cell.LA)
+		}
+		if cell.HasMCC {
+			args = append(args, "mcc", cell.MCC)
+		}
+		if cell.HasMNC {
+			args = append(args, "mnc", cell.MNC)
+		}
+		if cell.HasLA {
+			args = append(args, "la", cell.LA)
+		}
+		if cell.HasMaxTxPower {
+			args = append(args, "max_tx_power_raw", cell.MaxTxPower)
+		}
+		if cell.HasMinRxLevel {
+			args = append(args, "min_rx_level_raw", cell.MinRxLevel)
+		}
+		if cell.HasSubscriberClass {
+			args = append(args, "subscriber_class", fmt.Sprintf("0x%04x", cell.SubscriberClass))
+		}
+		if cell.HasServiceDetails {
+			args = append(args, "bs_service_details", fmt.Sprintf("0x%03x", cell.ServiceDetails))
+		}
+		if cell.HasTimeshare {
+			args = append(args, "timeshare_security", fmt.Sprintf("0x%02x", cell.Timeshare))
+		}
+		if cell.HasFrameOffset {
+			args = append(args, "tdma_frame_offset", cell.FrameOffset)
+		}
+		c.log.Debug("tetra: d-nwrk-broadcast neighbour cell", args...)
 	}
 	c.publishSiteIdentity()
 }

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -212,6 +212,13 @@ type ControlChannel struct {
 	fragTMSDU    []byte
 	fragResource MACResource
 	fragActive   bool
+	// curSlotPos is the absolute dibit stream position of the NCDB slot
+	// currently being decoded (stamped by decodeDownlinkSlot); fragLastPos is
+	// the position of the reassembly's most recent piece. Successive pieces of
+	// one fragmented TM-SDU must be stream-adjacent (within fragMaxGapDibits) —
+	// see appendFragment. Guarded by mu.
+	curSlotPos  int
+	fragLastPos int
 
 	// pendingSoft holds the per-symbol complex differential (soft
 	// information) for the next Process call, stashed by StashSoft
@@ -1218,6 +1225,18 @@ func (c *ControlChannel) isIndividual(ssi uint32) bool {
 // never delivers a MAC-END from growing the buffer without limit.
 const fragMaxBits = 2048
 
+// fragMaxGapDibits bounds the dibit stream distance between successive pieces
+// of one fragmented TM-SDU. Fragments continue in the following signalling
+// opportunities of the same channel (§23.4.2), i.e. one TDMA frame apart on the
+// MCCH (4 slots × 255 dibits = 1020), occasionally displaced by a sync burst or
+// the frame-18 schedule — four frames of slack accepts all of that. What it
+// rejects is a MAC-FRAG/MAC-END arriving long after the chain's previous piece:
+// that continuation belongs to a LATER fragmented PDU whose own start fragment
+// was lost, and splicing it onto the stale chain manufactures a corrupt L3 PDU
+// (see abandonFragment's caller for why that corruption survives dedup).
+// osmo-tetra-sq5bpf ages fragment slots out the same way (fragtimer > N203).
+const fragMaxGapDibits = 4 * 4 * 255
+
 // stashFragment records a start-fragment MAC-RESOURCE's partial TM-SDU and its
 // resource context so a following MAC-END can reassemble the complete L3 PDU. A
 // new start fragment replaces any incomplete one (single TM-SDU in flight).
@@ -1227,38 +1246,69 @@ func (c *ControlChannel) stashFragment(m MACResource, partial []byte) {
 	c.fragResource = m
 	c.fragTMSDU = append(c.fragTMSDU[:0], partial...)
 	c.fragActive = true
+	c.fragLastPos = c.curSlotPos
+}
+
+// fragChainAdjacentLocked reports whether the slot being decoded is close
+// enough in the dibit stream to the reassembly's previous piece for a
+// MAC-FRAG/MAC-END in it to be that chain's continuation. A negative delta is
+// a stream discontinuity (resync baseline jump) and never adjacent. Callers
+// hold mu.
+func (c *ControlChannel) fragChainAdjacentLocked() bool {
+	delta := c.curSlotPos - c.fragLastPos
+	return delta >= 0 && delta <= fragMaxGapDibits
+}
+
+// dropFragmentLocked abandons the in-progress reassembly. Callers hold mu.
+func (c *ControlChannel) dropFragmentLocked() {
+	c.fragActive = false
+	c.fragTMSDU = c.fragTMSDU[:0]
+	c.fragResource = MACResource{}
+}
+
+// abandonFragment drops any in-progress TM-SDU reassembly, logging why. Used
+// when continuity is broken — an undecoded control slot, or a continuation
+// arriving too far from the chain's previous piece — because a spliced
+// reassembly around a lost block parses as a plausible corrupt L3 PDU.
+func (c *ControlChannel) abandonFragment(reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.fragActive {
+		return
+	}
+	c.dropFragmentLocked()
+	c.log.Debug("tetra: abandoning TM-SDU fragment reassembly", "reason", reason)
 }
 
 // appendFragment appends a MAC-FRAG continuation to the in-progress TM-SDU. A
 // no-op when no start fragment is in progress; a stream that would exceed
-// fragMaxBits is dropped rather than accumulated.
+// fragMaxBits, or a continuation that is not stream-adjacent to the chain's
+// previous piece, drops the chain rather than splicing.
 func (c *ControlChannel) appendFragment(payload []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.fragActive {
 		return
 	}
-	if len(c.fragTMSDU)+len(payload) > fragMaxBits {
-		c.fragActive = false
-		c.fragTMSDU = c.fragTMSDU[:0]
+	if !c.fragChainAdjacentLocked() || len(c.fragTMSDU)+len(payload) > fragMaxBits {
+		c.dropFragmentLocked()
 		return
 	}
 	c.fragTMSDU = append(c.fragTMSDU, payload...)
+	c.fragLastPos = c.curSlotPos
 }
 
 // takeFragment appends a MAC-END payload, returns the reassembled TM-SDU (a
 // fresh slice) plus the start fragment's MAC-RESOURCE context, and clears the
-// buffer. ok is false for a stray MAC-END with no start fragment in progress or
-// an over-length reassembly.
+// buffer. ok is false for a stray MAC-END with no start fragment in progress,
+// an over-length reassembly, or a MAC-END that is not stream-adjacent to the
+// chain's previous piece (its own start fragment was lost — splicing it onto
+// the stale chain would manufacture a corrupt L3 PDU).
 func (c *ControlChannel) takeFragment(payload []byte) (MACResource, []byte, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	defer func() {
-		c.fragActive = false
-		c.fragTMSDU = c.fragTMSDU[:0]
-		c.fragResource = MACResource{}
-	}()
-	if !c.fragActive || len(c.fragTMSDU)+len(payload) > fragMaxBits {
+	defer c.dropFragmentLocked()
+	if !c.fragActive || !c.fragChainAdjacentLocked() || len(c.fragTMSDU)+len(payload) > fragMaxBits {
 		return MACResource{}, nil, false
 	}
 	sdu := make([]byte, 0, len(c.fragTMSDU)+len(payload))
@@ -1562,7 +1612,5 @@ func (c *ControlChannel) ResyncReset() {
 	// A stream re-sync abandons any half-reassembled TM-SDU: its continuation
 	// belonged to the pre-resync bit index and must not splice onto a fragment
 	// decoded after the baseline jump.
-	c.fragActive = false
-	c.fragTMSDU = c.fragTMSDU[:0]
-	c.fragResource = MACResource{}
+	c.dropFragmentLocked()
 }

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -41,10 +41,13 @@ type downlinkNCDB struct {
 	softBuf []complex64 // per-symbol differentials, strictly parallel to buf (or empty)
 	bufBase int
 	pending []int
-	onSlot  func(bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64)
+	// onSlot receives the burst's absolute dibit stream position L alongside the
+	// slot's blocks — the continuity currency the MAC fragment reassembly uses to
+	// refuse splicing pieces that are not stream-adjacent.
+	onSlot func(pos int, bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64)
 }
 
-func newDownlinkNCDB(onSlot func(bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64)) *downlinkNCDB {
+func newDownlinkNCDB(onSlot func(pos int, bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64)) *downlinkNCDB {
 	d := &downlinkNCDB{onSlot: onSlot}
 	// The π/4-DQPSK stream carries a residual 0..3 dibit rotation, so correlate
 	// the normal training sequence (NTS1 + NTS2) under all four rotations.
@@ -153,7 +156,7 @@ func (d *downlinkNCDB) emit(L int) {
 	if bkn1 == nil || aach1 == nil || aach2 == nil || bkn2 == nil {
 		return
 	}
-	d.onSlot(bkn1, aach1, aach2, bkn2, softSlice(ndbBKN1Start, ndbBlockDibits), softSlice(ndbBKN2Start, ndbBlockDibits))
+	d.onSlot(L, bkn1, aach1, aach2, bkn2, softSlice(ndbBKN1Start, ndbBlockDibits), softSlice(ndbBKN2Start, ndbBlockDibits))
 }
 
 // decodeDownlinkSlot classifies and decodes one NCDB. It reads the AACH to find
@@ -162,9 +165,13 @@ func (d *downlinkNCDB) emit(L int) {
 // and hands each CRC-clean block to the MAC demux. CRC gates every decode, so
 // trying all three channel shapes never double-counts: a full-slot SCH/F slot
 // fails the half-slot SCH/HD CRC and vice versa.
-func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64) {
+func (c *ControlChannel) decodeDownlinkSlot(pos int, bkn1, aach1, aach2, bkn2 []uint8, bkn1Diffs, bkn2Diffs []complex64) {
 	c.mu.Lock()
 	colour := c.colourCode
+	// Stamp the slot's stream position before any block decodes: the MAC
+	// fragment reassembly uses it to verify that successive pieces of one
+	// TM-SDU are stream-adjacent (see fragMaxGapDibits).
+	c.curSlotPos = pos
 	c.mu.Unlock()
 
 	derot := func(d []uint8, rot uint8) []byte {
@@ -237,6 +244,15 @@ func (c *ControlChannel) decodeDownlinkSlot(bkn1, aach1, aach2, bkn2 []uint8, bk
 		c.notePayloadActivity()
 	} else if aachOK && aa.IsControlChannel() {
 		c.addStat(&c.stats.SCHPDUsFail, 1)
+		// A control slot that yielded no CRC-clean block is a lost signalling
+		// block. If a fragmented TM-SDU is mid-reassembly, its continuation may
+		// be exactly what was lost — splicing the pieces either side of the gap
+		// yields a plausible-looking corrupt L3 PDU, and because broadcast
+		// content and fragmentation split points repeat, the SAME corrupt
+		// reassembly can repeat bit-identically (defeating confirm-twice dedup
+		// downstream, e.g. bogus D-NWRK-BROADCAST neighbour cells). Abandon the
+		// chain; the broadcast rebroadcasts within seconds.
+		c.abandonFragment("undecoded control slot mid-reassembly")
 	}
 }
 

--- a/internal/radio/tetra/frag_continuity_test.go
+++ b/internal/radio/tetra/frag_continuity_test.go
@@ -1,0 +1,121 @@
+package tetra
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// Continuity regressions for the MAC fragment reassembly. Fragments of one
+// TM-SDU continue in the following signalling opportunities of the same channel
+// (§23.4.2); the reassembly used to splice a MAC-FRAG/MAC-END onto whatever
+// start fragment was in flight, however long ago it was stashed and however
+// many undecoded slots sat in between. Around a lost block that manufactures a
+// plausible corrupt L3 PDU — and because broadcast content and fragmentation
+// split points repeat, the SAME corrupt reassembly repeats bit-identically,
+// defeating the confirm-twice dedup on D-NWRK-BROADCAST neighbour cells
+// (osmo-tetra-sq5bpf ages fragment slots out for the same reason).
+
+// ingestMACAt stamps the slot stream position the NCDB path normally stamps
+// (decodeDownlinkSlot) and ingests the block at it.
+func ingestMACAt(cc *ControlChannel, pos int, block []byte) {
+	cc.mu.Lock()
+	cc.curSlotPos = pos
+	cc.mu.Unlock()
+	cc.ingestMAC(block)
+}
+
+// enrichedGrantSeen reports whether the bus carried a grant enriched from a
+// reassembled D-SETUP (SourceID + Emergency only a completed reassembly has).
+func enrichedGrantSeen(sub *events.Subscription, party uint32) bool {
+	for _, g := range collectGrants(sub) {
+		if g.SourceID == party && g.Emergency {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFragmentReassemblyRefusesStaleContinuation: a MAC-END arriving far
+// beyond fragMaxGapDibits after the start fragment belongs to a LATER
+// fragmented PDU whose own start was lost — it must not splice onto the stale
+// chain. A stream-adjacent MAC-END (one TDMA frame later) must still
+// reassemble. Fails against the old takeFragment, which spliced at any
+// distance.
+func TestFragmentReassemblyRefusesStaleContinuation(t *testing.T) {
+	const (
+		gssi     = 0x0F5670
+		party    = 0x0123AB
+		carrier  = 2716
+		timeslot = 1
+	)
+	full := cmceSetupEmergencyParty(0x1234, party)
+	split := 24
+
+	run := func(endPos int) bool {
+		bus := events.NewBus(32)
+		defer bus.Close()
+		sub := bus.Subscribe()
+		defer sub.Close()
+		cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+		ingestMACAt(cc, 1020, macResourceStartFragment(gssi, carrier, timeslot, full[:split]))
+		ingestMACAt(cc, endPos, macEndPDU(full[split:]))
+		return enrichedGrantSeen(sub, party)
+	}
+
+	if run(1020 + fragMaxGapDibits + 1) {
+		t.Error("a MAC-END far past fragMaxGapDibits was spliced onto the stale start fragment")
+	}
+	if !run(1020 + 1020) { // the next TDMA frame's MCCH slot — the normal case
+		t.Error("a stream-adjacent MAC-END no longer reassembles (continuity window too tight)")
+	}
+	// A backwards position is a stream discontinuity (resync baseline jump).
+	if run(0) {
+		t.Error("a MAC-END at an earlier stream position was spliced onto the chain")
+	}
+}
+
+// TestFragmentReassemblyAbandonedOnUndecodedControlSlot drives the real NCDB
+// slot path: a start fragment is in flight when a control slot (valid AACH,
+// common control) yields no CRC-clean block — a lost signalling block, quite
+// possibly the chain's continuation. The chain must be abandoned so the next
+// MAC-END cannot splice around the gap. Fails against the old code, which
+// completed the splice and published the corrupt-chain grant.
+func TestFragmentReassemblyAbandonedOnUndecodedControlSlot(t *testing.T) {
+	const (
+		gssi     = 0x0F5670
+		party    = 0x0123AB
+		carrier  = 2716
+		timeslot = 1
+		colour   = 0
+	)
+	full := cmceSetupEmergencyParty(0x1234, party)
+	split := 24
+
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+
+	ingestMACAt(cc, 0, macResourceStartFragment(gssi, carrier, timeslot, full[:split]))
+
+	// An AACH that decodes (header 0 ⇒ downlink common control) over BKN halves
+	// that do not: the SCHPDUsFail shape — a lost control block mid-reassembly.
+	aachType5 := EncodeAACH(make([]byte, 14), colour)
+	aachDibits := TetraBitsToDibits(aachType5)
+	if len(aachDibits) != 15 {
+		t.Fatalf("AACH encoded to %d dibits, want 15", len(aachDibits))
+	}
+	garbage := make([]uint8, ndbBlockDibits)
+	for i := range garbage {
+		garbage[i] = uint8((i*7 + 3) % 4)
+	}
+	cc.decodeDownlinkSlot(1020, garbage, aachDibits[:ndbAACH1Len], aachDibits[ndbAACH1Len:], garbage, nil, nil)
+
+	ingestMACAt(cc, 2040, macEndPDU(full[split:]))
+
+	if enrichedGrantSeen(sub, party) {
+		t.Error("reassembly spliced across an undecoded control slot and published the corrupt-chain grant")
+	}
+}

--- a/internal/radio/tetra/ghost_grant_test.go
+++ b/internal/radio/tetra/ghost_grant_test.go
@@ -12,6 +12,9 @@ import (
 // PDU) — the exact layout ParseMACResource reads (EN 300 392-2 §21.4.3.1 /
 // §21.5.2). ULDL=1 and monitoring-pattern=1 keep parseChanAlloc out of its
 // augmented / frame-18 branches so the TM-SDU begins right after the element.
+// The length indication is stamped with the PDU's real octet length — it used
+// to be a hardcoded 1 ("any non-reserved value"), which the decoder now honours
+// as an 8-bit PDU bound.
 func macResourceGrant(ssi uint32, carrier uint16, timeslot uint8, tmsdu []byte) []byte {
 	w := &cmceBitWriter{}
 	w.u(uint64(MACPDUResource), 2) // MAC PDU type
@@ -19,7 +22,7 @@ func macResourceGrant(ssi uint32, carrier uint16, timeslot uint8, tmsdu []byte) 
 	w.u(0, 1)                      // grant position
 	w.u(0, 2)                      // encryption mode (0 = clear)
 	w.u(0, 1)                      // random access
-	w.u(1, 6)                      // length indication (not 0x3f/0x3e)
+	w.u(0, 6)                      // length indication — stamped below
 	w.u(uint64(addrSSI), 3)        // address type = SSI
 	w.u(uint64(ssi), 24)           // SSI
 	w.u(0, 1)                      // power control absent
@@ -33,7 +36,24 @@ func macResourceGrant(ssi uint32, carrier uint16, timeslot uint8, tmsdu []byte) 
 	w.u(uint64(carrier), 12)       // main carrier number
 	w.u(0, 1)                      // extended carrier absent
 	w.u(1, 2)                      // monitoring pattern (nonzero → no frame-18 field)
-	return append(w.bits, tmsdu...)
+	return stampMACResourceLength(append(w.bits, tmsdu...))
+}
+
+// stampMACResourceLength patches a built MAC-RESOURCE bit vector's 6-bit length
+// indication (bit offsets 7..12: after type+fill+grant-position+encryption+
+// random-access) to the PDU's total length in octets, rounded up — the octet
+// coding both reference decoders implement (osmo-tetra decode_length /
+// tetra-kit decodeLength). A real transmitter fill-pads the final octet; the
+// decoder clamps the bound to the block, so the round-up alone is enough here.
+func stampMACResourceLength(bits []byte) []byte {
+	octets := (len(bits) + 7) / 8
+	if octets == 0 || octets > 0x3a {
+		panic("stampMACResourceLength: PDU length outside the plain length-indication range")
+	}
+	for i := 0; i < 6; i++ {
+		bits[7+i] = byte((octets >> (5 - i)) & 1)
+	}
+	return bits
 }
 
 // cmceReleaseTMSDU / cmceSetupTMSDU wrap a CMCE PDU in a BL-UDATA LLC PDU — the

--- a/internal/radio/tetra/mac.go
+++ b/internal/radio/tetra/mac.go
@@ -297,14 +297,71 @@ func SysInfoMainCarrier(bits []byte) (uint16, bool) {
 	return si.MainCarrier, ok
 }
 
+// macPDULengthBits converts a 6-bit MAC length indication to the total MAC PDU
+// length in BITS, measured from the PDU's first bit (§21.4.3.1). The coding is
+// octets for the π/4-DQPSK channels — osmo-tetra's decode_length returns
+// length_ind octets for 1..0x3a (its Y2/Z2 multipliers are 1 for QPSK) and
+// rx_resrc bounds the SDU with macpdu_length*8; tetra-kit extracts the SDU as
+// decodeLength(li)*8 - pos. Returns 0 for the reserved/marker values (0,
+// 0x3b..0x3f: invalid, second-half stolen, start fragment), meaning "no bound
+// known — the PDU runs to the block end".
+func macPDULengthBits(li uint8) int {
+	if li == 0 || li > 0x3a {
+		return 0
+	}
+	return int(li) * 8
+}
+
+// stripFillBits removes trailing MAC fill bits from a PDU tail: a single '1'
+// followed by zero or more '0's (§23.4.3.2 — "the first fill bit shall be set
+// to 1 and any subsequent fill bits set to 0", so stripping walks the tail in
+// reverse). Mirrors tetra-kit's removeFillBits. Call it only when the PDU's
+// fill-bit indication is set; a tail of all zeros (malformed — no fill '1' to
+// anchor on) strips to empty rather than guessing.
+func stripFillBits(bits []byte) []byte {
+	end := len(bits)
+	for end > 0 && bits[end-1] == 0 {
+		end--
+	}
+	if end > 0 {
+		end-- // the '1' that opens the fill run
+	}
+	return bits[:end]
+}
+
 // tmSDU returns the TM-SDU (Layer-3 PDU) bits following the MAC header, as a
 // one-bit-per-byte slice. Returns nil when the offset runs past the block or
 // the PDU carries no TM-SDU (null / start-fragment-with-nothing).
+//
+// The SDU is bounded by the header's length indication (total PDU length in
+// octets) and stripped of trailing fill bits when the fill-bit indication is
+// set — both per osmo-tetra rx_resrc / tetra-kit. Without the bound, whatever
+// follows the L3 PDU inside the MAC block (fill bits, or a further multiplexed
+// MAC PDU, §23.4.3.1) leaked into the TL-SDU; harmless to parsers that read a
+// fixed prefix, but a parser with trailing presence bits — ParseDNwrkBroadcast's
+// last neighbour cell — read the leaked bits as phantom optional fields
+// (e.g. a frequency-band extension of garbage ⇒ a bogus 1.5 GHz neighbour).
+// Deterministic tail content repeats bit-identically across rebroadcasts, so
+// the corruption also defeated confirm-twice dedup downstream.
 func (m MACResource) tmSDU(bits []byte) []byte {
 	if m.NullPDU || m.TMSDUBitOffset >= len(bits) {
 		return nil
 	}
-	return bits[m.TMSDUBitOffset:]
+	end := len(bits)
+	if n := macPDULengthBits(m.LengthInd); n > 0 && n < end {
+		end = n
+	}
+	if end <= m.TMSDUBitOffset {
+		return nil
+	}
+	sdu := bits[m.TMSDUBitOffset:end]
+	if m.FillBits {
+		sdu = stripFillBits(sdu)
+	}
+	if len(sdu) == 0 {
+		return nil
+	}
+	return sdu
 }
 
 // macFragmentSubtype reports the MAC-FRAG/MAC-END subtype for a PDU whose
@@ -338,16 +395,24 @@ func macFragmentSubtype(bits []byte) (uint8, bool) {
 // D-NWRK-BROADCAST's neighbour list decoded its first ~two cells (before the
 // seam) and garbage after it; deleting exactly one bit at the seam made all
 // seven advertised cells decode cleanly.
+// Like tmSDU, the payload honours the header's own boundary metadata — the
+// MAC-END length indication bounds the PDU and a set fill-bit indication
+// strips the trailing fill run — so the reassembled TM-SDU ends where the PDU
+// ends instead of at the block end (see tmSDU for why leaked tail bits are not
+// harmless).
 func macFragmentPayload(bits []byte) []byte {
 	sub, ok := macFragmentSubtype(bits)
 	if !ok {
 		return nil
 	}
 	r := &bitReader{bits: bits}
-	r.u(3)  // MAC PDU type + subtype
-	r.bit() // fill-bit indication (present on MAC-FRAG and MAC-END alike)
+	r.u(3)               // MAC PDU type + subtype
+	fill := r.bit() == 1 // fill-bit indication (present on MAC-FRAG and MAC-END alike)
+	end := len(bits)
 	if sub == macEnd {
-		r.u(6) // length indication
+		if n := macPDULengthBits(uint8(r.u(6))); n > 0 && n < end {
+			end = n
+		}
 		if r.bit() == 1 {
 			r.u(8) // basic slot-granting element (§21.5.1)
 		}
@@ -355,8 +420,15 @@ func macFragmentPayload(bits []byte) []byte {
 			parseChanAlloc(r) // variable-length channel allocation (§21.5.2)
 		}
 	}
-	if r.pos >= len(bits) {
+	if r.pos >= end {
 		return nil
 	}
-	return bits[r.pos:]
+	payload := bits[r.pos:end]
+	if fill {
+		payload = stripFillBits(payload)
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	return payload
 }

--- a/internal/radio/tetra/mac_boundary_test.go
+++ b/internal/radio/tetra/mac_boundary_test.go
@@ -1,0 +1,198 @@
+package tetra
+
+import (
+	"bytes"
+	"testing"
+)
+
+// These are the regressions for the MAC PDU boundary bugs behind the operator's
+// "totally bogus entries in the neighbours list, like a 1.5 GHz one" report:
+// tmSDU/macFragmentPayload used to hand everything to the block end to L3, so
+// fill bits and any further multiplexed content after the PDU leaked into the
+// TL-SDU. Most L3 parsers read a fixed prefix and never noticed; a parser with
+// trailing presence bits — ParseDNwrkBroadcast's last neighbour cell — read the
+// leaked bits as phantom optional fields. Because the leaked content repeats
+// bit-identically across rebroadcasts, the corruption also defeated the
+// confirm-twice dedup in learnNeighbourCells.
+
+// macResourceSDU builds a MAC-RESOURCE block with an SSI address, no channel
+// allocation, and the given TM-SDU — the shape a D-NWRK-BROADCAST arrives in.
+// Length indication stamped like macResourceGrant.
+func macResourceSDU(ssi uint32, tmsdu []byte) []byte {
+	w := &cmceBitWriter{}
+	w.u(uint64(MACPDUResource), 2) // MAC PDU type
+	w.u(0, 1)                      // fill bit
+	w.u(0, 1)                      // grant position
+	w.u(0, 2)                      // encryption mode (0 = clear)
+	w.u(0, 1)                      // random access
+	w.u(0, 6)                      // length indication — stamped below
+	w.u(uint64(addrSSI), 3)        // address type = SSI
+	w.u(uint64(ssi), 24)           // SSI
+	w.u(0, 1)                      // power control absent
+	w.u(0, 1)                      // slot granting absent
+	w.u(0, 1)                      // channel allocation absent
+	return stampMACResourceLength(append(w.bits, tmsdu...))
+}
+
+// bitsPattern returns n bits of the given value repeated.
+func bitsPattern(bit byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = bit
+	}
+	return out
+}
+
+// TestTMSDUHonoursLengthIndicationAndFill: the TM-SDU must end where the
+// header's length indication says the PDU ends, minus the fill run the
+// fill-bit indication flags — not at the block end. Fails against the old
+// tmSDU, which returned tmsdu+fill+garbage.
+func TestTMSDUHonoursLengthIndicationAndFill(t *testing.T) {
+	tmsdu := []byte{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0}
+	block := macResourceSDU(0x0ABCDE, tmsdu)
+
+	// Fill-pad the PDU to the stamped octet boundary ('1' then '0's,
+	// §23.4.3.2), setting the fill-bit indication, exactly as a transmitter
+	// does. Then extend the block with garbage simulating further multiplexed
+	// content after the PDU.
+	pad := ((len(block) + 7) / 8 * 8) - len(block)
+	if pad == 0 {
+		tmsdu = append(tmsdu, 0, 1, 0)
+		block = macResourceSDU(0x0ABCDE, tmsdu)
+		pad = ((len(block) + 7) / 8 * 8) - len(block)
+	}
+	if pad == 0 {
+		t.Fatal("could not arrange a fill-padded PDU")
+	}
+	block[2] = 1 // fill-bit indication
+	block = append(block, 1)
+	block = append(block, bitsPattern(0, pad-1)...)
+	full := append(append([]byte{}, block...), bitsPattern(1, 48)...)
+
+	m, ok := ParseMACResource(full, false)
+	if !ok {
+		t.Fatal("ParseMACResource rejected the block")
+	}
+	got := m.tmSDU(full)
+	if !bytes.Equal(got, tmsdu) {
+		t.Errorf("tmSDU returned %d bits, want the exact %d-bit TM-SDU\n got: %v\nwant: %v",
+			len(got), len(tmsdu), got, tmsdu)
+	}
+}
+
+// TestMACEndPayloadHonoursLengthAndFill: the MAC-END fragment payload must
+// stop at the header's length indication and drop the flagged fill run.
+func TestMACEndPayloadHonoursLengthAndFill(t *testing.T) {
+	payload := []byte{1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 0}
+	pdu := macEndPDU(payload) // 12-bit header + payload; li written as 0
+	pad := ((len(pdu) + 7) / 8 * 8) - len(pdu)
+	if pad == 0 {
+		payload = append(payload, 0, 1, 1)
+		pdu = macEndPDU(payload)
+		pad = ((len(pdu) + 7) / 8 * 8) - len(pdu)
+	}
+	if pad == 0 {
+		t.Fatal("could not arrange a fill-padded MAC-END")
+	}
+	pdu[3] = 1 // fill-bit indication
+	octets := (len(pdu) + pad) / 8
+	for i := 0; i < 6; i++ { // length indication at bit offsets 4..9
+		pdu[4+i] = byte((octets >> (5 - i)) & 1)
+	}
+	pdu = append(pdu, 1)
+	pdu = append(pdu, bitsPattern(0, pad-1)...)
+	full := append(append([]byte{}, pdu...), bitsPattern(1, 40)...)
+
+	got := macFragmentPayload(full)
+	if !bytes.Equal(got, payload) {
+		t.Errorf("macFragmentPayload returned %d bits, want the exact %d-bit fragment\n got: %v\nwant: %v",
+			len(got), len(payload), got, payload)
+	}
+}
+
+// TestMACFragPayloadStripsFill: a MAC-FRAG with the fill-bit indication set
+// must drop its trailing fill run.
+func TestMACFragPayloadStripsFill(t *testing.T) {
+	payload := []byte{0, 1, 1, 0, 1, 0, 0, 1, 1, 1}
+	pdu := macFragPDU(payload)
+	pdu[3] = 1 // fill-bit indication
+	pdu = append(pdu, 1, 0, 0, 0)
+
+	got := macFragmentPayload(pdu)
+	if !bytes.Equal(got, payload) {
+		t.Errorf("macFragmentPayload returned %v, want %v", got, payload)
+	}
+}
+
+// dnwrkTLSDUTruncatedCell builds a D-NWRK-BROADCAST TL-SDU carrying ONE
+// neighbour cell whose element ends mid-optional-list (LA is the last present
+// field; the six remaining P-bits are omitted because the PDU ends there —
+// the legal type-2 truncation real encoders use). Whatever follows the PDU in
+// the MAC block must NOT be read as those P-bits.
+func dnwrkTLSDUTruncatedCell() []byte {
+	w := &cmceBitWriter{}
+	w.u(0x5, 3)     // MLE PD
+	w.u(0x2, 3)     // D-NWRK-BROADCAST
+	w.u(0xAB54, 16) // cell re-select parameters
+	w.u(0, 2)       // serving cell service level
+	w.u(1, 1)       // O-bit
+	w.u(0, 1)       // P: network time absent
+	w.u(1, 1)       // P: neighbour cells present
+	w.u(1, 3)       // count = 1
+	w.u(9, 5)       // cell id
+	w.u(0, 2)       // reselect types
+	w.u(0, 1)       // not synchronized
+	w.u(0, 2)       // cell service level
+	w.u(2754, 12)   // main carrier
+	w.u(1, 1)       // O-bit: optionals follow
+	w.u(1, 1)       // P: extension present
+	w.u(4, 4)       // band 4
+	w.u(3, 2)       // offset
+	w.u(6, 3)       // duplex spacing
+	w.u(0, 1)       // reverse operation
+	w.u(0, 1)       // P: MCC absent
+	w.u(0, 1)       // P: MNC absent
+	w.u(1, 1)       // P: LA present
+	w.u(1031, 14)   // LA
+	return w.bits   // PDU ends here — remaining six P-bits omitted
+}
+
+// TestNeighbourCellNoPhantomOptionalsFromBlockTail is the end-to-end
+// regression: a MAC block whose D-NWRK-BROADCAST PDU is followed by non-fill
+// content (further multiplexed bits) must decode the neighbour cell EXACTLY,
+// with no phantom optional statuses read from the tail. Ingested twice because
+// deterministic tail garbage repeats bit-identically — the confirm-twice gate
+// does not catch it, which is the point of fixing the boundary instead.
+func TestNeighbourCellNoPhantomOptionalsFromBlockTail(t *testing.T) {
+	tmsdu := append(bl(llcBLUDATA, 0), dnwrkTLSDUTruncatedCell()...)
+	block := macResourceSDU(0x0ABCDE, tmsdu)
+	// The fixture is arranged to end exactly on the stamped octet boundary
+	// (43-bit MAC header + 85-bit TM-SDU = 128 bits), so the garbage tail sits
+	// DIRECTLY after the PDU with no intervening fill — the shape that made the
+	// old block-end tmSDU read tail bits as the cell's omitted P-bits.
+	if len(block)%8 != 0 {
+		t.Fatalf("fixture PDU is %d bits — must be octet-aligned for the tail to abut the PDU", len(block))
+	}
+	// All-ones tail: under the old block-end tmSDU every omitted P-bit read 1
+	// and the cell grew phantom max-tx-power/min-rx/subscriber-class/… fields.
+	full := append(append([]byte{}, block...), bitsPattern(1, 60)...)
+
+	cc := New(Options{SystemName: "Sys", FrequencyHz: 467_912_500})
+	cc.ingestMAC(full)
+	cc.ingestMAC(full)
+
+	cc.mu.Lock()
+	got, ok := cc.neighbours[9]
+	cc.mu.Unlock()
+	if !ok {
+		t.Fatal("neighbour cell 9 did not surface after two identical sightings")
+	}
+	want := NeighbourCell{
+		CellID: 9, MainCarrier: 2754,
+		HasExtension: true, FreqBand: 4, Offset: 3, DuplexSpacing: 6,
+		HasLA: true, LA: 1031,
+	}
+	if got != want {
+		t.Errorf("neighbour cell decoded with phantom fields from the block tail:\n got: %+v\nwant: %+v", got, want)
+	}
+}

--- a/internal/radio/tetra/mle_parse.go
+++ b/internal/radio/tetra/mle_parse.go
@@ -71,6 +71,42 @@ type NeighbourCell struct {
 	MNC    uint16 // 14-bit
 	HasLA  bool
 	LA     uint16 // 14-bit location area
+
+	// Remaining optional per-cell status elements (§18.5.17), surfaced as RAW
+	// field values. The spec-derived semantic mappings (e.g. §18.5.3's BS
+	// service details bit assignments: registration, de-registration, priority
+	// cell, minimum mode service, migration, system wide services, TETRA voice
+	// service, circuit mode data service, reserved, SNDCP service, air
+	// interface encryption service, advanced link — MSB first) are deliberately
+	// NOT rendered as named flags until confirmed against a capture: neither
+	// osmo-tetra nor tetra-kit itemises them, so naming them now would be the
+	// same spec-only guess the CommsType discipline forbids acting on.
+	HasMaxTxPower      bool
+	MaxTxPower         uint8 // 3-bit maximum MS transmit power
+	HasMinRxLevel      bool
+	MinRxLevel         uint8 // 4-bit minimum RX access level
+	HasSubscriberClass bool
+	SubscriberClass    uint16 // 16-bit allowed subscriber classes bitmap
+	HasServiceDetails  bool
+	ServiceDetails     uint16 // 12-bit BS service details bitmap
+	HasTimeshare       bool
+	Timeshare          uint8 // 5-bit timeshare cell / security parameters
+	HasFrameOffset     bool
+	FrameOffset        uint8 // 6-bit TDMA frame offset
+}
+
+// CellLoadName renders a 2-bit cell service level as the load it advertises
+// (§18.5.5): 0 = unknown, 1 = low, 2 = medium, 3 = high.
+func CellLoadName(level uint8) string {
+	switch level & 0x3 {
+	case 1:
+		return "low"
+	case 2:
+		return "medium"
+	case 3:
+		return "high"
+	}
+	return "unknown"
 }
 
 // DNwrkBroadcast is the decoded D-NWRK-BROADCAST PDU.
@@ -131,8 +167,8 @@ func ParseDNwrkBroadcast(tl []byte) (DNwrkBroadcast, bool) {
 }
 
 // parseNeighbourCell reads one Neighbour cell information element (§18.5.17)
-// from r. Unsurfaced optional fields are length-skipped so the NEXT cell in the
-// list stays aligned.
+// from r. Every optional field is decoded with a Has* presence flag, so
+// consumers can distinguish "absent" from a genuine zero.
 func parseNeighbourCell(r *bitReader) (NeighbourCell, bool) {
 	if r.remaining() < 5+2+1+2+12+1 {
 		return NeighbourCell{}, false
@@ -165,12 +201,12 @@ func parseNeighbourCell(r *bitReader) (NeighbourCell, bool) {
 		{10, func() { cell.HasMCC = true; cell.MCC = uint16(r.u(10)) }},
 		{14, func() { cell.HasMNC = true; cell.MNC = uint16(r.u(14)) }},
 		{14, func() { cell.HasLA = true; cell.LA = uint16(r.u(14)) }},
-		{3, func() { r.u(3) }},   // max MS tx power
-		{4, func() { r.u(4) }},   // min RX access level
-		{16, func() { r.u(16) }}, // subscriber class
-		{12, func() { r.u(12) }}, // BS service details
-		{5, func() { r.u(5) }},   // timeshare cell / security parameters
-		{6, func() { r.u(6) }},   // TDMA frame offset
+		{3, func() { cell.HasMaxTxPower = true; cell.MaxTxPower = uint8(r.u(3)) }},
+		{4, func() { cell.HasMinRxLevel = true; cell.MinRxLevel = uint8(r.u(4)) }},
+		{16, func() { cell.HasSubscriberClass = true; cell.SubscriberClass = uint16(r.u(16)) }},
+		{12, func() { cell.HasServiceDetails = true; cell.ServiceDetails = uint16(r.u(12)) }},
+		{5, func() { cell.HasTimeshare = true; cell.Timeshare = uint8(r.u(5)) }},
+		{6, func() { cell.HasFrameOffset = true; cell.FrameOffset = uint8(r.u(6)) }},
 	}
 	for _, o := range opts {
 		if r.remaining() < 1 {

--- a/internal/radio/tetra/mle_parse_test.go
+++ b/internal/radio/tetra/mle_parse_test.go
@@ -44,13 +44,20 @@ func TestParseDNwrkBroadcastLiteral(t *testing.T) {
 	// carrier=2716 (101010011100), O=1, then P-gated: extension present
 	// (band=4 0100, offset=3 11, duplex=6 110, reverse=0), MCC=250
 	// (0011111010), MNC=13 (00000000001101), LA=4001 (00111110100001),
-	// remaining six optionals absent.
+	// max tx power=5 (101), min rx level=10 (1010), subscriber class=0x8001,
+	// BS service details=0x5A5 (010110100101), timeshare=0x15 (10101),
+	// TDMA frame offset=51 (110011).
 	pdu += "00101" + "11" + "1" + "01" + "101010011100" + "1" +
 		"1" + "0100" + "11" + "110" + "0" +
 		"1" + "0011111010" +
 		"1" + "00000000001101" +
 		"1" + "00111110100001" +
-		"0" + "0" + "0" + "0" + "0" + "0"
+		"1" + "101" +
+		"1" + "1010" +
+		"1" + "1000000000000001" +
+		"1" + "010110100101" +
+		"1" + "10101" +
+		"1" + "110011"
 	// Cell 2: id=9 (01001), reselect types=0, synced=0, service=3 (11),
 	// carrier=2720 (101010100000), O=0 — no optionals at all.
 	pdu += "01001" + "00" + "0" + "11" + "101010100000" + "0"
@@ -75,11 +82,23 @@ func TestParseDNwrkBroadcastLiteral(t *testing.T) {
 	if !c1.HasMCC || c1.MCC != 250 || !c1.HasMNC || c1.MNC != 13 || !c1.HasLA || c1.LA != 4001 {
 		t.Errorf("cell 1 identity = %+v, want MCC=250 MNC=13 LA=4001", c1)
 	}
+	if !c1.HasMaxTxPower || c1.MaxTxPower != 5 || !c1.HasMinRxLevel || c1.MinRxLevel != 10 {
+		t.Errorf("cell 1 power/access = %+v, want tx=5 rx=10", c1)
+	}
+	if !c1.HasSubscriberClass || c1.SubscriberClass != 0x8001 ||
+		!c1.HasServiceDetails || c1.ServiceDetails != 0x5A5 {
+		t.Errorf("cell 1 class/services = %+v, want subscriber=0x8001 bs=0x5a5", c1)
+	}
+	if !c1.HasTimeshare || c1.Timeshare != 0x15 || !c1.HasFrameOffset || c1.FrameOffset != 51 {
+		t.Errorf("cell 1 timeshare/offset = %+v, want timeshare=0x15 offset=51", c1)
+	}
 	c2 := nb.Neighbours[1]
 	if c2.CellID != 9 || c2.Synchronized || c2.CellServiceLevel != 3 || c2.MainCarrier != 2720 {
 		t.Errorf("cell 2 = %+v, want id=9 unsynced sl=3 carrier=2720", c2)
 	}
-	if c2.HasExtension || c2.HasMCC || c2.HasMNC || c2.HasLA {
+	if c2.HasExtension || c2.HasMCC || c2.HasMNC || c2.HasLA || c2.HasMaxTxPower ||
+		c2.HasMinRxLevel || c2.HasSubscriberClass || c2.HasServiceDetails ||
+		c2.HasTimeshare || c2.HasFrameOffset {
 		t.Errorf("cell 2 carries optionals it did not broadcast: %+v", c2)
 	}
 }
@@ -169,5 +188,55 @@ func TestLearnNeighbourCellsFillsTopology(t *testing.T) {
 	cc.learnNeighbourCells(nb)
 	if n := countSiteUpdates(); n != 0 {
 		t.Errorf("unchanged rebroadcast published %d site updates, want 0", n)
+	}
+}
+
+// TestLearnNeighbourCellsRejectsImplausibleCells: cells whose decoded content
+// is physically impossible for a TETRA network — a ≥1 GHz frequency-band
+// extension (an operator's field report showed a confirmed 1.5 GHz
+// "neighbour") or a zero main carrier — must never surface, even when the same
+// corrupt content decodes twice; plausible siblings in the same broadcast
+// still do.
+func TestLearnNeighbourCellsRejectsImplausibleCells(t *testing.T) {
+	cc := New(Options{SystemName: "Sys", FrequencyHz: 467_912_500})
+	cc.learnSysInfo(SysInfo{MainCarrier: 2716, FreqBand: 4, Offset: 3, DuplexSpacing: 6})
+
+	nb := DNwrkBroadcast{
+		Neighbours: []NeighbourCell{
+			{CellID: 1, MainCarrier: 2795, HasExtension: true, FreqBand: 15}, // 1.5 GHz
+			{CellID: 2, MainCarrier: 2795, HasExtension: true, FreqBand: 0},  // sub-100 MHz
+			{CellID: 3, MainCarrier: 0},                                      // no carrier
+			{CellID: 4, MainCarrier: 2720, Synchronized: true},               // plausible
+		},
+	}
+	cc.learnNeighbourCells(nb)
+	cc.learnNeighbourCells(nb)
+
+	got := cc.TopologySnapshot().Neighbors
+	if len(got) != 1 || got[0].Site != 4 {
+		t.Fatalf("surfaced neighbours = %+v, want only the plausible cell 4", got)
+	}
+}
+
+// TestNeighbourStatusFlagsRendersStatuses: the StatusFlags string carries the
+// advertised load and the raw status fields when present, and never renders an
+// absent optional as a zero.
+func TestNeighbourStatusFlagsRendersStatuses(t *testing.T) {
+	cell := NeighbourCell{
+		Synchronized:      true,
+		CellServiceLevel:  2,
+		HasLA:             true,
+		LA:                1031,
+		HasServiceDetails: true,
+		ServiceDetails:    0x5A5,
+		HasTimeshare:      true,
+		Timeshare:         0x15,
+	}
+	if got, want := neighbourStatusFlags(cell), "synced,load=medium,la=1031,bs_svc=0x5a5,timeshare=0x15"; got != want {
+		t.Errorf("StatusFlags = %q, want %q", got, want)
+	}
+	bare := NeighbourCell{}
+	if got, want := neighbourStatusFlags(bare), "unsynced"; got != want {
+		t.Errorf("bare StatusFlags = %q, want %q (absent fields must be omitted, not zero)", got, want)
 	}
 }


### PR DESCRIPTION
Root causes of the operator's bogus D-NWRK-BROADCAST neighbour entries
(e.g. a confirmed 1.5 GHz "neighbour" on a 400 MHz network):

1. tmSDU/macFragmentPayload handed everything to the block end to L3:
   the MAC-RESOURCE length indication (total PDU octets — osmo-tetra
   rx_resrc, tetra-kit decodeLength) was parsed but never applied, and
   the fill-bit indication was read but fill never stripped
   (tetra-kit removeFillBits; EN 300 392-2 §23.4.3.2). Fill bits and
   any further multiplexed content after the PDU leaked into the
   TL-SDU; parsers reading a fixed prefix never noticed, but
   ParseDNwrkBroadcast's trailing presence bits read the leaked tail
   as phantom optional fields on the last neighbour cell.

2. The MAC fragment reassembly spliced a MAC-FRAG/MAC-END onto
   whatever start fragment was in flight, with no continuity check.
   Around a lost signalling block that splices two different PDUs
   into a plausible corrupt L3 PDU. Fragments now must be
   stream-adjacent (fragMaxGapDibits, mirroring osmo-tetra-sq5bpf's
   fragslot aging), and an AACH-confirmed control slot that yields no
   CRC-clean block abandons the in-flight chain.

Both corruptions are deterministic — broadcast content and
fragmentation split points repeat — so the same corrupt cells decoded
bit-identically across rebroadcasts and defeated the confirm-twice
dedup in learnNeighbourCells.

Regressions (all fail against the old code):
TestTMSDUHonoursLengthIndicationAndFill,
TestMACEndPayloadHonoursLengthAndFill, TestMACFragPayloadStripsFill,
TestFragmentReassemblyRefusesStaleContinuation,
TestFragmentReassemblyAbandonedOnUndecodedControlSlot, and
TestNeighbourCellNoPhantomOptionalsFromBlockTail (fails once the
neighbour-cell optionals are surfaced in the follow-up commit).
Test builders now stamp real octet lengths instead of a placeholder
length indication the decoder used to ignore.

Refs the Discord field report (neighbour list carrying bogus entries).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CiseHJLU1QwzTorXivo24r