### PR TITLE
motorola: backfill SmartNet call source RID onto voice updates (#1143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ for tagged releases.
   never require acceptance.
 
 ### Fixed
+- **SmartNet/SmartZone call source RID no longer blanks after the first frame**
+  (#1143). Motorola SmartNet sends the calling radio ID only on the two-OSW
+  grant that starts a call; the single-OSW voice updates that keep it alive omit
+  it, so the source flashed for one frame on the Active Calls view and then
+  disappeared. The control channel now remembers each talkgroup's source from
+  its initiating grant and backfills it onto the following updates (aged out
+  after the call ends so a stale talker can't attach to a later call, and
+  replaced when a new talker keys up the same talkgroup). Display/attribution
+  only — decode and recording are unaffected.
 - **Conventional DMR now decodes through a grossly-mistuned RTL-SDR** (#836).
   DMR was the one C4FM receiver whose only carrier-offset correction was the
   post-clock CoarseAFC, which pulls in just a few hundred Hz — so a dongle off

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -33,6 +33,18 @@ func (s LockState) LockedNAC() uint16         { return s.SystemID }
 // sequencer only steps once it can see a full window.
 const oswQueueDepth = 3
 
+// sourceMemoryTTL bounds how long the source radio ID from an initiating
+// grant is remembered and backfilled onto that talkgroup's later voice
+// updates (issue #1143). SmartNet sends the source RID only on the two-OSW
+// grant that starts a call; the single-OSW updates that keep it alive omit
+// it, so without this the Active Calls source blanks after one frame. The
+// memory is refreshed on every grant/update for the talkgroup, so a call
+// keeps its source however sparsely its updates arrive on a weak CC; it ages
+// out this long after updates stop (the call ended) so a stale talker can't
+// be attached to a later, source-less call on the same talkgroup. It is only
+// ever a display/attribution aid — decode and recording never key off it.
+const sourceMemoryTTL = 30 * time.Second
+
 // ControlChannel ingests OSWs from a single SmartNet / SmartZone
 // control channel, emits cc.locked the first time the OSW stream
 // carries the system identity, and republishes voice grants as
@@ -66,6 +78,17 @@ type ControlChannel struct {
 	oswQ   []OSW
 	locked bool
 	last   LockState
+	// callSrc remembers the calling radio ID from each talkgroup's
+	// initiating grant so the source-less voice updates that follow can be
+	// backfilled with it (issue #1143). Keyed by masked talkgroup.
+	callSrc map[uint16]srcMemo
+}
+
+// srcMemo is one talkgroup's remembered source radio ID and the time it was
+// last seen, for aging out a stale talker (see sourceMemoryTTL).
+type srcMemo struct {
+	id uint32
+	at time.Time
 }
 
 // Options configure a ControlChannel.
@@ -108,6 +131,7 @@ func New(opts Options) *ControlChannel {
 		plan:       plan,
 		onOSW:      opts.OnOSW,
 		now:        now,
+		callSrc:    map[uint16]srcMemo{},
 	}
 }
 
@@ -237,12 +261,17 @@ func (c *ControlChannel) publishGrant(grantOSW OSW, src uint32) {
 	if !ok {
 		return
 	}
+	tg := grantOSW.Talkgroup()
+	// Backfill the calling radio ID onto a source-less voice update from the
+	// grant that started the call, and remember a fresh source for the updates
+	// still to come (issue #1143).
+	src = c.resolveSource(tg, src)
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
 			System:      c.systemName,
 			Protocol:    "motorola",
-			GroupID:     uint32(grantOSW.Talkgroup()),
+			GroupID:     uint32(tg),
 			SourceID:    src,
 			FrequencyHz: freq,
 			ChannelNum:  grantOSW.Command,
@@ -252,8 +281,33 @@ func (c *ControlChannel) publishGrant(grantOSW OSW, src uint32) {
 		},
 	})
 	c.log.Debug("motorola: grant",
-		"system", c.systemName, "tg", grantOSW.Talkgroup(), "src", src,
+		"system", c.systemName, "tg", tg, "src", src,
 		"channel", grantOSW.Command, "freq_hz", freq)
+}
+
+// resolveSource remembers a talkgroup's source radio ID from its initiating
+// grant (src != 0) and backfills it onto that talkgroup's later voice updates
+// (src == 0), which SmartNet sends without a source (issue #1143). A fresh
+// grant for the talkgroup overwrites the remembered source with the new
+// talker; a remembered source older than sourceMemoryTTL is treated as stale
+// (the previous call ended) and not attached to a new source-less call. Every
+// hit refreshes recency so a call keeps its source across sparse updates on a
+// weak control channel. Caller holds c.mu.
+func (c *ControlChannel) resolveSource(tg uint16, src uint32) uint32 {
+	now := c.now()
+	if src != 0 {
+		c.callSrc[tg] = srcMemo{id: src, at: now}
+		return src
+	}
+	if m, ok := c.callSrc[tg]; ok && now.Sub(m.at) <= sourceMemoryTTL {
+		m.at = now
+		c.callSrc[tg] = m
+		return m.id
+	}
+	// Stale or never seen: drop any aged entry so the map can't grow without
+	// bound on a busy system, and report no source.
+	delete(c.callSrc, tg)
+	return 0
 }
 
 // maybeLockLocked publishes cc.locked on the first (or a changed)

