### PR TITLE
tetra: stop fragment-reassembly splices from manufacturing phantom neighbour sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,40 @@ confirmation before any close-as-completed.
   — likely another MAC boundary/seam hole in a rarely-sent broadcast variant — is still
   un-root-caused; the hex dump is the instrument). Pinned failing-first by
   `TestLearnNeighbourCellsRejectsImplausibleCells` (old code reproduces the operator's exact row).
+- **The phantom-neighbour corruption source is ROOT-CAUSED (5 Sep, from the 4 Sep tl_sdu_hex
+  instrument alone): mis-continued fragment reassembly SPLICING TWO TRANSMISSIONS of the rotating
+  D-NWRK-BROADCAST.** The 11 rejected dumps in the operator's 10.4 h log decode as the real cell
+  list (9,10,11 … 57-bit cells, perfect) that mid-cell jumps back to another copy of the list —
+  identical substrings repeat inside one TL-SDU, and every dump left 15–388 trailing bits after a
+  "complete" cell list (genuine: <8, the MAC bounds the TM-SDU to the PDU's own length). Bogus
+  sites that LOOKED plausible (mnc=1021/1032 = the real cells' LAs shifted into the MNC field)
+  were the same splices confirming twice, because the loss pattern repeats with the broadcast
+  schedule. Three holes let a chain survive the losses that set a splice up, all fixed in
+  `decodeDownlinkSlot`/`fragChainAdjacentLocked`: (1) a control slot with ONE decoded SCH/HD half
+  counted as recovered — the failed half IS a lost signalling block (on a control slot both halves
+  carry signalling; stealing exists only on traffic slots); (2) **`DecodeAACH` is an ML search that
+  ALWAYS returns the nearest RM(30,14) codeword** (`errs` = Hamming distance, garbage lands at
+  4-6), so a faded AACH was a coin-flip classification and "traffic" kept the chain — the
+  classification is now trusted only at `errs ≤ aachClassifyMaxErrs` (2). (Searching the other
+  three rotations on unconfident slots was tried and REVERTED: most emits on this capture are
+  unconfident, and the extra 16k-codeword ML searches took the 120 s replay 61→139 s, past real
+  time — the multi-rotation loop was always unreachable anyway, r=0 is the stream's rotation);
+  (3) adjacency tightened
+  4→2 frames + the continuation must land on the chain's 255-dibit slot grid. **The grid gate is
+  load-bearing, measured on the 4 Sep MRC captures**: the NCDB detector also emits spurious
+  off-grid correlator hits (+92/+163 dibits, tolerance-2 matches inside payloads), and a naive
+  "gap between emitted slots" check (first attempt) aborted every chain on this SCBS/timeshare
+  carrier (neighbours 0/8) — integrity evidence must be slots on the chain's own grid, nothing
+  else. Defence in depth: `ParseDNwrkBroadcast` rejects ≥8 trailing bits after the neighbour list
+  (kills the whole splice class even if a new hole appears; reject logged with `tl_sdu_hex`), and
+  neighbours now EXPIRE after `neighbourExpiry` (30 min) without re-advertisement — aged only
+  across ACCEPTED broadcasts, so a CC outage expires nothing — ending the 10-hour phantom pile-up.
+  The periodic "abandoning TM-SDU fragment reassembly" DEBUG line is the continuity guard WORKING
+  (each abandon costs one broadcast cycle; the reporter read it as a parse bug) — it now says so,
+  and `frag_abandons` in the decode-status line tracks the rate. Pinned failing-first:
+  `TestParseDNwrkBroadcastRejectsSplicedFieldCapture` (a LITERAL field dump), half-slot /
+  unclassifiable-AACH / on-grid tests in `frag_continuity_test.go`, expiry in `mle_parse_test.go`;
+  no-harm: both 4 Sep captures replay 8/8 real cells through `TestTETRANeighbourReportReplay`.
 - **TETRA control-plane decode surface (the "advanced D-SYSINFO / D-ATTACH/DETACH / D-NEW-CELL /
   SCCH" request) — what's decoded vs deliberately raw.** `ParseSysInfoExtended` (`sysinfo_ext.go`)
   decodes the rest of the 124-bit SYSINFO: common-SCCH count (+ TS2..TS4 mapping),

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -195,8 +195,13 @@ type ControlChannel struct {
 	// broadcast repeats every few seconds with identical content; bit garbage
 	// does not (mirrors the BSCH identity/colour confirm-twice rule).
 	// Inherently bounded (32 ids each). Lazily built; guarded by mu.
+	// neighboursSeen stamps when each cell id last appeared in an ACCEPTED
+	// broadcast; cells the BS stops advertising for neighbourExpiry are pruned
+	// (see learnNeighbourCells) so a long session's report tracks the live
+	// neighbour list instead of accumulating every cell ever seen.
 	neighbours        map[uint8]NeighbourCell
 	neighboursPending map[uint8]NeighbourCell
+	neighboursSeen    map[uint8]time.Time
 
 	// releaseSeen records when a KindCallRelease was last published per group
 	// (GSSI). The SwMI retransmits D-RELEASE / D-DISCONNECT — once per addressed
@@ -713,6 +718,12 @@ type Stats struct {
 	SCHPDUs     int64 // signalling channel (SCH/F, SCH/HD) blocks recovered CRC-clean off a real NCDB slot
 	SCHPDUsFail int64 // AACH-confirmed control slots that yielded no CRC-clean SCH block
 	Grants      int64 // voice grants published
+	// FragAbandons counts TM-SDU fragment chains dropped by the reassembly
+	// continuity guards (see abandonFragment): a designed safety response to a
+	// lost/unreadable slot mid-reassembly, not a parse defect — the broadcast
+	// repeats within seconds, so each abandon costs one cycle. A high rate
+	// simply tracks marginal RF.
+	FragAbandons int64
 }
 
 // addStat adds n to a decode-health counter when debug telemetry is on. A
@@ -1020,12 +1031,16 @@ func (c *ControlChannel) learnNeighbourCells(nb DNwrkBroadcast, tl []byte) {
 		}
 	}
 	var confirmed []NeighbourCell
+	var expired []uint8
+	now := c.now()
 	c.mu.Lock()
 	if c.neighbours == nil {
 		c.neighbours = make(map[uint8]NeighbourCell)
 		c.neighboursPending = make(map[uint8]NeighbourCell)
+		c.neighboursSeen = make(map[uint8]time.Time)
 	}
 	for _, cell := range nb.Neighbours {
+		c.neighboursSeen[cell.CellID] = now
 		if cur, seen := c.neighbours[cell.CellID]; seen && cur == cell {
 			continue // steady-state rebroadcast of a confirmed cell
 		}
@@ -1039,8 +1054,32 @@ func (c *ControlChannel) learnNeighbourCells(nb DNwrkBroadcast, tl []byte) {
 		}
 		c.neighboursPending[cell.CellID] = cell
 	}
+	// Age out cells the BS stopped advertising. The broadcast rotates through
+	// the live neighbour list within a minute or two, so a cell absent for
+	// neighbourExpiry has genuinely left it — a reconfigured network, or a
+	// phantom that slipped an earlier gate. Pruning happens only here, on an
+	// ACCEPTED broadcast, so a CC outage (no broadcasts at all) never expires
+	// anything: the clock only advances relative to broadcasts still arriving.
+	for id, seen := range c.neighboursSeen {
+		if now.Sub(seen) < neighbourExpiry {
+			continue
+		}
+		delete(c.neighboursSeen, id)
+		delete(c.neighboursPending, id)
+		if _, surfaced := c.neighbours[id]; surfaced {
+			delete(c.neighbours, id)
+			expired = append(expired, id)
+		}
+	}
 	c.mu.Unlock()
+	for _, id := range expired {
+		c.log.Debug("tetra: neighbour cell no longer advertised — expiring",
+			"system", c.systemName, "cell_id", id, "expiry", neighbourExpiry)
+	}
 	if len(confirmed) == 0 {
+		if len(expired) > 0 {
+			c.publishSiteIdentity()
+		}
 		return
 	}
 	for _, cell := range confirmed {
@@ -1373,14 +1412,61 @@ const fragMaxBits = 2048
 // fragMaxGapDibits bounds the dibit stream distance between successive pieces
 // of one fragmented TM-SDU. Fragments continue in the following signalling
 // opportunities of the same channel (§23.4.2), i.e. one TDMA frame apart on the
-// MCCH (4 slots × 255 dibits = 1020), occasionally displaced by a sync burst or
-// the frame-18 schedule — four frames of slack accepts all of that. What it
-// rejects is a MAC-FRAG/MAC-END arriving long after the chain's previous piece:
-// that continuation belongs to a LATER fragmented PDU whose own start fragment
-// was lost, and splicing it onto the stale chain manufactures a corrupt L3 PDU
-// (see abandonFragment's caller for why that corruption survives dedup).
-// osmo-tetra-sq5bpf ages fragment slots out the same way (fragtimer > N203).
-const fragMaxGapDibits = 4 * 4 * 255
+// MCCH (4 slots × 255 dibits = 1020), occasionally two frames when the
+// frame-18 schedule displaces one — two frames plus grid jitter accepts all of
+// that. What it rejects is a MAC-FRAG/MAC-END arriving later: that
+// continuation belongs to a LATER transmission of a fragmented PDU whose own
+// start fragment was lost, and splicing it onto the stale chain manufactures a
+// corrupt L3 PDU (see abandonFragment's caller for why that corruption
+// survives dedup). osmo-tetra-sq5bpf ages fragment slots out the same way
+// (fragtimer > N203). The 4-5 Sep field splices (phantom D-NWRK-BROADCAST
+// neighbour sites built from two transmissions of the rotating broadcast)
+// arrived inside the old FOUR-frame window; two frames rejects every splice
+// that lost a whole transmission's worth of pieces, and the on-grid slot
+// checks in decodeDownlinkSlot cover the tighter cases.
+const fragMaxGapDibits = 2*4*255 + 2*fragGridJitterDibits
+
+// fragGridJitterDibits is the tolerance around the 255-dibit slot grid within
+// which an NCDB position still counts as the same slot: the detector's
+// correlation lead can slip a couple of dibits between bursts on a marginal
+// carrier.
+const fragGridJitterDibits = 3
+
+// onChainSlotGrid reports whether a positive dibit-stream delta from a
+// fragment chain's last piece lands on the downlink's 255-dibit slot grid
+// (± fragGridJitterDibits). Real slots — the only places a continuation can
+// arrive, and the only places its loss can hide — are on the grid; the NCDB
+// detector's spurious off-grid correlator emits (tolerance-2 matches inside
+// burst payloads, e.g. at +92/+163 dibits on the 4 Sep field captures) are
+// not, and must count for nothing: neither as a continuation opportunity nor
+// as decode-failure evidence.
+func onChainSlotGrid(delta int) bool {
+	r := delta % 255
+	return r <= fragGridJitterDibits || r >= 255-fragGridJitterDibits
+}
+
+// aachClassifyMaxErrs is the maximum Hamming distance at which a hard AACH
+// decode's slot classification (control vs traffic) is TRUSTED. DecodeAACH's
+// RM(30,14) maximum-likelihood search always returns the nearest codeword —
+// random garbage typically lands at distance 4-6 (the sphere around some
+// codeword: ~2^14 codewords in 2^30 words), so an unconfident "decode" is a
+// coin-flip classification, not evidence. A genuine AACH at workable SNR
+// decodes at 0-2 errors; at ≤2 the chance of garbage passing is ~0.7%
+// (466·2^-16). Trusted-only classification gates the SCHPDUsFail counter and
+// the fragment-chain integrity checks in decodeDownlinkSlot. (The soft-decision
+// fallback in traffic.go uses its own, looser aachSoftMaxDist — that path also
+// requires a routable traffic marker, a stronger content check.)
+const aachClassifyMaxErrs = 2
+
+// neighbourExpiry is how long a neighbour cell stays in the surfaced set (and
+// the pending confirm-twice set) without reappearing in an accepted
+// D-NWRK-BROADCAST. The broadcast rotates through the live list within a
+// minute or two, so 30 minutes of absence — measured only while broadcasts
+// keep arriving, never across a CC outage — means the BS no longer advertises
+// the cell. Keeps a long session's "Neighbor sites" tracking the network's
+// live list rather than accumulating every cell ever seen (the 4-5 Sep 10-hour
+// field report's phantom pile-up).
+const neighbourExpiry = 30 * time.Minute
 
 // stashFragment records a start-fragment MAC-RESOURCE's partial TM-SDU and its
 // resource context so a following MAC-END can reassemble the complete L3 PDU. A
@@ -1395,13 +1481,14 @@ func (c *ControlChannel) stashFragment(m MACResource, partial []byte) {
 }
 
 // fragChainAdjacentLocked reports whether the slot being decoded is close
-// enough in the dibit stream to the reassembly's previous piece for a
-// MAC-FRAG/MAC-END in it to be that chain's continuation. A negative delta is
-// a stream discontinuity (resync baseline jump) and never adjacent. Callers
-// hold mu.
+// enough in the dibit stream to the reassembly's previous piece — and on the
+// chain's 255-dibit slot grid — for a MAC-FRAG/MAC-END in it to be that
+// chain's continuation. A negative delta is a stream discontinuity (resync
+// baseline jump) and never adjacent; an off-grid delta is a spurious
+// correlator emit, not a slot a continuation can arrive in. Callers hold mu.
 func (c *ControlChannel) fragChainAdjacentLocked() bool {
 	delta := c.curSlotPos - c.fragLastPos
-	return delta >= 0 && delta <= fragMaxGapDibits
+	return delta >= 0 && delta <= fragMaxGapDibits && onChainSlotGrid(delta)
 }
 
 // dropFragmentLocked abandons the in-progress reassembly. Callers hold mu.
@@ -1422,7 +1509,13 @@ func (c *ControlChannel) abandonFragment(reason string) {
 		return
 	}
 	c.dropFragmentLocked()
-	c.log.Debug("tetra: abandoning TM-SDU fragment reassembly", "reason", reason)
+	if c.debug {
+		c.statsMu.Lock()
+		c.stats.FragAbandons++
+		c.statsMu.Unlock()
+	}
+	c.log.Debug("tetra: abandoning TM-SDU fragment reassembly — awaiting rebroadcast (continuity guard, not a parse error)",
+		"reason", reason)
 }
 
 // appendFragment appends a MAC-FRAG continuation to the in-progress TM-SDU. A

--- a/internal/radio/tetra/downlink.go
+++ b/internal/radio/tetra/downlink.go
@@ -170,7 +170,15 @@ func (c *ControlChannel) decodeDownlinkSlot(pos int, bkn1, aach1, aach2, bkn2 []
 	colour := c.colourCode
 	// Stamp the slot's stream position before any block decodes: the MAC
 	// fragment reassembly uses it to verify that successive pieces of one
-	// TM-SDU are stream-adjacent (see fragMaxGapDibits).
+	// TM-SDU are stream-adjacent AND on the chain's 255-dibit slot grid (see
+	// fragMaxGapDibits / fragChainAdjacentLocked). chainDelta places THIS slot
+	// relative to the chain's last ingested piece, for the integrity checks at
+	// the end: only a slot on the chain's grid is a real slot whose loss can
+	// have eaten the chain's continuation — the NCDB detector also emits
+	// spurious off-grid correlator hits (e.g. at +92/+163 dibits on the 4 Sep
+	// field captures, tolerance-2 matches inside burst payloads), and those
+	// must not count as slot evidence of anything.
+	chainDelta, fragActive := pos-c.fragLastPos, c.fragActive
 	c.curSlotPos = pos
 	c.mu.Unlock()
 
@@ -178,25 +186,38 @@ func (c *ControlChannel) decodeDownlinkSlot(pos int, bkn1, aach1, aach2, bkn2 []
 		return TetraDibitsToBits(rotateDibits(d, (4-rot)&3))
 	}
 
-	// The AACH is present in every downlink slot and decodes ~100% on a locked
-	// carrier, so it pins the rotation cheaply; fall back to trying all four
-	// only when it does not decode (e.g. a synthesised slot with no AACH). The
-	// parsed ACCESS-ASSIGN also classifies the slot (control vs traffic), which
-	// gates the SCHPDUsFail counter below.
-	rots := []uint8{0, 1, 2, 3}
+	// The AACH is present in every downlink slot; it classifies the slot
+	// (control vs traffic), which gates the SCHPDUsFail counter and the
+	// fragment-chain integrity checks below — but ONLY when the decode is
+	// CONFIDENT. DecodeAACH is a maximum-likelihood search that ALWAYS returns
+	// the nearest RM(30,14) codeword — its errs is that codeword's Hamming
+	// distance, and ParseAccessAssign accepts any 14 bits — so a faded/garbage
+	// AACH "decodes" (typically at distance 4-6) to RANDOM header bits, a
+	// coin-flip control/traffic classification. The old code took any errs >= 0
+	// as authoritative, which let a lost control slot mid-reassembly read as
+	// "traffic" and keep a fragment chain alive across the loss (one leg of
+	// the 4-5 Sep phantom-neighbour splices); aachTrusted now requires
+	// errs <= aachClassifyMaxErrs.
+	//
+	// ONE ML search, at rotation 0 only. The receiver's differential decode
+	// leaves this path's dibit stream at a fixed rotation (the old loop's
+	// "search all four" was unreachable: errs is never negative and
+	// ParseAccessAssign accepts anything, so it always broke at r=0 — and
+	// everything decodes on air that way). Searching the other rotations on
+	// unconfident slots was tried and measured: on the 4 Sep capture most
+	// emits ARE unconfident (spurious off-grid hits, timeshare-off periods),
+	// and the extra RM(30,14) searches took the 120 s replay from 61 s to
+	// 139 s — past real time. Decoding extra rotations of SCH would likewise
+	// only multiply the 16-bit-CRC collision floor on garbage.
 	var aa AccessAssign
-	var aachOK bool
+	var aachTrusted bool
 	aachDi := append(append([]uint8{}, aach1...), aach2...)
-	for r := uint8(0); r < 4; r++ {
-		rec, errs := DecodeAACH(derot(aachDi, r), colour)
-		if errs >= 0 {
-			if parsed, ok := ParseAccessAssign(rec); ok {
-				aa, aachOK = parsed, true
-				rots = []uint8{r}
-				break
-			}
+	if rec, errs := DecodeAACH(derot(aachDi, 0), colour); errs >= 0 && errs <= aachClassifyMaxErrs {
+		if parsed, ok := ParseAccessAssign(rec); ok {
+			aa, aachTrusted = parsed, true
 		}
 	}
+	rots := []uint8{0}
 
 	// Soft data (the per-symbol differentials) lets the longer SCH/F and SCH/HD
 	// blocks decode ~1.5–2 dB deeper on a marginal constellation — the same soft
@@ -206,6 +227,7 @@ func (c *ControlChannel) decodeDownlinkSlot(pos int, bkn1, aach1, aach2, bkn2 []
 	haveF := bkn1Diffs != nil && bkn2Diffs != nil && len(bkn1Diffs) == len(bkn1) && len(bkn2Diffs) == len(bkn2)
 
 	recovered := 0
+	var fullOK, half1OK, half2OK bool
 	for _, r := range rots {
 		full := append(append([]uint8{}, bkn1...), bkn2...)
 		if haveF {
@@ -213,19 +235,24 @@ func (c *ControlChannel) decodeDownlinkSlot(pos int, bkn1, aach1, aach2, bkn2 []
 			if rec, ok := DecodeSCHFSoft(softType5FromDiffs(fullDiffs, (4-r)&3), colour); ok {
 				c.ingestMAC(rec)
 				recovered++
+				fullOK = true
 			} else if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
 				c.ingestMAC(rec)
 				recovered++
+				fullOK = true
 			}
 		} else if rec, ok := DecodeSCHF(derot(full, r), colour); ok {
 			c.ingestMAC(rec)
 			recovered++
+			fullOK = true
 		}
 		if c.decodeDownlinkHalf(bkn1, bkn1Diffs, r, derot, colour) {
 			recovered++
+			half1OK = true
 		}
 		if c.decodeDownlinkHalf(bkn2, bkn2Diffs, r, derot, colour) {
 			recovered++
+			half2OK = true
 		}
 	}
 
@@ -242,17 +269,51 @@ func (c *ControlChannel) decodeDownlinkSlot(pos int, bkn1, aach1, aach2, bkn2 []
 		// genuinely decoding channel from the BSCH-only "locked but deaf" state
 		// (wrong AFC alias latch) the payload-drought check escapes.
 		c.notePayloadActivity()
-	} else if aachOK && aa.IsControlChannel() {
+	} else if aachTrusted && aa.IsControlChannel() {
 		c.addStat(&c.stats.SCHPDUsFail, 1)
-		// A control slot that yielded no CRC-clean block is a lost signalling
-		// block. If a fragmented TM-SDU is mid-reassembly, its continuation may
-		// be exactly what was lost — splicing the pieces either side of the gap
-		// yields a plausible-looking corrupt L3 PDU, and because broadcast
-		// content and fragmentation split points repeat, the SAME corrupt
-		// reassembly can repeat bit-identically (defeating confirm-twice dedup
-		// downstream, e.g. bogus D-NWRK-BROADCAST neighbour cells). Abandon the
-		// chain; the broadcast rebroadcasts within seconds.
-		c.abandonFragment("undecoded control slot mid-reassembly")
+	}
+
+	// Fragment-chain integrity. A control slot that yielded no CRC-clean block
+	// is a lost signalling block. If a fragmented TM-SDU is mid-reassembly, its
+	// continuation may be exactly what was lost — splicing the pieces either
+	// side of the gap yields a plausible-looking corrupt L3 PDU, and because
+	// broadcast content and fragmentation split points repeat, the SAME corrupt
+	// reassembly can repeat bit-identically (defeating confirm-twice dedup
+	// downstream, e.g. bogus D-NWRK-BROADCAST neighbour cells). Abandon the
+	// chain; the broadcast rebroadcasts within seconds.
+	//
+	// Only a slot ON THE CHAIN'S 255-dibit GRID counts as evidence: spurious
+	// off-grid correlator emits are not slots, and their garbage "decodes"
+	// prove nothing (gating on the grid is what lets the checks below stay
+	// aggressive without aborting every chain on a busy carrier).
+	//
+	// "Lost" is judged per BLOCK, not per slot: the 4-5 Sep field splices got
+	// past the old slot-level check (recovered == 0) through two holes it left
+	// open. (1) A control slot where one SCH/HD half decodes and the other
+	// fails CRC counted as recovered — but on an AACH-confirmed control slot
+	// both halves carry signalling (SCH/HD or BNCH; half-slot stealing exists
+	// only on traffic slots), so the failed half IS a lost block. A decoded
+	// SCH/F consumes the whole slot (the halves' CRCs cannot also pass), so
+	// fullOK means nothing was lost. (2) A slot whose AACH itself does not
+	// decode CONFIDENTLY is unclassifiable — DecodeAACH always returns the
+	// nearest codeword, so a faded AACH is a coin-flip classification, and the
+	// old code kept the chain whenever the coin read "traffic". Both abandons
+	// cost one broadcast cycle at worst; a spliced corrupt PDU costs a phantom
+	// neighbour site that repeats until restart.
+	slotFullyRecovered := fullOK || (half1OK && half2OK)
+	if fragActive && !slotFullyRecovered && chainDelta > 0 && onChainSlotGrid(chainDelta) {
+		switch {
+		case aachTrusted && aa.IsControlChannel():
+			if recovered == 0 {
+				c.abandonFragment("undecoded control slot mid-reassembly")
+			} else {
+				c.abandonFragment("half-slot signalling block lost mid-reassembly")
+			}
+		case !aachTrusted:
+			c.abandonFragment("unclassifiable slot mid-reassembly")
+		}
+		// aachTrusted && !IsControlChannel(): a confirmed traffic slot carries no
+		// control signalling — nothing of the chain's can have been lost in it.
 	}
 }
 
@@ -367,6 +428,15 @@ func (c *ControlChannel) ingestResourceTMSDU(m MACResource, sdu []byte) {
 			// every non-MLE TL-SDU.
 			if nb, ok := ParseDNwrkBroadcast(tl); ok {
 				c.learnNeighbourCells(nb, tl)
+			} else if t, isMLE := ParseMLESubsystemType(tl); isMLE && t == mlePDUTypeDNwrkBroadcast {
+				// A TL-SDU that names itself D-NWRK-BROADCAST but fails the
+				// full parse (truncated list, or the trailing-residue gate) is
+				// misframed or spliced upstream. Keep the raw hex instrument
+				// alive — it is what pinned the 4-5 Sep splice mechanism from
+				// a field report alone.
+				c.log.Debug("tetra: rejecting misframed d-nwrk-broadcast",
+					"system", c.systemName,
+					"tl_sdu_hex", packBitsHex(tl))
 			}
 			// MLE D-RESTORE-ACK wraps the call-restoration CMCE SDU for an MS
 			// that re-selected onto this cell mid-call — decode it like the

--- a/internal/radio/tetra/frag_continuity_test.go
+++ b/internal/radio/tetra/frag_continuity_test.go
@@ -119,3 +119,172 @@ func TestFragmentReassemblyAbandonedOnUndecodedControlSlot(t *testing.T) {
 		t.Error("reassembly spliced across an undecoded control slot and published the corrupt-chain grant")
 	}
 }
+
+// fragTestChain stashes a start fragment at slot position 0 and returns the
+// bus subscription plus the CMCE payload halves, so each abandon-hole test
+// shares one setup: stash → the slot under test → MAC-END → did the corrupt
+// chain publish?
+func fragTestChain(t *testing.T) (*ControlChannel, *events.Subscription, []byte, int) {
+	t.Helper()
+	const (
+		gssi     = 0x0F5670
+		carrier  = 2716
+		timeslot = 1
+	)
+	full := cmceSetupEmergencyParty(0x1234, 0x0123AB)
+	split := 24
+	bus := events.NewBus(32)
+	t.Cleanup(bus.Close)
+	sub := bus.Subscribe()
+	t.Cleanup(sub.Close)
+	cc := New(Options{Bus: bus, SystemName: "Sys", FrequencyHz: 467_913_000})
+	ingestMACAt(cc, 0, macResourceStartFragment(gssi, carrier, timeslot, full[:split]))
+	return cc, sub, full, split
+}
+
+// controlAACHDibits encodes an AACH whose header reads downlink common control
+// and splits it into the two NCDB half spans.
+func controlAACHDibits(t *testing.T, colour uint32) (aach1, aach2 []uint8) {
+	t.Helper()
+	dibits := TetraBitsToDibits(EncodeAACH(make([]byte, 14), colour))
+	if len(dibits) != ndbAACH1Len+ndbAACH2Len {
+		t.Fatalf("AACH encoded to %d dibits, want %d", len(dibits), ndbAACH1Len+ndbAACH2Len)
+	}
+	return dibits[:ndbAACH1Len], dibits[ndbAACH1Len:]
+}
+
+// garbageBlock is a BKN half that fails every SCH CRC.
+func garbageBlock() []uint8 {
+	g := make([]uint8, ndbBlockDibits)
+	for i := range g {
+		g[i] = uint8((i*7 + 3) % 4)
+	}
+	return g
+}
+
+// benignSCHHDHalf encodes a decodable SCH/HD half-slot block (a real SYSINFO
+// broadcast block, harmless to ingest) at the given colour.
+func benignSCHHDHalf(t *testing.T, colour uint32) []uint8 {
+	t.Helper()
+	type1 := hexToBits(t, "8a9c4c0e928eec8bd0c0041cffffd700")[:124]
+	dibits := TetraBitsToDibits(EncodeSCHHD(type1, colour))
+	if len(dibits) != ndbBlockDibits {
+		t.Fatalf("SCH/HD encoded to %d dibits, want %d", len(dibits), ndbBlockDibits)
+	}
+	return dibits
+}
+
+// TestFragmentReassemblyAbandonedOnHalfSlotLoss: a control slot where one
+// SCH/HD half decodes and the other fails CRC lost a signalling block — the
+// old slot-level check (recovered == 0) counted it as recovered, kept the
+// chain, and let the NEXT transmission's MAC-FRAG/MAC-END splice on (the 4-5
+// Sep field mechanism behind the phantom D-NWRK-BROADCAST neighbour sites).
+// Fails against the old code: the corrupt chain published its grant.
+func TestFragmentReassemblyAbandonedOnHalfSlotLoss(t *testing.T) {
+	const colour = 0
+	cc, sub, full, split := fragTestChain(t)
+	aach1, aach2 := controlAACHDibits(t, colour)
+	cc.decodeDownlinkSlot(1020, benignSCHHDHalf(t, colour), aach1, aach2, garbageBlock(), nil, nil)
+	ingestMACAt(cc, 2040, macEndPDU(full[split:]))
+	if enrichedGrantSeen(sub, 0x0123AB) {
+		t.Error("reassembly spliced across a half-slot signalling loss and published the corrupt-chain grant")
+	}
+}
+
+// TestFragmentReassemblyAbandonedOnUnclassifiableSlot: a slot whose AACH does
+// not decode is of unknown type — it may have been a control slot carrying the
+// chain's continuation. DecodeAACH's maximum-likelihood search ALWAYS returns
+// the nearest codeword, so a garbage AACH "decodes" — at a large Hamming
+// distance — to random header bits: the old code took that as an authoritative
+// classification, and whenever the coin-flip read "traffic" the chain survived
+// the loss. Fails against the old code.
+func TestFragmentReassemblyAbandonedOnUnclassifiableSlot(t *testing.T) {
+	cc, sub, full, split := fragTestChain(t)
+	g := garbageBlock()
+	// Pick a garbage AACH whose nearest codeword is beyond the trust gate at
+	// every rotation, so this slot is genuinely unclassifiable — and prove it,
+	// so the test cannot silently exercise the trusted-control branch instead.
+	// (The old code additionally had to read "traffic" from the garbage to
+	// expose the hole; this seed does.)
+	aach := make([]uint8, ndbAACH1Len+ndbAACH2Len)
+	derot := func(d []uint8, rot uint8) []byte {
+		return TetraDibitsToBits(rotateDibits(d, (4-rot)&3))
+	}
+	seedOK := false
+	for seed := 1; seed <= 64 && !seedOK; seed++ {
+		for i := range aach {
+			aach[i] = uint8((i*seed + seed*seed + 1) % 4)
+		}
+		seedOK = true
+		for r := uint8(0); r < 4; r++ {
+			if _, errs := DecodeAACH(derot(aach, r), 0); errs >= 0 && errs <= aachClassifyMaxErrs {
+				seedOK = false
+				break
+			}
+		}
+		if !seedOK {
+			continue
+		}
+		// Old-code exposure: its first-rotation decode must coin-flip to
+		// "traffic" for the hole to manifest (it abandoned on "control").
+		if rec, errs := DecodeAACH(derot(aach, 0), 0); errs >= 0 {
+			if parsed, ok := ParseAccessAssign(rec); ok && parsed.IsControlChannel() {
+				seedOK = false
+			}
+		}
+	}
+	if !seedOK {
+		t.Fatal("no garbage AACH beyond the classification trust gate found")
+	}
+	cc.decodeDownlinkSlot(1020, g, aach[:ndbAACH1Len], aach[ndbAACH1Len:], g, nil, nil)
+	ingestMACAt(cc, 2040, macEndPDU(full[split:]))
+	if enrichedGrantSeen(sub, 0x0123AB) {
+		t.Error("reassembly spliced across an unclassifiable slot and published the corrupt-chain grant")
+	}
+}
+
+// TestFragmentReassemblyRequiresOnGridContinuation: a MAC-END can only arrive
+// in a real slot, and real slots sit on the 255-dibit grid anchored by the
+// chain's own pieces. An off-grid position is a spurious correlator emit (the
+// NCDB detector's tolerance-2 matches inside burst payloads, seen at +92/+163
+// dibits on the 4 Sep field captures) — a continuation "arriving" there must
+// not splice. Fails against the old adjacency check, which accepted any delta
+// within the window. Also pins the window itself at two frames: the 4-5 Sep
+// splices arrived 3+ frames after the stale chain's last piece, inside the old
+// four-frame window.
+func TestFragmentReassemblyRequiresOnGridContinuation(t *testing.T) {
+	cc, sub, full, split := fragTestChain(t)
+	ingestMACAt(cc, 1020+92, macEndPDU(full[split:])) // off-grid spurious emit
+	if enrichedGrantSeen(sub, 0x0123AB) {
+		t.Error("an off-grid MAC-END was spliced onto the chain")
+	}
+
+	cc2, sub2, full2, split2 := fragTestChain(t)
+	ingestMACAt(cc2, 3*1020, macEndPDU(full2[split2:])) // three frames late
+	if enrichedGrantSeen(sub2, 0x0123AB) {
+		t.Error("a MAC-END three frames after the chain's last piece was spliced on")
+	}
+
+	cc3, sub3, full3, split3 := fragTestChain(t)
+	ingestMACAt(cc3, 2*1020, macEndPDU(full3[split3:])) // frame-18 skip: legitimate
+	if !enrichedGrantSeen(sub3, 0x0123AB) {
+		t.Error("a MAC-END two frames later (frame-18 skip) no longer reassembles")
+	}
+}
+
+// TestFragmentReassemblySurvivesDecodedSlots is the no-harm control for the
+// abandon holes: fully decoded control slots between the start fragment and
+// its MAC-END (both halves clean, at the legitimate 255/510-dibit emit
+// spacing) must NOT abandon the chain — the reassembly still completes.
+func TestFragmentReassemblySurvivesDecodedSlots(t *testing.T) {
+	const colour = 0
+	cc, sub, full, split := fragTestChain(t)
+	aach1, aach2 := controlAACHDibits(t, colour)
+	half := benignSCHHDHalf(t, colour)
+	cc.decodeDownlinkSlot(255, half, aach1, aach2, half, nil, nil)
+	cc.decodeDownlinkSlot(765, half, aach1, aach2, half, nil, nil) // 510: the frame-18 SB skip
+	ingestMACAt(cc, 1020, macEndPDU(full[split:]))
+	if !enrichedGrantSeen(sub, 0x0123AB) {
+		t.Error("clean decoded slots mid-chain abandoned the reassembly; MAC-END no longer completes it")
+	}
+}

--- a/internal/radio/tetra/mle_parse.go
+++ b/internal/radio/tetra/mle_parse.go
@@ -243,6 +243,19 @@ func ParseDNwrkBroadcast(tl []byte) (DNwrkBroadcast, bool) {
 			}
 			out.Neighbours = append(out.Neighbours, cell)
 		}
+		// The neighbour list is the PDU's last element, and the MAC/LLC layers
+		// bound the TL-SDU to the PDU's own advertised length (length
+		// indication honoured, fill bits stripped) — so a genuine broadcast
+		// ends within a fill run (< 8 bits) of the last cell. A longer residue
+		// is proof the bits are not one D-NWRK-BROADCAST: every 4-5 Sep field
+		// splice (two transmissions of the broadcast glued by a mis-continued
+		// fragment reassembly) left 15-388 trailing bits after a cell list
+		// that parsed "cleanly", and the phantom neighbour sites were parsed
+		// out of exactly that misalignment. Rejecting here is defence in depth
+		// behind the reassembly-integrity abandons in decodeDownlinkSlot.
+		if r.remaining() >= 8 {
+			return DNwrkBroadcast{}, false
+		}
 	}
 	return out, true
 }

--- a/internal/radio/tetra/mle_parse_test.go
+++ b/internal/radio/tetra/mle_parse_test.go
@@ -3,6 +3,7 @@ package tetra
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 )
@@ -276,5 +277,86 @@ func TestNeighbourStatusFlagsRendersStatuses(t *testing.T) {
 	bare := NeighbourCell{}
 	if got, want := neighbourStatusFlags(bare), "unsynced"; got != want {
 		t.Errorf("bare StatusFlags = %q, want %q (absent fields must be omitted, not zero)", got, want)
+	}
+}
+
+// TestParseDNwrkBroadcastRejectsSplicedFieldCapture pins the trailing-residue
+// gate with a LITERAL TL-SDU from the 4 Sep 2026 field log (tl_sdu_hex, 17:02
+// broadcast): a fragment reassembly that spliced two transmissions of the
+// serving cell's rotating neighbour broadcast. The first cells parse perfectly
+// (they are the real cells 9/10 with their true carriers and LAs) and the list
+// "completes", but 132 bits of the second transmission trail the last cell — a
+// genuine broadcast ends within a fill run (< 8 bits) of its final cell,
+// because the MAC bounds the TM-SDU to the PDU's own length. The old parser
+// accepted this and the misaligned later cells became phantom neighbour sites
+// that repeated bit-identically past the confirm-twice dedup. Fails against
+// the old parser (it returned ok=true with 7 "cells").
+func TestParseDNwrkBroadcastRejectsSplicedFieldCapture(t *testing.T) {
+	spliced := hexToBits(t,
+		"ab1ba8e8a2ce0035fffd20ac2d30220380a0557680110200582baf4520ac2d3022"+
+			"0380a0557680110200582baf40087fa030153fa60444100a0ab3d00110a40302bb340080")[:552]
+	if _, ok := ParseDNwrkBroadcast(spliced); ok {
+		t.Error("ParseDNwrkBroadcast accepted a spliced broadcast with 132 bits of trailing residue")
+	}
+}
+
+// TestParseDNwrkBroadcastTrailingResidue: the gate's boundary. A genuine
+// TL-SDU may end with up to 7 bits of MAC fill after the last cell (octet
+// granularity of the length indication); 8 or more residual bits is proof of a
+// misframed/spliced PDU.
+func TestParseDNwrkBroadcastTrailingResidue(t *testing.T) {
+	// Header + one cell (id=9, no optionals), ending flush.
+	base := "101" + "010" + "1010101101010100" + "10" + "1" + "0" + "1" + "001" +
+		"01001" + "00" + "0" + "11" + "101010100000" + "0"
+	if _, ok := ParseDNwrkBroadcast(bitsOf(t, base)); !ok {
+		t.Fatal("flush-ending broadcast rejected")
+	}
+	if nb, ok := ParseDNwrkBroadcast(bitsOf(t, base+"0000000")); !ok || len(nb.Neighbours) != 1 {
+		t.Error("broadcast with 7 fill bits after the list rejected")
+	}
+	if _, ok := ParseDNwrkBroadcast(bitsOf(t, base+"00000000")); ok {
+		t.Error("broadcast with 8 residual bits after the list accepted")
+	}
+}
+
+// TestLearnNeighbourCellsExpiresUnadvertisedCells: a cell absent from every
+// accepted broadcast for neighbourExpiry leaves the surfaced set (and the
+// topology republishes), so a long session's "Neighbor sites" tracks the
+// network's LIVE neighbour list — the 4-5 Sep 10-hour field report accumulated
+// phantom sites for the daemon's whole lifetime because nothing ever pruned.
+// Expiry is measured only across accepted broadcasts: a CC outage (no
+// broadcasts at all) must not expire anything.
+func TestLearnNeighbourCellsExpiresUnadvertisedCells(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	cc := New(Options{SystemName: "Sys", FrequencyHz: 467_912_500,
+		Now: func() time.Time { return now }})
+	cc.learnSysInfo(SysInfo{MainCarrier: 2716, FreqBand: 4, Offset: 3, DuplexSpacing: 6})
+
+	cellA := NeighbourCell{CellID: 7, MainCarrier: 2720, Synchronized: true}
+	cellB := NeighbourCell{CellID: 9, MainCarrier: 2754}
+	both := DNwrkBroadcast{Neighbours: []NeighbourCell{cellA, cellB}}
+	onlyA := DNwrkBroadcast{Neighbours: []NeighbourCell{cellA}}
+
+	cc.learnNeighbourCells(both, nil)
+	cc.learnNeighbourCells(both, nil) // confirm-twice
+	if got := len(cc.TopologySnapshot().Neighbors); got != 2 {
+		t.Fatalf("surfaced %d neighbours, want 2", got)
+	}
+
+	// B keeps rotating out of the broadcast but the window has not elapsed yet:
+	// it must survive.
+	now = now.Add(neighbourExpiry / 2)
+	cc.learnNeighbourCells(onlyA, nil)
+	if got := len(cc.TopologySnapshot().Neighbors); got != 2 {
+		t.Fatalf("cell expired before neighbourExpiry: surfaced %d, want 2", got)
+	}
+
+	// Past the window with B still absent: B is pruned, A (just re-advertised)
+	// stays.
+	now = now.Add(neighbourExpiry/2 + time.Minute)
+	cc.learnNeighbourCells(onlyA, nil)
+	snap := cc.TopologySnapshot()
+	if len(snap.Neighbors) != 1 || snap.Neighbors[0].Site != 7 {
+		t.Fatalf("after expiry snapshot = %+v, want only cell 7", snap.Neighbors)
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -1070,6 +1070,7 @@ func (p *tetraPipeline) maybeLogStatus() {
 		"sysinfo", st.SysInfo,
 		"sch_pdus", st.SCHPDUs,
 		"sch_pdus_fail", st.SCHPDUsFail,
+		"frag_abandons", st.FragAbandons,
 		"grants", st.Grants,
 		"colour_code", p.cc.Topology().ColourCode&0x3F,
 	)


### PR DESCRIPTION
Root cause of the 4-5 Sep "even more bogus sites" report, pinned from the
operator's own tl_sdu_hex dumps alone: the MAC TM-SDU fragment reassembly
spliced pieces of TWO transmissions of the rotating D-NWRK-BROADCAST into one
TL-SDU (the rejected dumps contain the real cell list twice, with 15-388
residual bits after a "complete" list), and the misaligned bits parsed as
plausible-looking neighbour cells that repeat bit-identically past the
confirm-twice dedup.

Three chain-integrity holes closed in decodeDownlinkSlot /
fragChainAdjacentLocked:

- A control slot where one SCH/HD half decoded and the other failed CRC
  counted as "recovered" and kept the chain; the failed half is a lost
  signalling block (both halves of a control slot carry signalling).
- DecodeAACH's RM(30,14) ML search always returns the nearest codeword, so a
  faded AACH "decodes" to random header bits and a coin-flip "traffic"
  classification kept the chain across the loss. Classification is now
  trusted only at errs <= aachClassifyMaxErrs; an unconfident slot that did
  not fully decode abandons the chain.
- Piece adjacency tightened from four frames to two, and every continuation
  (and loss-evidence slot) must land on the chain's 255-dibit slot grid: the
  NCDB detector also emits spurious off-grid correlator hits (+92/+163 dibits
  on the 4 Sep captures) that must count for nothing.

Defence in depth behind the reassembly fixes:

- ParseDNwrkBroadcast rejects a broadcast with >= 8 residual bits after the
  neighbour list (a genuine TL-SDU ends within a fill run of its last cell);
  rejects log the raw hex so the field instrument stays alive.
- Neighbour cells now expire after 30 min without re-advertisement, aged only
  across accepted broadcasts (a CC outage expires nothing), ending the
  long-session phantom pile-up.

The periodic "abandoning TM-SDU fragment reassembly" DEBUG line the reporter
flagged is the continuity guard working as designed; it now says so, and the
decode-status line carries a frag_abandons counter.

Verified: failing-first regressions for every hole (including a literal field
tl_sdu_hex vector), and both 4 Sep pre-combine MRC captures replay 8/8
genuine neighbour cells through TestTETRANeighbourReportReplay, byte-identical
to the pre-change baseline, at slightly better decode throughput (56/42 s vs
61/43 s for 120 s of air).

Refs the 4-5 Sep Discord field report (bogus neighbour sites after ~10 h).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NYxdJFChp2Hh5xaMtwHYpr