### PR TITLE
dmr: coarse pre-clock carrier acquisition for grossly-mistuned dongles (#836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ for tagged releases.
   never require acceptance.
 
 ### Fixed
+- **Conventional DMR now decodes through a grossly-mistuned RTL-SDR** (#836).
+  DMR was the one C4FM receiver whose only carrier-offset correction was the
+  post-clock CoarseAFC, which pulls in just a few hundred Hz — so a dongle off
+  by tens of ppm (several kHz at 446 MHz) sat past the decode cliff and never
+  synced, and there was no way to hand-set `sdr.ppm` without a GSM-based
+  calibration tool. A new pre-clock coarse carrier acquisition estimates the
+  offset from the discriminator mean and de-rotates the IQ once, before the
+  discriminator, so the timing loop and matched filter see a centred eye;
+  synthetic decode is now invariant to a tuner offset out to ~40 ppm. Only
+  engages above a 500 Hz deadband, so a well-tuned dongle is unchanged.
+  Synthetic-verified; on-air confirmation against a real mistuned dongle is
+  still pending a capture.
 - **Talkgroups auto-discovered on analog trunking systems are no longer
   labeled mode "D" (digital)** (#1143 follow-up). Discovered-talkgroup mode
   now follows the system's protocol: SmartNet/SmartZone, LTR, MPT-1327 and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,11 @@ for tagged releases.
   offset from the discriminator mean and de-rotates the IQ once, before the
   discriminator, so the timing loop and matched filter see a centred eye;
   synthetic decode is now invariant to a tuner offset out to ~40 ppm. Only
-  engages above a 500 Hz deadband, so a well-tuned dongle is unchanged.
-  Synthetic-verified; on-air confirmation against a real mistuned dongle is
-  still pending a capture.
+  engages above a 500 Hz deadband (a well-tuned dongle is unchanged), and
+  requires two agreeing acquisition windows so it waits through the idle noise
+  of a silent conventional/simplex channel and locks on the transmission rather
+  than the silence. Synthetic-verified; on-air confirmation still pending a
+  usable capture.
 - **Talkgroups auto-discovered on analog trunking systems are no longer
   labeled mode "D" (digital)** (#1143 follow-up). Discovered-talkgroup mode
   now follows the system's protocol: SmartNet/SmartZone, LTR, MPT-1327 and

--- a/internal/dsp/sync/clock.go
+++ b/internal/dsp/sync/clock.go
@@ -92,6 +92,20 @@ func (m *MuellerMuller) Process(dst []float32, src []float32) []float32 {
 	return dst
 }
 
+// Reset returns the loop to its just-constructed state, so a downstream
+// consumer that applies a large mid-stream correction (e.g. a coarse
+// carrier de-rotation) can re-acquire symbol timing from scratch on the
+// corrected signal instead of carrying a phase parked against the old one.
+// The nominal sps and gain are preserved.
+func (m *MuellerMuller) Reset() {
+	m.mu = m.sps
+	m.prevSym = 0
+	m.prevMid = 0
+	m.have = false
+	m.prevTail = 0
+	m.havePrev = false
+}
+
 // Mu returns the current sub-sample phase accumulator (rad-equivalent;
 // in (-1, sps] depending on where the loop is in the symbol period).
 // At steady state on a noise-free signal mu cycles deterministically

--- a/internal/radio/dmr/receiver/coarse_carrier.go
+++ b/internal/radio/dmr/receiver/coarse_carrier.go
@@ -1,0 +1,146 @@
+package receiver
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+)
+
+// coarseCarrierAcquirer performs a one-shot, frozen coarse carrier-offset
+// acquisition in the COMPLEX-IQ domain, ahead of the FM discriminator — the
+// "before-clock/freeze stage" the receiver's post-clock CoarseAFC doc names as
+// the follow-up for grossly-mistuned dongles (issue #836).
+//
+// # Why the post-clock CoarseAFC is not enough on its own
+//
+// The receiver's CoarseAFC removes a carrier offset's constant DC bias from the
+// recovered SYMBOL stream (post-clock, pre-slicer). That recentres the 4-level
+// eye for the slicer, but the Mueller-Müller timing loop and the RRC matched
+// filter still see the uncorrected, frequency-shifted signal — so its pull-in
+// range is bounded to a few hundred Hz. Measured on the synthetic decode path,
+// decode is clean to ~800 Hz, collapses by ~1.5 kHz, and floors at the
+// mis-slice level for any offset past ~3 kHz. At 446 MHz that ceiling is ≈1.8
+// ppm — far short of a typical RTL-SDR's tens-of-ppm tuner error (issue #836:
+// the reporter's dongle never decoded 446.500 simplex, and kalibrate-rtl was
+// unavailable to hand-set sdr.ppm).
+//
+// # What this stage does
+//
+// A constant carrier offset Δf appears at the FM discriminator output as a
+// constant DC bias of 2π·Δf/Fs rad/sample; for a spectrally-balanced 4-level
+// C4FM stream the data modulation averages to zero, so the MEAN of the
+// discriminator output over a long-enough window is an unbiased estimate of Δf.
+// The acquirer accumulates that mean over a fixed acquisition window, and once
+// filled applies it ONCE to a complex NCO that de-rotates the IQ before the
+// discriminator — recentring the signal in the channel so the timing loop and
+// matched filter see a centred eye. The estimate is then FROZEN: a constant
+// de-rotation is a single step the timing loop rides out, whereas a
+// continuously-adapting IQ-domain correction would wander the discriminator
+// output and destabilise symbol timing (the exact reason the residual AFC runs
+// post-clock, and the same frozen-snapshot discipline the TETRA equalizers use).
+//
+// It is deliberately coarse and one-shot. The residual it leaves (tens of Hz)
+// is well inside the post-clock CoarseAFC's comfortable range, which continues
+// to track slow drift. A deadband keeps the stage from touching signals the
+// post-clock AFC already handles, so a well-tuned dongle stays byte-identical.
+type coarseCarrierAcquirer struct {
+	nco        *dsp.NCO
+	sampleRate float64
+	acqSamples int     // acquisition window length, in IQ samples
+	deadbandHz float64 // minimum |estimate| worth correcting
+
+	seen   int
+	sumRad float64 // running sum of discriminator output over the window (rad/sample)
+	locked bool
+	offHz  float64 // frozen correction applied to the NCO (0 until/unless it engages)
+}
+
+// coarseAcqSymbols is the acquisition window length in symbol periods. ~512
+// symbols (~107 ms at 4800 baud) is long enough that ordinary DMR traffic /
+// idle / sync content averages spectrally flat — so the mean tracks the carrier
+// offset, not a transient symbol-distribution bias — yet short enough to lock
+// early in a transmission. Only the leading window of the first transmission
+// after a Reset decodes uncorrected; every burst after the freeze is centred.
+const coarseAcqSymbols = 512
+
+// coarseAcqDeadbandHz is the smallest estimated offset the stage will correct.
+// The post-clock CoarseAFC already decodes cleanly below ~800 Hz, so a 500 Hz
+// deadband leaves that regime untouched (a well-tuned dongle never engages this
+// stage and stays byte-identical) while still catching everything past the
+// ~1.5 kHz decode cliff. It also guards against a mildly-unbalanced acquisition
+// window: faking a 500 Hz mean needs a sustained ~0.77-of-full-scale symbol DC
+// bias over the whole window, which real DMR content does not carry.
+const coarseAcqDeadbandHz = 500.0
+
+// newCoarseCarrierAcquirer builds a one-shot coarse acquirer for an IQ stream
+// sampled at sampleRateHz with sps samples per symbol. Panics on non-positive
+// arguments.
+func newCoarseCarrierAcquirer(sampleRateHz, sps float64) *coarseCarrierAcquirer {
+	if sampleRateHz <= 0 || sps <= 0 {
+		panic("receiver: coarse carrier acquirer requires positive sample rate and sps")
+	}
+	return &coarseCarrierAcquirer{
+		nco:        dsp.NewNCO(0, sampleRateHz), // identity until it engages
+		sampleRate: sampleRateHz,
+		acqSamples: int(math.Round(coarseAcqSymbols * sps)),
+		deadbandHz: coarseAcqDeadbandHz,
+	}
+}
+
+// Mix de-rotates iq by the frozen offset and returns the result (into dst when
+// it has capacity). Until the stage engages the NCO is an identity mix, so the
+// output is bit-identical to the input and downstream decode is unchanged.
+func (c *coarseCarrierAcquirer) Mix(dst, iq []complex64) []complex64 {
+	return c.nco.Mix(dst, iq)
+}
+
+// Observe accumulates the discriminator output toward the acquisition mean and,
+// once the window is full, applies the one-shot frozen correction. disc is the
+// FM-discriminator output for the (already-mixed) IQ of the same Process call.
+// It returns engaged==true on the single call where a correction is applied, so
+// the receiver can reset the downstream DSP to re-lock cleanly on the newly
+// centred signal. A no-op (returns false) after the stage has locked.
+func (c *coarseCarrierAcquirer) Observe(disc []float32) (engaged bool) {
+	if c.locked {
+		return false
+	}
+	for _, x := range disc {
+		c.sumRad += float64(x)
+		c.seen++
+	}
+	if c.seen < c.acqSamples {
+		return false
+	}
+	meanRad := c.sumRad / float64(c.seen)
+	offHz := meanRad * c.sampleRate / (2 * math.Pi)
+	c.locked = true
+	if math.Abs(offHz) < c.deadbandHz {
+		return false
+	}
+	// The NCO shifts a component at +offHz down to DC; the balanced-data mean
+	// is measured on the current (identity, pre-lock) stream, so the full
+	// offset folds in at once. += keeps the general form; the freeze above
+	// makes it single-shot. The frequency step this applies mid-stream would
+	// otherwise leave the Mueller-Müller timing loop parked at a bad phase
+	// (measured: a narrow band of offsets re-locks to a wrong symbol instant),
+	// so the receiver resets the downstream chain when engaged is true.
+	c.offHz += offHz
+	c.nco.SetOffset(c.offHz, c.sampleRate)
+	return true
+}
+
+// OffsetHz reports the frozen coarse correction in hertz (0 until/unless the
+// stage engages). Exposed for daemon logging so an operator sees the tuner
+// offset the receiver pulled out.
+func (c *coarseCarrierAcquirer) OffsetHz() float64 { return c.offHz }
+
+// Reset clears the acquisition so the next transmission re-acquires from
+// scratch. Call on stream re-tune / re-sync alongside the rest of the receiver.
+func (c *coarseCarrierAcquirer) Reset() {
+	c.nco.Reset()
+	c.nco.SetOffset(0, c.sampleRate)
+	c.seen = 0
+	c.sumRad = 0
+	c.locked = false
+	c.offHz = 0
+}

--- a/internal/radio/dmr/receiver/coarse_carrier.go
+++ b/internal/radio/dmr/receiver/coarse_carrier.go
@@ -43,25 +43,52 @@ import (
 // is well inside the post-clock CoarseAFC's comfortable range, which continues
 // to track slow drift. A deadband keeps the stage from touching signals the
 // post-clock AFC already handles, so a well-tuned dongle stays byte-identical.
+//
+// # Idle-channel robustness
+//
+// A conventional / simplex channel is silent before its first transmission, and
+// the discriminator output on noise is ~zero-mean but not zero-variance — one
+// window of noise can post a mean of a few hundred Hz by chance. So the stage
+// does NOT freeze on a single window: it requires TWO consecutive windows whose
+// estimates both clear the deadband AND agree with each other (a real tuner
+// offset is constant window-to-window; noise is not). Windows that fall below
+// the deadband — silence, or a well-tuned signal — simply re-arm, so the stage
+// waits through idle noise and engages on the first ~two windows of a genuinely
+// offset transmission rather than latching onto a noise fluctuation. This
+// replaces an earlier single-window design that locked on the leading silence of
+// a bursty channel and never corrected the transmission (found replaying a real
+// simplex capture, issue #836). It uses no absolute-power gate — agreement, not
+// dBFS, is the signal-vs-noise discriminator.
 type coarseCarrierAcquirer struct {
 	nco        *dsp.NCO
 	sampleRate float64
 	acqSamples int     // acquisition window length, in IQ samples
 	deadbandHz float64 // minimum |estimate| worth correcting
+	agreeHz    float64 // max window-to-window disagreement to accept a lock
 
-	seen   int
-	sumRad float64 // running sum of discriminator output over the window (rad/sample)
-	locked bool
-	offHz  float64 // frozen correction applied to the NCO (0 until/unless it engages)
+	seen    int
+	sumRad  float64 // running sum of discriminator output over the window (rad/sample)
+	haveCan bool    // a prior above-deadband window is pending confirmation
+	canHz   float64 // that window's estimate, awaiting an agreeing second window
+	locked  bool
+	offHz   float64 // frozen correction applied to the NCO (0 until/unless it engages)
 }
 
 // coarseAcqSymbols is the acquisition window length in symbol periods. ~512
 // symbols (~107 ms at 4800 baud) is long enough that ordinary DMR traffic /
 // idle / sync content averages spectrally flat — so the mean tracks the carrier
-// offset, not a transient symbol-distribution bias — yet short enough to lock
-// early in a transmission. Only the leading window of the first transmission
-// after a Reset decodes uncorrected; every burst after the freeze is centred.
+// offset, not a transient symbol-distribution bias — yet short enough that the
+// two-window confirmation still locks early in a transmission (~2 windows,
+// ~214 ms). Only that leading span of the first transmission after a Reset
+// decodes uncorrected; every burst after the freeze is centred.
 const coarseAcqSymbols = 512
+
+// coarseAcqAgreeHz is the maximum window-to-window disagreement accepted when
+// confirming a lock. A real tuner offset is constant to well within this;
+// two independent noise windows agreeing this closely at a >deadband magnitude
+// is vanishingly unlikely, which is what keeps the stage from latching on idle
+// noise. 250 Hz is well below the deadband so a confirmed pair is unambiguous.
+const coarseAcqAgreeHz = 250.0
 
 // coarseAcqDeadbandHz is the smallest estimated offset the stage will correct.
 // The post-clock CoarseAFC already decodes cleanly below ~800 Hz, so a 500 Hz
@@ -84,6 +111,7 @@ func newCoarseCarrierAcquirer(sampleRateHz, sps float64) *coarseCarrierAcquirer 
 		sampleRate: sampleRateHz,
 		acqSamples: int(math.Round(coarseAcqSymbols * sps)),
 		deadbandHz: coarseAcqDeadbandHz,
+		agreeHz:    coarseAcqAgreeHz,
 	}
 }
 
@@ -111,20 +139,37 @@ func (c *coarseCarrierAcquirer) Observe(disc []float32) (engaged bool) {
 	if c.seen < c.acqSamples {
 		return false
 	}
+	// One window complete: estimate its offset and reset the accumulator for the
+	// next window.
 	meanRad := c.sumRad / float64(c.seen)
 	offHz := meanRad * c.sampleRate / (2 * math.Pi)
-	c.locked = true
+	c.seen = 0
+	c.sumRad = 0
+
+	// Below the deadband — silence, or a signal the post-clock AFC already
+	// handles. Drop any pending candidate and re-arm; never freeze here, so an
+	// idle channel keeps waiting instead of latching on a noise fluctuation.
 	if math.Abs(offHz) < c.deadbandHz {
+		c.haveCan = false
 		return false
 	}
-	// The NCO shifts a component at +offHz down to DC; the balanced-data mean
-	// is measured on the current (identity, pre-lock) stream, so the full
-	// offset folds in at once. += keeps the general form; the freeze above
-	// makes it single-shot. The frequency step this applies mid-stream would
-	// otherwise leave the Mueller-Müller timing loop parked at a bad phase
-	// (measured: a narrow band of offsets re-locks to a wrong symbol instant),
-	// so the receiver resets the downstream chain when engaged is true.
-	c.offHz += offHz
+	// Above the deadband but not yet confirmed: hold it as a candidate and wait
+	// for the next window. A real tuner offset repeats; a noise window won't.
+	if !c.haveCan || math.Abs(offHz-c.canHz) > c.agreeHz {
+		c.haveCan = true
+		c.canHz = offHz
+		return false
+	}
+	// Two consecutive windows agree above the deadband — a genuine, constant
+	// carrier offset. Freeze the average and apply it once. The NCO shifts a
+	// component at +offHz down to DC; the estimate is measured on the current
+	// (identity, pre-lock) stream, so the full offset folds in at once. The
+	// frequency step this applies mid-stream would otherwise leave the
+	// Mueller-Müller timing loop parked at a bad phase (measured: a narrow band
+	// of offsets re-locks to a wrong symbol instant), so the receiver resets the
+	// downstream chain when engaged is true.
+	c.locked = true
+	c.offHz += 0.5 * (offHz + c.canHz)
 	c.nco.SetOffset(c.offHz, c.sampleRate)
 	return true
 }
@@ -141,6 +186,8 @@ func (c *coarseCarrierAcquirer) Reset() {
 	c.nco.SetOffset(0, c.sampleRate)
 	c.seen = 0
 	c.sumRad = 0
+	c.haveCan = false
+	c.canHz = 0
 	c.locked = false
 	c.offHz = 0
 }

--- a/internal/radio/dmr/receiver/receiver.go
+++ b/internal/radio/dmr/receiver/receiver.go
@@ -115,9 +115,12 @@ type Receiver struct {
 	mf        *demod.C4FM
 	clock     *sync.MuellerMuller
 	afc       *demod.CoarseAFC
+	acq       *coarseCarrierAcquirer
 	agc       demod.C4FMSymbolAGC
 	dibitSink dmr.DibitSink
 	dibitBase int
+
+	mixed []complex64 // scratch for the coarse-acquirer de-rotation (acq path only)
 
 	// Optional diagnostic taps (symbol scope). nil = no-op.
 	softSink   func([]float32)
@@ -198,11 +201,27 @@ func New(opts Options) *Receiver {
 		afc = demod.NewCoarseAFC(1)
 	}
 
+	// Coarse pre-clock carrier acquisition (issue #836): the post-clock
+	// CoarseAFC above only pulls in a few hundred Hz because the timing loop
+	// and matched filter still see the shifted signal. A grossly-mistuned
+	// dongle (tens of ppm — several kHz at 446 MHz) sits far past that, at the
+	// slicer's mis-slice floor, and no sdr.ppm was set. This stage estimates
+	// the offset from the discriminator mean and de-rotates the IQ once, before
+	// the discriminator, so everything downstream sees a centred eye; the
+	// post-clock AFC then mops up the small residual. Allocated only on the
+	// calibrated DeviationHz>0 path so legacy pre-scaled fixtures stay
+	// byte-identical, and a deadband keeps it dormant on well-tuned signals.
+	var acq *coarseCarrierAcquirer
+	if opts.DeviationHz > 0 {
+		acq = newCoarseCarrierAcquirer(opts.SampleRateHz, sps)
+	}
+
 	return &Receiver{
 		fm:    demod.NewFM(),
 		mf:    demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
 		clock: sync.NewMuellerMuller(sps, gain),
 		afc:   afc,
+		acq:   acq,
 		// Symbol-AGC bridges the level mismatch between the unit-energy
 		// RRC matched filter and the 4-level slicer's fixed thresholds.
 		// The RRC has a DC gain of ~3.1 (it is normalised to unit
@@ -235,7 +254,35 @@ func (r *Receiver) Process(iq []complex64) {
 	if len(iq) == 0 {
 		return
 	}
-	r.disc = r.fm.Process(r.disc, iq)
+	// Coarse pre-clock carrier de-rotation (issue #836). Until the acquirer
+	// engages this is an identity mix (byte-identical output); once it locks it
+	// removes the bulk of a large tuner offset in the IQ domain so the timing
+	// loop and matched filter see a centred signal. nil on the legacy
+	// DeviationHz<=0 path — iq is then passed through untouched.
+	src := iq
+	if r.acq != nil {
+		r.mixed = r.acq.Mix(r.mixed, iq)
+		src = r.mixed
+	}
+	r.disc = r.fm.Process(r.disc, src)
+	if r.acq != nil {
+		// Fold this chunk's discriminator output into the acquisition mean and,
+		// once the window is full, apply the one-shot frozen correction to the
+		// NCO — which takes effect on the NEXT chunk's Mix. When it engages, the
+		// downstream timing loop and level trackers have been following the
+		// uncorrected (shifted) signal, so re-acquire them on the now-centred
+		// signal: without this, the Mueller-Müller loop stays parked at a phase
+		// tuned to the old offset and a narrow band of large offsets re-locks to
+		// the wrong symbol instant (issue #836). This chunk is still inside the
+		// discarded acquisition warm-up, so the reset costs nothing decoded.
+		if r.acq.Observe(r.disc) {
+			r.clock.Reset()
+			r.agc.Reset()
+			if r.afc != nil {
+				r.afc.Reset()
+			}
+		}
+	}
 	r.matched = r.mf.MatchedFilter(r.matched, r.disc)
 	r.symbols = r.clock.Process(r.symbols, r.matched)
 	if len(r.symbols) == 0 {
@@ -308,6 +355,21 @@ func (r *Receiver) Reset() {
 	if r.afc != nil {
 		r.afc.Reset()
 	}
+	if r.acq != nil {
+		r.acq.Reset()
+	}
+}
+
+// CoarseCarrierOffsetHz reports the frozen coarse carrier-offset correction the
+// pre-clock acquirer pulled out of the IQ, in hertz (issue #836). It is 0 until
+// the stage engages (a well-tuned dongle, or an offset below the deadband) and
+// 0 on the legacy pre-scaled-fixture path where the acquirer is disabled.
+// Exposed so the daemon can log the tuner offset an operator's dongle carries.
+func (r *Receiver) CoarseCarrierOffsetHz() float64 {
+	if r.acq == nil {
+		return 0
+	}
+	return r.acq.OffsetHz()
 }
 
 // AGCLevel and AGCTarget expose the shared symbol-AGC's running mean|x|

--- a/internal/radio/dmr/receiver/receiver_test.go
+++ b/internal/radio/dmr/receiver/receiver_test.go
@@ -180,6 +180,149 @@ func TestReceiverIsCarrierOffsetInvariant(t *testing.T) {
 	}
 }
 
+// decodeDibitsChunked runs one IQ buffer through a DeviationHz-calibrated DMR
+// receiver in fixed-size chunks (mirroring how the daemon feeds live IQ) and
+// returns the recovered dibit stream. The pre-clock coarse acquirer only
+// applies its one-shot correction on the chunk AFTER it locks, so exercising it
+// requires chunked delivery — a single Process call mixes the whole buffer with
+// the identity NCO before the lock ever fires.
+func decodeDibitsChunked(iq []complex64, chunk int) []uint8 {
+	var got []uint8
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1944.0,
+		DibitSink:    func(dibits []uint8, baseIdx int) { got = append(got, dibits...) },
+	})
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	return got
+}
+
+// bestLagAgreement returns the fraction of dibits (over ref[warmup:]) that match
+// got at the single best constant lag in [-40, +40]. When the coarse acquirer
+// engages it re-acquires symbol timing on the corrected signal, which shifts the
+// recovered stream by a constant, decode-neutral number of symbols relative to a
+// stream that never engaged — so the streams are compared under their best
+// constant alignment, exactly as a downstream sync-word correlator finds a burst
+// wherever it lands. A true mis-decode stays at the ~0.25 chance / ~0.71
+// mis-slice floor at every lag; only a correct decode aligns.
+func bestLagAgreement(ref, got []uint8, warmup int) float64 {
+	best := 0.0
+	for lag := -40; lag <= 40; lag++ {
+		ok, tot := 0, 0
+		for i := warmup; i < len(ref); i++ {
+			j := i + lag
+			if j < 0 || j >= len(got) {
+				continue
+			}
+			tot++
+			if ref[i] == got[j] {
+				ok++
+			}
+		}
+		if tot > 500 {
+			if f := float64(ok) / float64(tot); f > best {
+				best = f
+			}
+		}
+	}
+	return best
+}
+
+// TestReceiverDecodesGrosslyMistunedDongle pins the issue #836 follow-up: the
+// pre-clock coarse carrier acquisition. The receiver's post-clock CoarseAFC
+// alone pulls in only a few hundred Hz, so a real RTL-SDR off by tens of ppm
+// (several kHz at 446 MHz — the reporter's case, with kalibrate-rtl unavailable
+// to hand-set sdr.ppm) sat past the decode cliff and never synced. The coarse
+// stage estimates the offset from the discriminator mean and de-rotates the IQ
+// once, before the discriminator, so the recovered stream matches the
+// zero-offset decode.
+//
+// Metric: decode each offset stream and the (never-engaging) zero-offset
+// reference, then take the best-constant-lag agreement over a post-acquisition
+// tail. Verified failing-first by disabling the stage (deadband → ∞): agreement
+// collapses to the ~0.71 mis-slice floor at 3–18 kHz and to the ~0.29 chance
+// floor in the ~1.2–1.5 kHz notch, versus ≥0.93 with the stage on.
+func TestReceiverDecodesGrosslyMistunedDongle(t *testing.T) {
+	const chunk = 4096 // RTL-realistic delivery; single Process can't exercise the stage
+	stream := balancedStream(3000)
+	// The reference never engages the acquirer (0 Hz < deadband), so it is
+	// identical to the pre-#836 decode and a stable ground truth.
+	ref := decodeDibitsChunked(makeC4FMIQWithOffset(stream, 0), chunk)
+
+	cases := []struct {
+		name     string
+		offsetHz float64
+	}{
+		// ≈2.7 ppm at 446 MHz — the ~1.2–1.5 kHz notch where the old code
+		// mis-locked to the wrong symbol instant (chance floor ~0.29).
+		{"mid-band notch 1500 Hz", 1500},
+		// ≈6.7 ppm — a typical RTL-SDR tuner error; old code floors at ~0.71.
+		{"grossly mistuned 3000 Hz", 3000},
+		// ≈13 ppm — a badly-mistuned dongle; old code floors at ~0.71.
+		{"grossly mistuned 6000 Hz", 6000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			off := decodeDibitsChunked(makeC4FMIQWithOffset(stream, tc.offsetHz), chunk)
+			// Skip past the coarse acquisition window (~819 symbols at chunk=4096)
+			// plus a short re-lock settle, so the measurement is over the frozen,
+			// centred steady state.
+			const warmup = 1100
+			if len(ref) <= warmup || len(off) <= warmup {
+				t.Fatalf("recovered too few dibits: ref=%d off=%d, need > %d", len(ref), len(off), warmup)
+			}
+			frac := bestLagAgreement(ref, off, warmup)
+			if frac < 0.95 {
+				t.Fatalf("dibit agreement with the zero-offset decode = %.3f at %.0f Hz, want >=0.95 — the coarse pre-clock acquirer should make decode invariant to a grossly-mistuned tuner (issue #836); the stage disabled floors at ~0.71 (mis-slice) / ~0.29 (notch)", frac, tc.offsetHz)
+			}
+		})
+	}
+}
+
+// TestCoarseCarrierAcquirerReportsOffset pins the diagnostic getter and the
+// deadband: a grossly-mistuned signal reports a frozen coarse offset close to
+// the true tuner error (so the daemon can log it), while a well-tuned signal
+// leaves the stage dormant at 0 (the post-clock CoarseAFC handles small offsets
+// and the pre-clock stage must not perturb an already-decoding dongle).
+func TestCoarseCarrierAcquirerReportsOffset(t *testing.T) {
+	const chunk = 4096
+	stream := balancedStream(3000)
+
+	runOffset := func(offsetHz float64) float64 {
+		r := New(Options{
+			SampleRateHz: 48_000,
+			DeviationHz:  1944.0,
+			DibitSink:    func([]uint8, int) {},
+		})
+		iq := makeC4FMIQWithOffset(stream, offsetHz)
+		for i := 0; i < len(iq); i += chunk {
+			end := i + chunk
+			if end > len(iq) {
+				end = len(iq)
+			}
+			r.Process(iq[i:end])
+		}
+		return r.CoarseCarrierOffsetHz()
+	}
+
+	// Below the deadband: the stage stays dormant and reports exactly 0.
+	if got := runOffset(120); got != 0 {
+		t.Errorf("small (120 Hz) offset engaged the coarse stage: reported %.1f Hz, want 0", got)
+	}
+	// Grossly mistuned: the stage engages and its frozen estimate is within a
+	// few hundred Hz of the true offset (a small bias is expected from the
+	// finite acquisition window's residual symbol DC).
+	if got := runOffset(6000); math.Abs(got-6000) > 400 {
+		t.Errorf("6000 Hz offset: reported coarse offset %.1f Hz, want within 400 Hz of 6000", got)
+	}
+}
+
 func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
 	r := New(Options{
 		SampleRateHz: 48_000,

--- a/internal/radio/dmr/receiver/receiver_test.go
+++ b/internal/radio/dmr/receiver/receiver_test.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 )
 
@@ -250,7 +251,7 @@ func bestLagAgreement(ref, got []uint8, warmup int) float64 {
 // floor in the ~1.2–1.5 kHz notch, versus ≥0.93 with the stage on.
 func TestReceiverDecodesGrosslyMistunedDongle(t *testing.T) {
 	const chunk = 4096 // RTL-realistic delivery; single Process can't exercise the stage
-	stream := balancedStream(3000)
+	stream := balancedStream(4500)
 	// The reference never engages the acquirer (0 Hz < deadband), so it is
 	// identical to the pre-#836 decode and a stable ground truth.
 	ref := decodeDibitsChunked(makeC4FMIQWithOffset(stream, 0), chunk)
@@ -270,10 +271,11 @@ func TestReceiverDecodesGrosslyMistunedDongle(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			off := decodeDibitsChunked(makeC4FMIQWithOffset(stream, tc.offsetHz), chunk)
-			// Skip past the coarse acquisition window (~819 symbols at chunk=4096)
-			// plus a short re-lock settle, so the measurement is over the frozen,
-			// centred steady state.
-			const warmup = 1100
+			// Skip past the two-window coarse acquisition. Observe accumulates whole
+			// chunks, so each window rounds up to ~one chunk beyond the 512-symbol
+			// minimum and the confirmed lock lands near ~1650 symbols; skip well past
+			// it so the measurement is over the frozen, centred steady state.
+			const warmup = 2400
 			if len(ref) <= warmup || len(off) <= warmup {
 				t.Fatalf("recovered too few dibits: ref=%d off=%d, need > %d", len(ref), len(off), warmup)
 			}
@@ -282,6 +284,85 @@ func TestReceiverDecodesGrosslyMistunedDongle(t *testing.T) {
 				t.Fatalf("dibit agreement with the zero-offset decode = %.3f at %.0f Hz, want >=0.95 — the coarse pre-clock acquirer should make decode invariant to a grossly-mistuned tuner (issue #836); the stage disabled floors at ~0.71 (mis-slice) / ~0.29 (notch)", frac, tc.offsetHz)
 			}
 		})
+	}
+}
+
+// prependNoise puts nNoise samples of complex Gaussian noise (amplitude amp)
+// ahead of sig — a stand-in for the idle noise a conventional / simplex channel
+// carries before its first transmission.
+func prependNoise(sig []complex64, nNoise int, amp float32, seed int64) []complex64 {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]complex64, nNoise+len(sig))
+	for i := 0; i < nNoise; i++ {
+		out[i] = complex(amp*float32(rng.NormFloat64()), amp*float32(rng.NormFloat64()))
+	}
+	copy(out[nNoise:], sig)
+	return out
+}
+
+// TestCoarseAcquirerEngagesAfterIdleNoise pins the idle-channel fix found while
+// replaying a real DMR simplex capture (issue #836): a conventional / simplex
+// channel is silent before the first transmission, and an earlier single-window
+// design locked on that leading noise (mean below the deadband → frozen at 0)
+// and never corrected the transmission. The two-window-agreement design instead
+// re-arms through idle noise and engages on the first ~two windows of the actual
+// (offset) signal. Verified failing-first against the single-window design:
+// there CoarseCarrierOffsetHz stays 0 (locked on silence); here it recovers the
+// tuner offset.
+func TestCoarseAcquirerEngagesAfterIdleNoise(t *testing.T) {
+	const chunk = 4096
+	const offsetHz = 4000.0 // ≈9 ppm at 446 MHz — well past the decode cliff
+	// ~1.4 windows of idle noise so a full pure-noise window is evaluated (and
+	// must be re-armed) before the signal starts.
+	noise := int(1.4 * coarseAcqSymbols * 10)
+	iq := prependNoise(makeC4FMIQWithOffset(balancedStream(3000), offsetHz), noise, 0.15, 1)
+
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1944.0,
+		DibitSink:    func([]uint8, int) {},
+	})
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	got := r.CoarseCarrierOffsetHz()
+	if got == 0 {
+		t.Fatalf("coarse stage never engaged after idle noise — it locked on the silence (issue #836 idle-channel bug); want a correction near %.0f Hz", offsetHz)
+	}
+	if math.Abs(got-offsetHz) > 500 {
+		t.Errorf("coarse offset after idle noise = %.1f Hz, want within 500 Hz of %.0f", got, offsetHz)
+	}
+}
+
+// TestCoarseAcquirerIgnoresPureNoise pins the other half of the idle-channel
+// design: a channel that is only ever noise (no transmission) must NOT engage
+// the stage — two independent noise windows do not agree above the deadband, so
+// a spurious per-window mean can't latch a bogus correction onto the stream.
+func TestCoarseAcquirerIgnoresPureNoise(t *testing.T) {
+	const chunk = 4096
+	rng := rand.New(rand.NewSource(7))
+	iq := make([]complex64, 60*coarseAcqSymbols*10) // ~60 windows of pure noise
+	for i := range iq {
+		iq[i] = complex(0.15*float32(rng.NormFloat64()), 0.15*float32(rng.NormFloat64()))
+	}
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1944.0,
+		DibitSink:    func([]uint8, int) {},
+	})
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if got := r.CoarseCarrierOffsetHz(); got != 0 {
+		t.Errorf("coarse stage engaged on pure noise: reported %.1f Hz, want 0 (two noise windows must not agree above the deadband)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds pre-clock **coarse carrier acquisition** to the DMR receiver so a grossly-mistuned RTL-SDR (off by tens of ppm — several kHz at 446 MHz) can still centre and decode. DMR was the one C4FM receiver whose only carrier-offset correction was the **post-clock** `CoarseAFC`, which recentres the eye for the slicer but leaves the Mueller-Müller timing loop and matched filter looking at the shifted signal — so its pull-in was only a few hundred Hz. The receiver doc already named this as the follow-up ("a P25-style before-clock/freeze stage is the follow-up for grossly-mistuned dongles").

**Scope note (important):** this is a **general large-offset improvement** raised by #836. While validating it against the reporter's actual IQ captures (which arrived after the PR opened), I found the reporter's specific 446.500 capture is **not** blocked by carrier offset — see the [investigation on #836](https://github.com/MattCheramie/GopherTrunk/issues/836). So this PR is `Refs #836`, not its fix. It stands on its own as correct, tested large-offset handling, and the real capture directly improved it (the idle-channel robustness below).

## Changes

- **`internal/radio/dmr/receiver/coarse_carrier.go` (new)** — one-shot, frozen coarse acquirer. A constant offset Δf is a constant DC bias at the FM-discriminator output; for a balanced C4FM stream the data averages to zero, so the **mean of the discriminator output** estimates Δf. It applies that estimate **once** to a complex `dsp.NCO` that de-rotates the IQ **before** the discriminator, then **freezes** (a constant de-rotation is a single step the loops ride out; a continuously-adapting one would wander the discriminator output and destabilise timing — the reason the residual AFC stays post-clock).
  - **Idle-channel robust:** requires **two consecutive acquisition windows** whose estimates both clear a 500 Hz deadband **and agree** (250 Hz) before freezing. A real tuner offset is constant window-to-window; idle noise is not. So on a silent conventional/simplex channel it re-arms through the leading noise and engages on the transmission, instead of latching onto a noise fluctuation (or, as an earlier single-window design did, locking on the silence and never correcting). No absolute-power gate — agreement, not dBFS, separates signal from noise (the repo's coherence-over-power rule).
- **`internal/radio/dmr/receiver/receiver.go`** — wire into `Process` (de-rotate → discriminate → observe); on engage, reset the downstream timing/level trackers so they re-acquire on the centred signal (a narrow band of offsets otherwise re-locks to the wrong symbol instant). Gated on the calibrated `DeviationHz>0` path and the deadband, so a well-tuned dongle is byte-identical and legacy fixtures untouched. Exposes `Receiver.CoarseCarrierOffsetHz()` for a future log line.
- **`internal/dsp/sync/clock.go`** — add `MuellerMuller.Reset()`.
- **`CHANGELOG.md`** — `[Unreleased]` bullet.

## Test plan

- [x] `go build ./...`, `go vet`, and tests for `dmr/...`, `dsp/sync`, `dsp/demod`, `ccdecoder`, `voice/composer`, `symbolscope`, `widebandt2` — all green.
- [x] Tests (all **failing-first**, verified by disabling the stage):
  - `TestReceiverDecodesGrosslyMistunedDongle` — large-offset decode agreement floors at ~0.71 (mis-slice) / ~0.29 (notch) disabled, ≥0.95 enabled, out to ~40 ppm.
  - `TestCoarseAcquirerEngagesAfterIdleNoise` — engages on the signal after a window of leading noise (single-window design stayed at 0).
  - `TestCoarseAcquirerIgnoresPureNoise` — 60 windows of pure noise never engage.
  - `TestCoarseCarrierAcquirerReportsOffset` — deadband dormancy + estimate accuracy.
- [ ] Smoke-tested against real hardware — **partially.** I did obtain and replay the reporter's real captures (link came back up). They confirmed the general behaviour is sound but showed carrier offset is **not** this reporter's blocker (details on #836), so the specific on-air win this was framed around is unproven; the general large-offset fix remains synthetic-verified.

## Breaking changes

None. Well-tuned dongles (offset below the deadband) and legacy `DeviationHz<=0` fixtures are byte-identical.

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullet added to `CHANGELOG.md`
- [ ] `README.md` / `docs/` — n/a (automatic; no config/CLI change)

## Linked issues

Refs #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FjAksgDRgfQwPp5DKEJJq