### PR TITLE
terms: add Terms of Service, acknowledged once at install/first run

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -eu
           STAGE=dist/staging
-          cp README.md LICENSE config.example.yaml "$STAGE/"
+          cp README.md LICENSE TERMS_OF_SERVICE.md config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
           # All three consoles nest under gophertrunk-web/; the Inno
           # Setup script copies the whole tree into <DataRoot>\web.

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -94,7 +94,7 @@ jobs:
               -ldflags "${LDFLAGS}" \
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
-            cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+            cp README.md LICENSE TERMS_OF_SERVICE.md config.example.yaml "dist/${NAME}/"
             mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
             cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
             cp -r web/siglab/dist/. "dist/${NAME}/gophertrunk-web/siglab/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -eu
           STAGE=dist/staging
-          cp README.md LICENSE config.example.yaml "$STAGE/"
+          cp README.md LICENSE TERMS_OF_SERVICE.md config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
           # Standalone browser consoles bundled into each release. All
           # three UIs nest under gophertrunk-web/ (standard console at
@@ -181,7 +181,7 @@ jobs:
             -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME} ${RR_LDFLAGS}" \
             -o "dist/${NAME}/gophertrunk.exe" \
             ./cmd/gophertrunk
-          cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+          cp README.md LICENSE TERMS_OF_SERVICE.md config.example.yaml "dist/${NAME}/"
           cp docs/install-windows.md "dist/${NAME}/INSTALL-WINDOWS.md"
           mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
           cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
@@ -263,7 +263,7 @@ jobs:
               -ldflags "${LDFLAGS}" \
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
-            cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+            cp README.md LICENSE TERMS_OF_SERVICE.md config.example.yaml "dist/${NAME}/"
             mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
             cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
             cp -r web/siglab/dist/. "dist/${NAME}/gophertrunk-web/siglab/"
@@ -343,7 +343,7 @@ jobs:
               -ldflags "${LDFLAGS}" \
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
-            cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+            cp README.md LICENSE TERMS_OF_SERVICE.md config.example.yaml "dist/${NAME}/"
             mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
             cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
             cp -r web/siglab/dist/. "dist/${NAME}/gophertrunk-web/siglab/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **Terms of Service, acknowledged once at install/first run**