--- a/internal/radio/motorola/motorola_test.go
+++ b/internal/radio/motorola/motorola_test.go
@@ -115,6 +115,119 @@ func TestSequencerPublishesSingleOSWUpdate(t *testing.T) {
 	}
 }
 
+// TestGrantSourceBackfilledOntoUpdates pins issue #1143: SmartNet carries the
+// calling radio ID only on the two-OSW grant that starts a call; the single-OSW
+// voice updates that keep it alive omit it. The ControlChannel remembers the
+// initiating grant's source and backfills it onto those updates, so the Active
+// Calls source no longer blanks after the first frame.
+func TestGrantSourceBackfilledOntoUpdates(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	clk := time.Unix(1000, 0)
+	c := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 854_562_500, Now: func() time.Time { return clk }})
+
+	// Initiating group grant: source 0x2E9A, talkgroup 0xB010, channel 0x8E.
+	c.Ingest(OSW{Address: 0x2E9A, Command: CmdFirstNormal})
+	c.Ingest(OSW{Address: 0xB01A, Group: true, Command: 0x8E})
+	// Two source-less voice updates, spaced out (a weak CC sends them sparsely).
+	clk = clk.Add(3 * time.Second)
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	clk = clk.Add(5 * time.Second)
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	// Flush the sequencer.
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+
+	_, grants := drainEvents(sub)
+	if len(grants) != 3 {
+		t.Fatalf("grants = %d, want 3 (initiating grant + 2 updates)", len(grants))
+	}
+	for i, g := range grants {
+		if g.GroupID != 0xB010 {
+			t.Fatalf("grant %d GroupID = %#x, want 0xB010", i, g.GroupID)
+		}
+		if g.SourceID != 0x2E9A {
+			t.Errorf("grant %d SourceID = %#x, want 0x2E9A backfilled from the initiating grant (issue #1143)", i, g.SourceID)
+		}
+	}
+}
+
+// TestGrantSourceMemoryAgesOut: once a call's updates stop for longer than
+// sourceMemoryTTL (the call ended), a later source-less update on the same
+// talkgroup must NOT inherit the previous talker.
+func TestGrantSourceMemoryAgesOut(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	clk := time.Unix(1000, 0)
+	c := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 854_562_500, Now: func() time.Time { return clk }})
+
+	// A call from source 0x2E9A on TG 0xB010. Flush the sequencer so the
+	// initiating grant is interpreted now (interpretation lags the queue), then
+	// advance the clock — otherwise the grant and the later update would be
+	// interpreted back-to-back at the same instant.
+	c.Ingest(OSW{Address: 0x2E9A, Command: CmdFirstNormal})
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+	// Long silence past the TTL — the call ended.
+	clk = clk.Add(sourceMemoryTTL + time.Second)
+	// A lone source-less update on the same talkgroup (e.g. a new call whose
+	// initiating grant was missed on a weak CC).
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+
+	_, grants := drainEvents(sub)
+	if len(grants) != 2 {
+		t.Fatalf("grants = %d, want 2", len(grants))
+	}
+	if grants[0].SourceID != 0x2E9A {
+		t.Errorf("first grant SourceID = %#x, want 0x2E9A", grants[0].SourceID)
+	}
+	if grants[1].SourceID != 0 {
+		t.Errorf("stale update SourceID = %#x, want 0 (previous talker aged out after %s)", grants[1].SourceID, sourceMemoryTTL)
+	}
+}
+
+// TestGrantSourceMemoryFollowsNewTalker: a fresh grant with a different source
+// on the same talkgroup replaces the remembered talker, so its updates carry
+// the new source, not the old one.
+func TestGrantSourceMemoryFollowsNewTalker(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	clk := time.Unix(1000, 0)
+	c := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 854_562_500, Now: func() time.Time { return clk }})
+
+	// First talker.
+	c.Ingest(OSW{Address: 0x1111, Command: CmdFirstNormal})
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	// Second talker keys up on the same talkgroup a moment later.
+	clk = clk.Add(2 * time.Second)
+	c.Ingest(OSW{Address: 0x2222, Command: CmdFirstNormal})
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	// A following update should carry the second talker.
+	c.Ingest(OSW{Address: 0xB010, Group: true, Command: 0x8E})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+	c.Ingest(OSW{Address: 0x02F8, Command: CmdIdle})
+
+	_, grants := drainEvents(sub)
+	if len(grants) != 3 {
+		t.Fatalf("grants = %d, want 3", len(grants))
+	}
+	if grants[0].SourceID != 0x1111 {
+		t.Errorf("grant 0 SourceID = %#x, want 0x1111", grants[0].SourceID)
+	}
+	if grants[1].SourceID != 0x2222 || grants[2].SourceID != 0x2222 {
+		t.Errorf("after re-grant SourceIDs = %#x,%#x, want 0x2222 (new talker replaces old)", grants[1].SourceID, grants[2].SourceID)
+	}
+}
+
 // TestSequencerRecordsAlternateCC: the 0x30B + 0x6000-masked pair
 // advertises an alternate / adjacent control channel for the hunt
 // topology, and its system ID locks.


