### PR TITLE
test(dmr): pin the conventional-DMR camp→keyup→lock→grant transition (#1036)

### DIFF
--- a/cmd/gophertrunk/dmr_ipsc_replay_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_replay_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -18,9 +20,13 @@ import (
 )
 
 // TestDMRIPSCReplay is a real-air diagnostic harness for conventional DMR /
-// IPSC captures (issue #1036). Skip unless GT_DMR_IQ points at a cs16
-// (interleaved int16) IQ file; GT_DMR_IQ_RATE gives its sample rate (default
-// 50000). It mirrors the daemon's dmr-tier2 decode: it downconverts to the DMR
+// IPSC captures (issue #1036). Skip unless GT_DMR_IQ points at an IQ file;
+// GT_DMR_IQ_RATE gives its sample rate (default 50000) and GT_DMR_IQ_FORMAT the
+// encoding (cs16 default, or f32 for a GNU Radio / gqrx cfile — the reporter's
+// 25 kS/s f32 capture: GT_DMR_IQ_RATE=25000 GT_DMR_IQ_FORMAT=f32). Note an
+// idle-beacon capture (a resting burst with no voice keyup) decodes 0 grants by
+// design — set GT_DMR_ALLOW_EMPTY=1 for that case. It mirrors the daemon's
+// dmr-tier2 decode: it downconverts to the DMR
 // channel rate, runs the shared DMR receiver, and feeds the recovered dibits to
 // BOTH the Tier II conventional state machine (which emits a grant on every
 // Voice LC Header — "grants but no voice" comes from here) AND the DMR voice
@@ -36,7 +42,7 @@ import (
 func TestDMRIPSCReplay(t *testing.T) {
 	path := os.Getenv("GT_DMR_IQ")
 	if path == "" {
-		t.Skip("set GT_DMR_IQ (cs16 IQ) [+ GT_DMR_IQ_RATE] to run the DMR IPSC replay")
+		t.Skip("set GT_DMR_IQ (IQ file) [+ GT_DMR_IQ_RATE, GT_DMR_IQ_FORMAT=cs16|f32] to run the DMR IPSC replay")
 	}
 	inRate := 50000.0
 	if v := os.Getenv("GT_DMR_IQ_RATE"); v != "" {
@@ -52,11 +58,31 @@ func TestDMRIPSCReplay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	iq := make([]complex64, len(raw)/4)
-	for i := range iq {
-		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
-		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
-		iq[i] = complex(float32(re)/32768, float32(im)/32768)
+	// GT_DMR_IQ_FORMAT selects the sample encoding: cs16 (default, interleaved
+	// int16) or f32 (interleaved float32 — the GNU Radio / gqrx cfile format the
+	// #1036 reporter's 25 kS/s capture uses).
+	format := strings.ToLower(os.Getenv("GT_DMR_IQ_FORMAT"))
+	if format == "" {
+		format = "cs16"
+	}
+	var iq []complex64
+	switch format {
+	case "cs16", "sc16":
+		iq = make([]complex64, len(raw)/4)
+		for i := range iq {
+			re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
+			im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
+			iq[i] = complex(float32(re)/32768, float32(im)/32768)
+		}
+	case "f32", "cf32", "fc32":
+		iq = make([]complex64, len(raw)/8)
+		for i := range iq {
+			re := math.Float32frombits(binary.LittleEndian.Uint32(raw[i*8:]))
+			im := math.Float32frombits(binary.LittleEndian.Uint32(raw[i*8+4:]))
+			iq[i] = complex(re, im)
+		}
+	default:
+		t.Fatalf("unknown GT_DMR_IQ_FORMAT %q (want cs16 or f32)", format)
 	}
 
 	// DMR is the 4800-baud C4FM family — normalise to the 48 kHz channel rate.

--- a/cmd/gophertrunk/integration_cc_dmr_tier2_camp_test.go
+++ b/cmd/gophertrunk/integration_cc_dmr_tier2_camp_test.go
@@ -1,0 +1,231 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestDaemonDMRTier2CampsThenGrantsOnKeyup pins the full issue #1036 transition
+// end-to-end through the production daemon: a conventional DMR / IPSC repeater
+// that is IDLE before the first transmission must CAMP on the channel (no
+// `cchunt.failed`, scanner state "camped") and then, when a station keys up,
+// LOCK and publish a GRANT carrying the talkgroup + source RID decoded off the
+// Voice LC Header.
+//
+// The camp state machine is unit-tested at the supervisor level
+// (internal/scanner/cchunt.TestSupervisorCampsIdleConventionalDMR). This is the
+// integration counterpart the issue asked for — it exercises the real
+// receiver → tier2 → grant path across the camp→keyup boundary, so the whole
+// chain can't silently break later. Reporter's repeater is colour code 10, so
+// the fixture uses that.
+func TestDaemonDMRTier2CampsThenGrantsOnKeyup(t *testing.T) {
+	const (
+		controlFreqHz = 460_500_000
+		sampleRateHz  = 48_000
+		sps           = 10
+		span          = 8
+		alpha         = 0.20
+		deviationHz   = 1944.0
+		colorCode     = 0xA // colour code 10, matching the reporter's IPSC repeater
+		groupID       = 0x2A2
+		sourceID      = 0x315AC5
+		burstRepeats  = 60
+	)
+
+	// ~1.5 s of low-level noise: the idle channel before anyone keys up. It
+	// never decodes, so the supervisor dwells, fails to lock, and — because
+	// dmr-tier2 CampsWhenIdle — camps instead of raising cchunt.failed.
+	idle := makeNoiseIQ(sampleRateHz*3/2, 0.05, 1)
+	// The keyup: repeated Voice LC Header bursts carrying the TG + source RID.
+	keyupDibits := buildDMRTier2VoiceLCHeaderDibits(burstRepeats, colorCode, groupID, sourceID)
+	keyup := demod.ModulateC4FM(keyupDibits, sps, span, alpha, sampleRateHz, deviationHz)
+	iq := append(idle, keyup...)
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "dmr-tier2-camp.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = sampleRateHz
+	cfg.SDR.Devices = []config.DeviceConfig{{Serial: "mock-00", Role: "control"}}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "IPSCRepeater", Protocol: "dmr-tier2", ControlChannels: []uint32{controlFreqHz}},
+	}
+	// Short dwell so the camp decision (and this test) is quick; the ~1.5 s idle
+	// prefix still spans several dwells before the keyup. Enabled must be set
+	// explicitly: any non-zero CCHunt field takes the config out of its
+	// "default (enabled)" zero value, so the supervisor would otherwise be
+	// switched off (daemon.go's cchEnabled gate).
+	cfg.Scanner.CCHunt.Enabled = true
+	cfg.Scanner.CCHunt.DwellMs = 400
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-dmr-tier2-camp", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	// Drain the bus for the life of the run: record a cchunt.failed for our
+	// system (the exact #1036 regression), and capture the lock + grant.
+	var (
+		mu       sync.Mutex
+		locked   bool
+		gotGrant bool
+		grantTG  uint32
+		grantSrc uint32
+	)
+	huntFailed := make(chan struct{}, 4)
+	stopDrain := make(chan struct{})
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for {
+			select {
+			case <-stopDrain:
+				return
+			case ev, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				switch ev.Kind {
+				case events.KindHuntFailed:
+					select {
+					case huntFailed <- struct{}{}:
+					default:
+					}
+				case events.KindCCLocked:
+					if ls, ok := ev.Payload.(tier2.LockState); ok && ls.ColorCode == colorCode {
+						mu.Lock()
+						locked = true
+						mu.Unlock()
+					}
+				case events.KindGrant:
+					if g, ok := ev.Payload.(trunking.Grant); ok && g.GroupID == groupID {
+						mu.Lock()
+						gotGrant = true
+						grantTG = g.GroupID
+						grantSrc = g.SourceID
+						mu.Unlock()
+					}
+				}
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		close(stopDrain)
+		<-drainDone
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	// 1) During the idle prefix the daemon must reach state=camped, and must not
+	//    have raised cchunt.failed.
+	if !waitForScannerState(t, base, "IPSCRepeater", "camped", 4*time.Second) {
+		t.Fatalf("daemon never reported state=camped on the idle conventional DMR channel (issue #1036)")
+	}
+	select {
+	case <-huntFailed:
+		t.Fatalf("idle conventional DMR raised cchunt.failed — it must camp, not fail (issue #1036)")
+	default:
+	}
+
+	// 2) On keyup, the daemon must lock and publish a grant with the TG + source.
+	deadline := time.After(10 * time.Second)
+	for {
+		mu.Lock()
+		l, g, tg, src := locked, gotGrant, grantTG, grantSrc
+		mu.Unlock()
+		if l && g {
+			if tg != groupID {
+				t.Errorf("grant GroupID = %#x, want %#x", tg, groupID)
+			}
+			if src != sourceID {
+				t.Errorf("grant SourceID = %#x, want %#x (source RID off the Voice LC Header)", src, sourceID)
+			}
+			break
+		}
+		select {
+		case <-huntFailed:
+			t.Fatalf("conventional DMR raised cchunt.failed (issue #1036)")
+		case <-deadline:
+			t.Fatalf("no lock+grant after keyup within 10s (locked=%v grant=%v)", l, g)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// makeNoiseIQ returns n samples of low-level complex Gaussian noise — a stand-in
+// for an idle conventional channel that carries no decodable traffic.
+func makeNoiseIQ(n int, amp float32, seed int64) []complex64 {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]complex64, n)
+	for i := range out {
+		out[i] = complex(amp*float32(rng.NormFloat64()), amp*float32(rng.NormFloat64()))
+	}
+	return out
+}
+
+// waitForScannerState polls /api/v1/scanner until the named system reports the
+// wanted state, returning true on success and false on timeout. Generalises
+// waitForScannerLock so a test can wait for "camped" as well as "locked".
+func waitForScannerState(t *testing.T, base, system, want string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/api/v1/scanner")
+		if err == nil {
+			var status struct {
+				Systems []struct {
+					Name  string `json:"name"`
+					State string `json:"state"`
+				} `json:"systems"`
+			}
+			err := json.NewDecoder(resp.Body).Decode(&status)
+			resp.Body.Close()
+			if err == nil {
+				for _, s := range status.Systems {
+					if s.Name == system && s.State == want {
+						return true
+					}
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Issue #1036's camp fix (PR #1093) let conventional DMR / IPSC repeaters **camp** on an idle channel instead of spamming `cchunt.failed`, so the decoder is on-channel when someone keys up. The supervisor-level behaviour is unit-tested (`TestSupervisorCampsIdleConventionalDMR`), but the **end-to-end camp → keyup → lock → grant** transition through the production daemon was not — which is exactly the offline regression the issue asked for ("so it can't silently break later"). This adds it.

The reporter (@n1zyy) also attached a real IPSC capture. It's a `f32` GNU Radio/gqrx cfile (25 kS/s) of a **resting/idle burst + analog CWID** — an idle beacon with no voice keyup — and the existing replay harness only read `cs16`, so this also teaches it to read `f32`.

## Changes

- **`cmd/gophertrunk/integration_cc_dmr_tier2_camp_test.go` (new, integration-tagged)** — `TestDaemonDMRTier2CampsThenGrantsOnKeyup`: boots the production daemon on a `dmr-tier2` system, replays **~1.5 s of idle noise** then **Voice LC Header bursts** (colour code 10, matching the reporter's repeater), and asserts:
  1. during the idle prefix the daemon reaches scanner state **`camped`** with **no `cchunt.failed`**, then
  2. on keyup it **locks** and publishes a **grant carrying the decoded talkgroup + source RID**.
  - **Failing-first verified**: removing `ProtocolDMRTier2` from `Protocol.CampsWhenIdle` makes it fail (the system never camps — it would hunt-fail instead).
  - Documents a real gotcha: any non-zero `Scanner.CCHunt` field takes the config out of its "default (enabled)" zero value, so the test must set `CCHunt.Enabled = true` explicitly or the supervisor is silently off (`daemon.go`'s `cchEnabled` gate).
- **`cmd/gophertrunk/dmr_ipsc_replay_test.go`** — the skip-guarded diagnostic harness now reads `f32` captures via `GT_DMR_IQ_FORMAT=cs16|f32`, so the reporter's `f32` cfile is usable (`GT_DMR_IQ_RATE=25000 GT_DMR_IQ_FORMAT=f32`), and its doc notes that an idle-beacon capture decodes 0 grants by design (`GT_DMR_ALLOW_EMPTY=1`).

## Test plan

- [x] `go build ./...`, `go vet -tags integration ./cmd/gophertrunk/` — clean.
- [x] `go test -tags integration ./cmd/gophertrunk/ -run 'TestDaemonDMRTier2CampsThenGrantsOnKeyup|TestDMRIPSCReplay'` — camp test passes (~1.7 s), replay harness skips cleanly with no env set.
- [x] Failing-first confirmed (see above).
- [ ] `make integration` full run — the two touched tests pass; the rest of the suite is unaffected (test-only change).
- [ ] Smoke-tested against real hardware — n/a; this is the offline regression itself. The `f32` support lets a maintainer (or the reporter) replay the attached capture with `GT_DMR_IQ`.

## Breaking changes

None — test-only. No production code changed.

## Docs / CHANGELOG

- n/a (test-only, not user-visible).

## Linked issues

Refs #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FjAksgDRgfQwPp5DKEJJq

---
_Generated by [Claude Code](https://claude.ai/code/session_016FjAksgDRgfQwPp5DKEJJq)_