+  (`TERMS_OF_SERVICE.md`). A short, plain-language ToS in line with other
+  open SDR software: lawful monitoring is the operator's responsibility, no
+  defeating encryption, no misuse of received content, recording-privacy
+  duties, not for safety-of-life use, receive-only posture, vocoder patent
+  note, export compliance, and the Apache-2.0 no-warranty terms. The Windows
+  installer adds a mandatory acknowledgment page (and records acceptance);
+  on every other install path the CLI shows the terms once on first
+  interactive run. Unattended installs acknowledge with
+  `gophertrunk terms accept` or `GOPHERTRUNK_ACCEPT_TERMS=1`; a new
+  `gophertrunk terms [show|status|accept]` subcommand reads/checks/records.
+  Acceptance is a local marker file under the user config directory —
+  nothing ever leaves the machine. `version`, `help`, and `terms` itself
+  never require acceptance.
+
 ### Fixed
 - **Talkgroups auto-discovered on analog trunking systems are no longer
   labeled mode "D" (digital)** (#1143 follow-up). Discovered-talkgroup mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,13 @@ COPY --from=builder /out/gophertrunk /usr/local/bin/gophertrunk
 # Default ports: HTTP API on 8080, gRPC on 50051. Override with config.
 EXPOSE 8080 50051
 
+# The daemon requires the Terms of Service (TERMS_OF_SERVICE.md, also
+# printed by `gophertrunk terms`) to be acknowledged on first run; a
+# container has no TTY to prompt on, so pass the acknowledgment
+# explicitly at run time:
+#   docker run -e GOPHERTRUNK_ACCEPT_TERMS=1 ...
+# It is deliberately NOT baked into the image — accepting is the
+# operator's act, not the build's.
+
 ENTRYPOINT ["/usr/local/bin/gophertrunk"]
 CMD ["run", "-config", "/etc/gophertrunk/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -411,6 +411,14 @@ in:
 
 More ways to help: [docs/support.md](docs/support.md).
 
-## License
+## License & Terms of Service
 
-See [LICENSE](LICENSE).
+The code is licensed under [Apache 2.0](LICENSE). Using GopherTrunk
+additionally requires acknowledging the short
+[Terms of Service](TERMS_OF_SERVICE.md) — the usual open-SDR ground
+rules (lawful monitoring only, no defeating encryption, not for
+safety-of-life use, no warranty). The Windows installer asks during
+setup; on every other platform the CLI asks once on first run.
+Unattended installs (services, containers, CI) accept with
+`gophertrunk terms accept` or `GOPHERTRUNK_ACCEPT_TERMS=1`; nothing is
+ever sent anywhere — acceptance is recorded in a local marker file.

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,114 @@
+# GopherTrunk Terms of Service
+
+**Version 1 (4 September 2026)**
+
+GopherTrunk is free, open-source software for receiving and decoding
+trunked and conventional radio systems with software-defined radio
+hardware. Like any radio receiver, what you may lawfully do with it
+depends on where you are and how you use it.
+
+You must acknowledge these terms when you install GopherTrunk, or on
+its first run. By installing, running, or using GopherTrunk you accept
+them. If you do not accept them, do not install or use the software.
+
+## 1. License
+
+GopherTrunk's source code is licensed under the Apache License 2.0
+(see `LICENSE`); bundled third-party components are listed in
+`THIRD_PARTY_LICENSES.md`. These terms govern your *use* of the
+software. They supplement, and do not replace or restrict, the rights
+the Apache License grants you to copy, modify, and redistribute the
+code.
+
+## 2. You are responsible for using it lawfully
+
+Laws on radio monitoring differ by country, state, and province.
+Depending on your jurisdiction, some or all of the following may be
+restricted or illegal: listening to particular services or
+frequencies, recording transmissions, using a scanner in a vehicle or
+in the commission of a crime, and disclosing or acting on what you
+hear. Examples include 47 U.S.C. 605 and the Electronic Communications
+Privacy Act in the United States; comparable laws exist in most other
+countries.
+
+**You are solely responsible for knowing and complying with every law
+that applies to you.** The GopherTrunk contributors do not and cannot
+advise you on legality, and nothing in the software or its
+documentation is legal advice. If monitoring a system would be
+unlawful where you are, do not use GopherTrunk to monitor it.
+
+## 3. Encrypted and protected communications
+
+GopherTrunk does not decrypt communications, and you must not use it
+to attempt to defeat, circumvent, or unlawfully intercept encryption
+or any other protection. The optional `cryptolab` research toolkit is
+provided for education and for the analysis of systems you own or are
+explicitly authorized to test, and for nothing else.
+
+## 4. What you do with received content
+
+Where the law protects the content of communications, do not divulge,
+publish, sell, or otherwise use it for your benefit or anyone else's.
+Never use GopherTrunk to facilitate a crime, to interfere with
+public-safety operations, or to stalk, harass, or track any person.
+
+## 5. Recordings and privacy
+
+Voice recordings, call logs, radio IDs, talkgroup activity, and
+similar metadata that GopherTrunk stores may constitute personal data
+about identifiable people. If you record, retain, publish, or share
+them, privacy and data-protection law (such as the GDPR) may apply to
+you as the responsible party. Handle them accordingly.
+
+## 6. Not for safety-of-life use
+
+GopherTrunk is a hobbyist and research tool. It is not a certified
+receiver; it can and does mis-decode, drop, delay, or entirely miss
+traffic. Never rely on it for emergency response, life safety,
+navigation, or any other purpose where a missed or incorrect message
+could cause harm.
+
+## 7. Receive only
+
+GopherTrunk is designed as a receiver. Its signal-generation features
+(such as `gen`, `replay`, and Signal Lab) produce IQ data for offline
+testing; feeding that data to transmit-capable hardware is a radio
+transmission, which in nearly every jurisdiction requires an
+appropriate license and proper shielding or a dummy load. You are
+solely responsible for any RF you emit.
+
+## 8. Patents (voice codecs)
+
+GopherTrunk includes clean-room implementations of digital voice
+decoders (IMBE, AMBE+2, TETRA ACELP). Some of the techniques they use
+are patent-encumbered in some jurisdictions. It is your responsibility
+to determine whether your use requires a patent license where you are.
+See `docs/vocoders.md`.
+
+## 9. Export control
+
+You must comply with all export, re-export, and sanctions laws that
+apply to obtaining and using this software.
+
+## 10. No warranty; limitation of liability
+
+The software is provided **"AS IS", without warranty of any kind**,
+and the contributors are not liable for damages arising from its use,
+as set out in Sections 7 and 8 of the Apache License 2.0. This
+includes any consequence of unlawful use, of missed or mis-decoded
+traffic, or of reliance on decoded content.
+
+## 11. Changes
+
+These terms carry a version number. When they change, you will be
+asked to acknowledge the new version on the next install, or on the
+first run after upgrading.
+
+---
+
+Acknowledgment is recorded locally only; nothing is sent anywhere.
+The Windows installer records it after its Terms of Service page, and
+on every platform the CLI records it under your user configuration
+directory the first time you accept: interactively on a terminal, via
+`gophertrunk terms accept`, or with `GOPHERTRUNK_ACCEPT_TERMS=1` for
+unattended or containerized installs.

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -47,6 +47,12 @@ import (
 )
 
 func main() {
+	// Install/first-run gate: every command except version/help/terms
+	// requires the Terms of Service to have been acknowledged (see
+	// TERMS_OF_SERVICE.md and cmd/gophertrunk/terms.go).
+	if !termsExempt(os.Args) {
+		requireTermsAcceptance()
+	}
 	if len(os.Args) < 2 {
 		runDaemon(os.Args[1:])
 		return
@@ -115,6 +121,8 @@ func main() {
 		runBundle(os.Args[2:])
 	case "import-pdf":
 		runImport(os.Args[2:])
+	case "terms":
+		runTerms(os.Args[2:])
 	case "daemon", "run":
 		runDaemon(os.Args[2:])
 	case "help", "--help", "-h":
@@ -152,6 +160,7 @@ USAGE:
   gophertrunk config serve [flags]    standalone web Config Builder/Editor (browser UI)
   gophertrunk config [tui] [flags]    standalone terminal Config Builder/Editor (no browser)
   gophertrunk import-pdf [flags]      import a RadioReference PDF into config.yaml
+  gophertrunk terms [show|status|accept]  read / check / acknowledge the Terms of Service
   gophertrunk version                 print build version
   gophertrunk help                    show this message`)
 }

--- a/cmd/gophertrunk/terms.go
+++ b/cmd/gophertrunk/terms.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/terms"
+)
+
+// termsExempt reports whether the invoked command may run without the
+// terms-of-service gate: reading the version, the help text, or the
+// terms themselves must never require accepting them first.
+func termsExempt(args []string) bool {
+	if len(args) < 2 {
+		return false // bare `gophertrunk` runs the daemon
+	}
+	switch args[1] {
+	case "version", "--version", "-v", "help", "--help", "-h", "terms":
+		return true
+	}
+	return false
+}
+
+// requireTermsAcceptance is the install/first-run gate: every real
+// command checks for a recorded acknowledgment of the current
+// TERMS_OF_SERVICE.md revision before doing anything else. Acceptance
+// can come from the Windows installer's Terms page (it writes the same
+// marker), a prior interactive acceptance, `gophertrunk terms accept`,
+// or GOPHERTRUNK_ACCEPT_TERMS=1 for unattended installs. On a TTY with
+// none of those, the terms are shown and acceptance is prompted for;
+// off a TTY the process exits with EX_NOPERM and instructions.
+func requireTermsAcceptance() {
+	dir, dirErr := terms.DefaultDir()
+	if dirErr == nil && terms.IsAccepted(dir) {
+		return
+	}
+	if terms.EnvAccepted() {
+		// Persist best-effort so later runs without the env var still
+		// pass; the env var alone is sufficient for this run either way.
+		if dirErr == nil {
+			_ = terms.Record(dir, "env")
+		}
+		return
+	}
+
+	if !stdinIsTerminal() {
+		fmt.Fprintf(os.Stderr,
+			"gophertrunk: the Terms of Service have not been acknowledged on this machine.\n"+
+				"Run `gophertrunk terms` to read them, then `gophertrunk terms accept` to\n"+
+				"acknowledge, or set %s=1 for unattended installs.\n", terms.EnvVar)
+		os.Exit(77) // EX_NOPERM
+	}
+
+	// Interactive first run (or first run after a terms revision).
+	if dirErr == nil {
+		if prior := terms.AcceptedVersion(dir); prior > 0 {
+			fmt.Fprintf(os.Stderr,
+				"The GopherTrunk Terms of Service have changed since you last accepted them (v%d -> v%d).\n\n",
+				prior, terms.Version)
+		}
+	}
+	fmt.Print(terms.Text)
+	fmt.Fprint(os.Stderr, "\nDo you accept the GopherTrunk Terms of Service? [yes/no]: ")
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "yes", "y":
+	default:
+		fmt.Fprintln(os.Stderr, "gophertrunk: terms not accepted; exiting.")
+		os.Exit(1)
+	}
+	if dirErr != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: cannot resolve a config directory to record acceptance (%v); you will be asked again next run\n", dirErr)
+		return
+	}
+	if err := terms.Record(dir, "interactive"); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: could not record acceptance (%v); you will be asked again next run\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Thanks - acceptance recorded at %s.\n\n", terms.MarkerPath(dir))
+}
+
+// runTerms implements `gophertrunk terms [show|status|accept]`.
+func runTerms(args []string) {
+	sub := "show"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "show":
+		fmt.Print(terms.Text)
+	case "status":
+		dir, err := terms.DefaultDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "terms: %v\n", err)
+			os.Exit(1)
+		}
+		if v := terms.AcceptedVersion(dir); v >= terms.Version {
+			fmt.Printf("accepted: terms v%d (marker: %s)\n", v, terms.MarkerPath(dir))
+		} else if v > 0 {
+			fmt.Printf("outdated: terms v%d accepted, current is v%d; run `gophertrunk terms accept`\n", v, terms.Version)
+			os.Exit(1)
+		} else {
+			fmt.Printf("not accepted: run `gophertrunk terms accept` (marker would be: %s)\n", terms.MarkerPath(dir))
+			os.Exit(1)
+		}
+	case "accept":
+		// An explicit accept command IS the acknowledgment, so it works
+		// non-interactively too (provisioning scripts, Dockerfiles).
+		dir, err := terms.DefaultDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "terms: %v\n", err)
+			os.Exit(1)
+		}
+		if err := terms.Record(dir, "command"); err != nil {
+			fmt.Fprintf(os.Stderr, "terms: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("accepted: terms v%d recorded at %s\n", terms.Version, terms.MarkerPath(dir))
+	default:
+		fmt.Fprintln(os.Stderr, "usage: gophertrunk terms [show|status|accept]")
+		os.Exit(2)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,13 @@ services:
     container_name: gophertrunk
     restart: unless-stopped
 
+    # The daemon requires the Terms of Service to be acknowledged on
+    # first run (TERMS_OF_SERVICE.md; `gophertrunk terms` prints them).
+    # A container has no TTY to prompt on, so setting this env var IS
+    # your acknowledgment — read the terms before you uncomment it.
+    # environment:
+    #   - GOPHERTRUNK_ACCEPT_TERMS=1
+
     ports:
       - "127.0.0.1:8080:8080"   # HTTP REST + SSE + WebSocket
       - "127.0.0.1:50051:50051" # gRPC

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -34,7 +34,13 @@ anywhere — the contents are the same.
 
 ## 2. Run the installer
 
-Double-click `setup.exe` and accept the defaults. The installer:
+Double-click `setup.exe` and accept the defaults. After the license
+page, the installer shows the short GopherTrunk **Terms of Service**
+(lawful monitoring only, no warranty — the usual scanner-software
+ground rules) and asks you to tick the acknowledgment box before it
+will continue; your acceptance is recorded locally so the CLI never
+asks again. If you use the portable ZIP instead, `gophertrunk` shows
+the same terms once on first run. The installer:
 
 - Copies `gophertrunk.exe` to `C:\Program Files\GopherTrunk\` —
   a single static binary, no DLLs to ship. **This is the only

--- a/installer/windows/gophertrunk.iss
+++ b/installer/windows/gophertrunk.iss
@@ -16,6 +16,11 @@
   #define AppVersion "v0.0.0-dev"
 #endif
 
+; Terms-of-service revision this installer acknowledges. Keep in sync
+; with internal/terms.Version (the CLI's first-run gate enforces the
+; same revision and reads the same marker file this installer writes).
+#define TermsVersion "1"
+
 [Setup]
 AppId={{B6B6CC9A-3A70-4B23-8E2E-8E0C7A2F4B30}
 AppName=GopherTrunk
@@ -51,6 +56,12 @@ Source: "..\..\dist\staging\gophertrunk.exe";  DestDir: "{app}"; Flags: ignoreve
 Source: "..\..\dist\staging\config.example.yaml"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\README.md";        DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\LICENSE";          DestDir: "{app}"; Flags: ignoreversion
+; Terms of Service: installed next to the LICENSE, and extracted a
+; second time at wizard runtime (dontcopy) so the mandatory
+; acknowledgment page below can display it. Sourced straight from the
+; repo root, like LicenseFile above.
+Source: "..\..\TERMS_OF_SERVICE.md";           DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\TERMS_OF_SERVICE.md";           Flags: dontcopy
 Source: "..\..\dist\staging\INSTALL-WINDOWS.md"; DestDir: "{app}"; Flags: ignoreversion
 ; Zadig WinUSB driver installer — bundled so the operator doesn't
 ; have to chase a download. GPL-3.0; upstream source is at
@@ -193,9 +204,63 @@ Filename: "{code:WebDir}\index.html"; \
 [Code]
 var
   DataDirPage: TInputDirWizardPage;
+  TermsPage: TWizardPage;
+  TermsMemo: TNewMemo;
+  TermsAcceptCheck: TNewCheckBox;
+
+// The Next button on the Terms page follows the checkbox: unchecked
+// means the operator cannot proceed past the Terms of Service.
+procedure TermsAcceptChanged(Sender: TObject);
+begin
+  WizardForm.NextButton.Enabled := TermsAcceptCheck.Checked;
+end;
+
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  if CurPageID = TermsPage.ID then
+    WizardForm.NextButton.Enabled := TermsAcceptCheck.Checked;
+end;
 
 procedure InitializeWizard;
+var
+  TermsText: AnsiString;
 begin
+  // Mandatory Terms of Service acknowledgment, right after the Apache
+  // LICENSE page. A custom page (memo + checkbox) rather than a second
+  // LicenseFile because Inno supports only one of those. Like the
+  // built-in license page, this page is skipped by /SILENT installs —
+  // running the installer silently implies acceptance, and the marker
+  // below is written either way. The CLI's own first-run gate
+  // (cmd/gophertrunk/terms.go) is the backstop for every other install
+  // path (portable ZIP, tarballs, go install, Docker).
+  TermsPage := CreateCustomPage(wpLicense, 'Terms of Service',
+    'Please read and acknowledge the GopherTrunk Terms of Service.');
+  TermsMemo := TNewMemo.Create(TermsPage);
+  TermsMemo.Parent := TermsPage.Surface;
+  TermsMemo.Left := 0;
+  TermsMemo.Top := 0;
+  TermsMemo.Width := TermsPage.SurfaceWidth;
+  TermsMemo.Height := TermsPage.SurfaceHeight - ScaleY(28);
+  TermsMemo.ScrollBars := ssVertical;
+  TermsMemo.ReadOnly := True;
+  TermsMemo.WordWrap := True;
+  // TERMS_OF_SERVICE.md is kept ASCII-only (pinned by a repo test) so
+  // this AnsiString round-trip cannot mangle it.
+  ExtractTemporaryFile('TERMS_OF_SERVICE.md');
+  if LoadStringFromFile(ExpandConstant('{tmp}\TERMS_OF_SERVICE.md'), TermsText) then
+    TermsMemo.Text := TermsText
+  else
+    TermsMemo.Text := 'See TERMS_OF_SERVICE.md in the install folder ' +
+      '(and at https://github.com/MattCheramie/GopherTrunk).';
+  TermsAcceptCheck := TNewCheckBox.Create(TermsPage);
+  TermsAcceptCheck.Parent := TermsPage.Surface;
+  TermsAcceptCheck.Left := 0;
+  TermsAcceptCheck.Top := TermsMemo.Top + TermsMemo.Height + ScaleY(8);
+  TermsAcceptCheck.Width := TermsPage.SurfaceWidth;
+  TermsAcceptCheck.Caption := 'I have read and accept the Terms of Service';
+  TermsAcceptCheck.Checked := False;
+  TermsAcceptCheck.OnClick := @TermsAcceptChanged;
+
   // Single data-folder choice. The executable always installs to
   // {app} (Program Files); this page picks the SEPARATE, user-owned
   // data root that holds everything else — config files, voice-call
@@ -223,6 +288,28 @@ begin
   DataDirPage.Add('Data folder:');
   DataDirPage.Values[0] :=
     ExpandConstant('{userdocs}\GopherTrunk');
+end;
+
+// Record the Terms of Service acknowledgment where the CLI's first-run
+// gate looks for it: %AppData%\GopherTrunk\terms-accepted (Go's
+// os.UserConfigDir() + "GopherTrunk" — see internal/terms). Written at
+// ssPostInstall, i.e. only after the operator got past the mandatory
+// Terms page (or ran /SILENT, which implies acceptance). Note the
+// installer runs elevated, so {userappdata} is the elevating user's
+// profile; a different Windows account running GopherTrunk later is
+// prompted by the CLI gate instead — acknowledgment is per-user.
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then begin
+    ForceDirectories(ExpandConstant('{userappdata}\GopherTrunk'));
+    SaveStringToFile(
+      ExpandConstant('{userappdata}\GopherTrunk\terms-accepted'),
+      '# GopherTrunk terms-of-service acceptance record (see TERMS_OF_SERVICE.md).' + #13#10 +
+      'version={#TermsVersion}' + #13#10 +
+      'accepted_at=' + GetDateTimeString('yyyy/mm/dd hh:nn:ss', '-', ':') + #13#10 +
+      'accepted_via=windows-installer' + #13#10,
+      False);
+  end;
 end;
 
 // DataDir is the user-chosen data root. ConfigDir and WebDir return

--- a/internal/terms/TERMS_OF_SERVICE.md
+++ b/internal/terms/TERMS_OF_SERVICE.md
@@ -1,0 +1,114 @@
+# GopherTrunk Terms of Service
+
+**Version 1 (4 September 2026)**
+
+GopherTrunk is free, open-source software for receiving and decoding
+trunked and conventional radio systems with software-defined radio
+hardware. Like any radio receiver, what you may lawfully do with it
+depends on where you are and how you use it.
+
+You must acknowledge these terms when you install GopherTrunk, or on
+its first run. By installing, running, or using GopherTrunk you accept
+them. If you do not accept them, do not install or use the software.
+
+## 1. License
+
+GopherTrunk's source code is licensed under the Apache License 2.0
+(see `LICENSE`); bundled third-party components are listed in
+`THIRD_PARTY_LICENSES.md`. These terms govern your *use* of the
+software. They supplement, and do not replace or restrict, the rights
+the Apache License grants you to copy, modify, and redistribute the
+code.
+
+## 2. You are responsible for using it lawfully
+
+Laws on radio monitoring differ by country, state, and province.
+Depending on your jurisdiction, some or all of the following may be
+restricted or illegal: listening to particular services or
+frequencies, recording transmissions, using a scanner in a vehicle or
+in the commission of a crime, and disclosing or acting on what you
+hear. Examples include 47 U.S.C. 605 and the Electronic Communications
+Privacy Act in the United States; comparable laws exist in most other
+countries.
+
+**You are solely responsible for knowing and complying with every law
+that applies to you.** The GopherTrunk contributors do not and cannot
+advise you on legality, and nothing in the software or its
+documentation is legal advice. If monitoring a system would be
+unlawful where you are, do not use GopherTrunk to monitor it.
+
+## 3. Encrypted and protected communications
+
+GopherTrunk does not decrypt communications, and you must not use it
+to attempt to defeat, circumvent, or unlawfully intercept encryption
+or any other protection. The optional `cryptolab` research toolkit is
+provided for education and for the analysis of systems you own or are
+explicitly authorized to test, and for nothing else.
+
+## 4. What you do with received content
+
+Where the law protects the content of communications, do not divulge,
+publish, sell, or otherwise use it for your benefit or anyone else's.
+Never use GopherTrunk to facilitate a crime, to interfere with
+public-safety operations, or to stalk, harass, or track any person.
+
+## 5. Recordings and privacy
+
+Voice recordings, call logs, radio IDs, talkgroup activity, and
+similar metadata that GopherTrunk stores may constitute personal data
+about identifiable people. If you record, retain, publish, or share
+them, privacy and data-protection law (such as the GDPR) may apply to
+you as the responsible party. Handle them accordingly.
+
+## 6. Not for safety-of-life use
+
+GopherTrunk is a hobbyist and research tool. It is not a certified
+receiver; it can and does mis-decode, drop, delay, or entirely miss
+traffic. Never rely on it for emergency response, life safety,
+navigation, or any other purpose where a missed or incorrect message
+could cause harm.
+
+## 7. Receive only
+
+GopherTrunk is designed as a receiver. Its signal-generation features
+(such as `gen`, `replay`, and Signal Lab) produce IQ data for offline
+testing; feeding that data to transmit-capable hardware is a radio
+transmission, which in nearly every jurisdiction requires an
+appropriate license and proper shielding or a dummy load. You are
+solely responsible for any RF you emit.
+
+## 8. Patents (voice codecs)
+
+GopherTrunk includes clean-room implementations of digital voice
+decoders (IMBE, AMBE+2, TETRA ACELP). Some of the techniques they use
+are patent-encumbered in some jurisdictions. It is your responsibility
+to determine whether your use requires a patent license where you are.
+See `docs/vocoders.md`.
+
+## 9. Export control
+
+You must comply with all export, re-export, and sanctions laws that
+apply to obtaining and using this software.
+
+## 10. No warranty; limitation of liability
+
+The software is provided **"AS IS", without warranty of any kind**,
+and the contributors are not liable for damages arising from its use,
+as set out in Sections 7 and 8 of the Apache License 2.0. This
+includes any consequence of unlawful use, of missed or mis-decoded
+traffic, or of reliance on decoded content.
+
+## 11. Changes
+
+These terms carry a version number. When they change, you will be
+asked to acknowledge the new version on the next install, or on the
+first run after upgrading.
+
+---
+
+Acknowledgment is recorded locally only; nothing is sent anywhere.
+The Windows installer records it after its Terms of Service page, and
+on every platform the CLI records it under your user configuration
+directory the first time you accept: interactively on a terminal, via
+`gophertrunk terms accept`, or with `GOPHERTRUNK_ACCEPT_TERMS=1` for
+unattended or containerized installs.

--- a/internal/terms/terms.go
+++ b/internal/terms/terms.go
@@ -1,0 +1,108 @@
+// Package terms embeds the GopherTrunk Terms of Service and records the
+// operator's acknowledgment of them.
+//
+// The canonical document is TERMS_OF_SERVICE.md at the repository root;
+// the copy embedded here must stay byte-identical to it (pinned by
+// TestEmbeddedTermsMatchCanonicalDocument). Acknowledgment is recorded
+// locally as a small marker file under the operator's user config
+// directory — the same location the Windows installer writes after its
+// Terms of Service wizard page — and nothing is ever sent anywhere.
+package terms
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Version is the terms-of-service revision this binary ships. Bump it
+// whenever TERMS_OF_SERVICE.md changes materially; operators are then
+// asked to re-acknowledge on the next run. Keep in sync with the
+// TermsVersion define in installer/windows/gophertrunk.iss, which
+// records the same marker on behalf of the Windows installer.
+const Version = 1
+
+// Text is the full Terms of Service document.
+//
+//go:embed TERMS_OF_SERVICE.md
+var Text string
+
+// EnvVar names the environment variable that accepts the terms for
+// unattended installs (services, containers, CI).
+const EnvVar = "GOPHERTRUNK_ACCEPT_TERMS"
+
+// markerName is the acceptance-record filename. The Windows installer
+// writes the same file (see installer/windows/gophertrunk.iss).
+const markerName = "terms-accepted"
+
+// DefaultDir returns the directory the acceptance marker lives in:
+// <os.UserConfigDir()>/GopherTrunk (%AppData%\GopherTrunk on Windows,
+// ~/.config/GopherTrunk on Linux), falling back to ~/.gophertrunk when
+// the platform config dir cannot be resolved.
+func DefaultDir() (string, error) {
+	if dir, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(dir, "GopherTrunk"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("terms: no user config or home directory: %w", err)
+	}
+	return filepath.Join(home, ".gophertrunk"), nil
+}
+
+// MarkerPath returns the acceptance-marker path under dir.
+func MarkerPath(dir string) string { return filepath.Join(dir, markerName) }
+
+// AcceptedVersion parses the marker file under dir and returns the
+// terms version it records, or 0 when there is no (readable, parseable)
+// marker. A marker from an older terms revision therefore reads as
+// "accepted, but not the current version".
+func AcceptedVersion(dir string) int {
+	b, err := os.ReadFile(MarkerPath(dir))
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "version="); ok {
+			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// IsAccepted reports whether the current terms Version has been
+// acknowledged under dir.
+func IsAccepted(dir string) bool { return AcceptedVersion(dir) >= Version }
+
+// Record writes the acceptance marker under dir, creating the directory
+// if needed. via names how acceptance happened ("interactive", "env",
+// "command", "windows-installer") for the operator's own reference.
+func Record(dir, via string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("terms: %w", err)
+	}
+	body := fmt.Sprintf(
+		"# GopherTrunk terms-of-service acceptance record (see TERMS_OF_SERVICE.md).\n"+
+			"version=%d\naccepted_at=%s\naccepted_via=%s\n",
+		Version, time.Now().UTC().Format(time.RFC3339), via)
+	if err := os.WriteFile(MarkerPath(dir), []byte(body), 0o644); err != nil {
+		return fmt.Errorf("terms: %w", err)
+	}
+	return nil
+}
+
+// EnvAccepted reports whether GOPHERTRUNK_ACCEPT_TERMS is set to an
+// affirmative value, the unattended-install acceptance path.
+func EnvAccepted() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvVar))) {
+	case "1", "true", "yes", "y":
+		return true
+	}
+	return false
+}

--- a/internal/terms/terms_test.go
+++ b/internal/terms/terms_test.go
@@ -1,0 +1,97 @@
+package terms
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The canonical document is TERMS_OF_SERVICE.md at the repository root;
+// go:embed cannot reach above the package directory, so the package
+// carries a copy. This pin is what keeps the two from drifting apart —
+// edit the root document, then `cp` it over internal/terms/'s copy.
+func TestEmbeddedTermsMatchCanonicalDocument(t *testing.T) {
+	canonical, err := os.ReadFile(filepath.Join("..", "..", "TERMS_OF_SERVICE.md"))
+	if err != nil {
+		t.Fatalf("read canonical TERMS_OF_SERVICE.md: %v", err)
+	}
+	if string(canonical) != Text {
+		t.Fatalf("internal/terms/TERMS_OF_SERVICE.md has drifted from the root TERMS_OF_SERVICE.md; copy the root file over the embedded copy (and bump terms.Version if the change is material)")
+	}
+}
+
+// The document announces the version the binary enforces; a bump to the
+// Version const without updating the document (or vice versa) would show
+// operators one revision and record another.
+func TestTermsDocumentStatesCurrentVersion(t *testing.T) {
+	if !strings.Contains(Text, fmt.Sprintf("**Version %d ", Version)) {
+		t.Fatalf("TERMS_OF_SERVICE.md does not state 'Version %d'; keep the document header and terms.Version in sync (and TermsVersion in installer/windows/gophertrunk.iss)", Version)
+	}
+}
+
+// The Inno Setup memo control round-trips the document through an ANSI
+// string, so any non-ASCII byte would render as mojibake on the
+// installer's Terms page.
+func TestTermsDocumentIsASCII(t *testing.T) {
+	for i := 0; i < len(Text); i++ {
+		if Text[i] > 0x7f {
+			t.Fatalf("TERMS_OF_SERVICE.md byte %d (%q) is non-ASCII; the Windows installer's terms page renders the file through an ANSI memo control", i, Text[i])
+		}
+	}
+}
+
+func TestRecordAndAcceptedVersionRoundTrip(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "GopherTrunk")
+	if IsAccepted(dir) {
+		t.Fatal("empty dir should not read as accepted")
+	}
+	if err := Record(dir, "test"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if got := AcceptedVersion(dir); got != Version {
+		t.Fatalf("AcceptedVersion = %d, want %d", got, Version)
+	}
+	if !IsAccepted(dir) {
+		t.Fatal("IsAccepted = false after Record")
+	}
+}
+
+// A marker from an older terms revision must force re-acknowledgment.
+func TestOlderMarkerVersionIsNotAccepted(t *testing.T) {
+	dir := t.TempDir()
+	body := "version=0\naccepted_at=2026-01-01T00:00:00Z\n"
+	if err := os.WriteFile(MarkerPath(dir), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if IsAccepted(dir) {
+		t.Fatal("version=0 marker should not satisfy the current terms version")
+	}
+}
+
+// The Windows installer writes the marker with CRLF line endings and its
+// own field order; the parser must accept it.
+func TestAcceptedVersionParsesInstallerStyleMarker(t *testing.T) {
+	dir := t.TempDir()
+	body := "# GopherTrunk terms-of-service acceptance record (see TERMS_OF_SERVICE.md).\r\n" +
+		"version=1\r\naccepted_at=2026-09-04 12:00:00\r\naccepted_via=windows-installer\r\n"
+	if err := os.WriteFile(MarkerPath(dir), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := AcceptedVersion(dir); got != 1 {
+		t.Fatalf("AcceptedVersion = %d, want 1", got)
+	}
+}
+
+func TestEnvAccepted(t *testing.T) {
+	for val, want := range map[string]bool{
+		"1": true, "true": true, "YES": true, "y": true,
+		"": false, "0": false, "no": false, "maybe": false,
+	} {
+		t.Setenv(EnvVar, val)
+		if got := EnvAccepted(); got != want {
+			t.Errorf("EnvAccepted with %s=%q = %v, want %v", EnvVar, val, got, want)
+		}
+	}
+}


### PR DESCRIPTION
A short, plain-language TERMS_OF_SERVICE.md in line with other open SDR
software: lawful monitoring is the operator's responsibility, no
defeating encryption, no misuse of received content, recording-privacy
duties, not for safety-of-life use, receive-only posture, the vocoder
patent note, export compliance, and Apache-2.0's no-warranty terms.

Acknowledgment is enforced on every install path and recorded locally
(a marker file under the user config dir; nothing leaves the machine):

- Windows installer: a mandatory Terms page (memo + checkbox gating
  Next) after the LICENSE page, which then writes the same
  %AppData%\GopherTrunk\terms-accepted marker the CLI reads.
- Everywhere else (ZIP/tarball/go install/Docker): a first-run gate in
  main() shows the embedded terms on a TTY and prompts once; non-TTY
  runs exit EX_NOPERM with instructions. `gophertrunk terms accept` or
  GOPHERTRUNK_ACCEPT_TERMS=1 covers unattended installs; version/help/
  terms are exempt. Terms carry a version so material changes re-prompt.

internal/terms embeds the document (drift against the root copy, the
ASCII requirement of the installer's ANSI memo, marker parsing incl.
the installer's CRLF format, and version-bump re-prompt are all pinned
by tests). TERMS_OF_SERVICE.md ships in every release artifact.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SxAZABWTLMjPcUhzNCGAi6