### PR DESCRIPTION
## Summary

On a SmartNet/SmartZone system the calling radio ID rides only the **two-OSW grant that starts a call**; the **single-OSW group voice updates** that keep the call alive carry the talkgroup + channel but no source. So the source appeared on the Active Calls view for one frame at call start and then blanked — exactly what @n1zyy reported in #1143 ("it just flashes for a second and then disappears, since the subsequent messages don't send a call ID").

## Changes

- **`internal/radio/motorola/control.go`** — the `ControlChannel` now remembers each talkgroup's source RID from its initiating grant (a `callSrc` map, mirroring the TETRA `callSrc` binding) and backfills it onto that talkgroup's later source-less updates in `publishGrant`, before the `trunking.Grant` is published. So the engine, the SSE/TUI Active Calls view, and completed-call recordings all see a **consistent source for the whole call** — fixing it once at the source rather than in each downstream consumer.
  - **Refreshed** on every grant/update, so a call keeps its source however sparsely its updates arrive on a weak control channel.
  - **Aged out** after `sourceMemoryTTL` (30 s) once updates stop (the call ended), so a stale talker can't be attached to a later source-less call on the same talkgroup.
  - **Replaced** when a fresh grant with a different source keys up the same talkgroup.
  - Display/attribution only — decode and recording never key off it.
- **`CHANGELOG.md`** — `[Unreleased]` bullet.

## Test plan

- [x] `make vet test` equivalent locally: `go build ./...`, `go vet ./internal/radio/motorola/`, and tests for `motorola/...`, `ccdecoder`, `trunking` — all green.
- [x] Added tests (all **failing-first**, verified against the pre-change publish path):
  - `TestGrantSourceBackfilledOntoUpdates` — the two source-less updates after an initiating grant inherit its source.
  - `TestGrantSourceMemoryAgesOut` — a source-less update > 30 s after the call ended does **not** inherit the previous talker.
  - `TestGrantSourceMemoryFollowsNewTalker` — a re-grant with a new source replaces the remembered one.
  - The existing `TestSequencerPublishesSingleOSWUpdate` (a lone update with no prior grant still reports source 0) still passes.
- [ ] `make integration` — n/a (no daemon wiring change; the `ControlChannel` is constructed unchanged).
- [ ] Smoke-tested against real hardware — not required (pure control-plane logic on decoded OSWs), but this will show on @n1zyy's live SmartZone system.

## Breaking changes

None. A lone update with no known source still publishes source 0 as before; only updates that follow a real grant now carry that grant's source.

## Docs / CHANGELOG

- [x] `## [Unreleased]` bullet added to `CHANGELOG.md`
- [ ] `README.md` / `docs/` — n/a

## Linked issues

Refs #1143

This addresses the **source-RID persistence** ask in #1143. The other item in that thread — analog SmartNet calls sometimes holding open squelch at end — is a separate root cause (the analog FM voice chain has no carrier-drop/squelch detection for trunked voice, so it records until the engine's hangtime); that needs a short audio capture to build and validate a carrier-power squelch safely, and is tracked in the issue discussion rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FjAksgDRgfQwPp5DKEJJq

---
_Generated by [Claude Code](https://claude.ai/code/session_016FjAksgDRgfQwPp5DKEJJq)_