### PR TITLE
rtlsdr: probe with a no-reset single-pass open (#1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ for tagged releases.
   never require acceptance.
 
 ### Fixed
+- **`sdr list --probe` no longer times out or swaps which RTL-SDR probes on
+  macOS with two dongles** (#1135). Probing opened each dongle through the
+  daemon bring-up envelope, which reset+retries a transient macOS
+  control-transfer abort up to four times. On macOS each device reset is an
+  IOKit re-enumeration, so a transient abort while probing one dongle blew past
+  the 5 s probe deadline *and* perturbed the sibling on the same USB controller
+  — making the successful probe alternate between the two run to run. Probing is
+  now a single best-effort bring-up pass with no device reset (a dongle that
+  doesn't come up just shows empty tuner/gain fields, as before); the daemon
+  open path that actually streams keeps the full reset+retry recovery.
 - **SmartNet/SmartZone call source RID no longer blanks after the first frame**
   (#1143). Motorola SmartNet sends the calling radio ID only on the two-OSW
   grant that starts a call; the single-OSW voice updates that keep it alive omit

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -436,9 +436,12 @@ func listSDRs(args []string) {
 	// --probe: open each device long enough to run the demod + tuner
 	// bring-up so TunerName and the gain ladder can be filled in. Each
 	// device is closed before the next is opened to avoid claiming two
-	// dongles at once. Failures don't abort the loop — the row just
-	// keeps the empty fields from Enumerate and the error is printed
-	// to stderr so the operator can see why probing failed.
+	// dongles at once, and probeDevice uses the driver's no-reset
+	// OpenProbe fast path (sdr.ProbeOpener) so probing one dongle can't
+	// reset-storm a sibling on the same host controller (issue #1135).
+	// Failures don't abort the loop — the row just keeps the empty
+	// fields from Enumerate and the error is printed to stderr so the
+	// operator can see why probing failed.
 	if probe {
 		for i := range infos {
 			d, err := sdr.DriverByName(infos[i].Driver)
@@ -473,14 +476,28 @@ const probeTimeout = 5 * time.Second
 // goroutine finish (and close the handle) on its own — harmless for a
 // short-lived CLI. Driver.Open takes no context, so the bound has to live
 // here at the call site rather than inside the driver.
+//
+// When the driver implements [sdr.ProbeOpener] the goroutine uses its
+// no-reset OpenProbe fast path instead of Open. This keeps probing a
+// read-only, single-pass operation: the daemon Open's reset+retry
+// envelope re-enumerates the device on macOS and would perturb a sibling
+// dongle on the same host controller, which is what made `sdr list
+// --probe` both time out and swap which of two dongles probed run to run
+// (issue #1135). With the no-reset probe each open touches only its own
+// device and finishes well inside the deadline, so the leaked-goroutine
+// safety net above almost never fires.
 func probeDevice(drv sdr.Driver, idx int, timeout time.Duration) (sdr.Info, error) {
 	type result struct {
 		info sdr.Info
 		err  error
 	}
+	open := drv.Open
+	if po, ok := drv.(sdr.ProbeOpener); ok {
+		open = po.OpenProbe
+	}
 	done := make(chan result, 1)
 	go func() {
-		dev, err := drv.Open(idx)
+		dev, err := open(idx)
 		if err != nil {
 			done <- result{err: err}
 			return

--- a/cmd/gophertrunk/sdr_list_test.go
+++ b/cmd/gophertrunk/sdr_list_test.go
@@ -21,6 +21,23 @@ func (d *fakeProbeDriver) Name() string                     { return "fake" }
 func (d *fakeProbeDriver) Enumerate() ([]sdr.Info, error)   { return nil, nil }
 func (d *fakeProbeDriver) Open(idx int) (sdr.Device, error) { return d.open(idx) }
 
+// fakeProbeOpenerDriver additionally implements sdr.ProbeOpener so the
+// probe fast path can be exercised: openProbe is used by probeDevice when
+// present, and open records whether the daemon path was taken instead.
+type fakeProbeOpenerDriver struct {
+	open      func(idx int) (sdr.Device, error)
+	openProbe func(idx int) (sdr.Device, error)
+}
+
+func (d *fakeProbeOpenerDriver) Name() string                   { return "fake-probe" }
+func (d *fakeProbeOpenerDriver) Enumerate() ([]sdr.Info, error) { return nil, nil }
+func (d *fakeProbeOpenerDriver) Open(idx int) (sdr.Device, error) {
+	return d.open(idx)
+}
+func (d *fakeProbeOpenerDriver) OpenProbe(idx int) (sdr.Device, error) {
+	return d.openProbe(idx)
+}
+
 // fakeProbeDevice reports a fixed Info and records that Close was called.
 type fakeProbeDevice struct {
 	info   sdr.Info
@@ -70,6 +87,62 @@ func TestProbeDeviceOpenError(t *testing.T) {
 	}}
 	if _, err := probeDevice(drv, 0, time.Second); !errors.Is(err, wantErr) {
 		t.Fatalf("probeDevice error = %v, want %v", err, wantErr)
+	}
+}
+
+// TestProbeDevicePrefersProbeOpener is the regression for the issue #1135
+// follow-up: `sdr list --probe` must use a driver's no-reset OpenProbe
+// fast path (sdr.ProbeOpener) rather than the daemon Open with its
+// reset+retry envelope, because on macOS that envelope re-enumerates the
+// device and made probing one dongle perturb its sibling (timeouts +
+// which-dongle-probes swapping). probeDevice must call OpenProbe and not
+// Open when the driver implements ProbeOpener.
+func TestProbeDevicePrefersProbeOpener(t *testing.T) {
+	want := sdr.Info{TunerName: "R820T2", Gains: []int{0, 496}}
+	var openCalled, probeCalled bool
+	drv := &fakeProbeOpenerDriver{
+		open: func(int) (sdr.Device, error) {
+			openCalled = true
+			return nil, errors.New("daemon Open must not be used for probing")
+		},
+		openProbe: func(int) (sdr.Device, error) {
+			probeCalled = true
+			return &fakeProbeDevice{info: want}, nil
+		},
+	}
+	got, err := probeDevice(drv, 0, time.Second)
+	if err != nil {
+		t.Fatalf("probeDevice: unexpected error: %v", err)
+	}
+	if openCalled {
+		t.Error("probeDevice called Driver.Open; it must use the no-reset OpenProbe fast path (issue #1135)")
+	}
+	if !probeCalled {
+		t.Error("probeDevice did not call OpenProbe despite the driver implementing sdr.ProbeOpener")
+	}
+	if got.TunerName != want.TunerName {
+		t.Errorf("TunerName = %q, want %q", got.TunerName, want.TunerName)
+	}
+}
+
+// A driver that does NOT implement sdr.ProbeOpener must still be probed
+// via Open — the fast path is an optional extension, not a requirement.
+func TestProbeDeviceFallsBackToOpen(t *testing.T) {
+	want := sdr.Info{TunerName: "FC0013"}
+	var openCalled bool
+	drv := &fakeProbeDriver{open: func(int) (sdr.Device, error) {
+		openCalled = true
+		return &fakeProbeDevice{info: want}, nil
+	}}
+	got, err := probeDevice(drv, 0, time.Second)
+	if err != nil {
+		t.Fatalf("probeDevice: unexpected error: %v", err)
+	}
+	if !openCalled {
+		t.Error("probeDevice did not fall back to Driver.Open for a driver without ProbeOpener")
+	}
+	if got.TunerName != want.TunerName {
+		t.Errorf("TunerName = %q, want %q", got.TunerName, want.TunerName)
 	}
 }
 

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -140,3 +140,19 @@ type Driver interface {
 	Enumerate() ([]Info, error)
 	Open(idx int) (Device, error)
 }
+
+// ProbeOpener is an optional Driver extension offering a fast,
+// read-only device open for `sdr list --probe`. Callers type-assert for
+// it (like FreqRanger / TunerDiagnoser) and fall back to Open when a
+// driver doesn't implement it.
+//
+// OpenProbe must bring the device up cheaply and touch ONLY that device
+// — in particular it must not run any multi-pass device-reset recovery,
+// because on macOS a reset re-enumerates the USB device and probing one
+// dongle would then perturb a sibling on the same host controller (issue
+// #1135). A device that doesn't come up on the first pass simply yields
+// the empty Info fields from Enumerate; the daemon Open path owns the
+// reset+retry recovery that actually getting a dongle streaming needs.
+type ProbeOpener interface {
+	OpenProbe(idx int) (Device, error)
+}

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -116,6 +116,34 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 //
 // Failure at any step closes the transport and returns the error.
 func (d *Driver) Open(idx int) (sdr.Device, error) {
+	return d.openIndex(idx, maxOpenAttempts)
+}
+
+// OpenProbe is the [sdr.ProbeOpener] fast path used by `sdr list
+// --probe`: it brings the device up in a SINGLE pass with NO
+// device-reset recovery envelope, then reads its tuner/gains and lets
+// the caller close it.
+//
+// Probing is a best-effort, read-only listing — a device that doesn't
+// come up on the first pass simply keeps the empty Info fields from
+// Enumerate. It must NOT run the daemon Open's reset+retry envelope,
+// because on macOS every transport.Reset() is an IOKit ResetDevice that
+// re-enumerates the device: with two dongles on one host controller, a
+// transient bring-up abort on one turned into up to four re-enumerations
+// (issue #1135) that both blew past the 5 s probe deadline AND perturbed
+// the sibling dongle, so which of the two probed successfully swapped
+// run to run. A single bring-up pass is fast and touches only the device
+// being probed, so probing one dongle can never reset-storm another. The
+// daemon Open path (the one that must actually get a dongle streaming)
+// keeps the full envelope.
+func (d *Driver) OpenProbe(idx int) (sdr.Device, error) {
+	return d.openIndex(idx, probeOpenAttempts)
+}
+
+// openIndex resolves the cached descriptor for idx, opens the USB
+// transport, and runs bring-up bounded to maxAttempts passes. Shared by
+// Open (maxOpenAttempts) and OpenProbe (probeOpenAttempts).
+func (d *Driver) openIndex(idx, maxAttempts int) (sdr.Device, error) {
 	d.mu.Lock()
 	if idx < 0 || idx >= len(d.detectCache) {
 		d.mu.Unlock()
@@ -130,7 +158,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	}
 	transport = usb.MaybeWrapDebug(transport, desc)
 
-	dev, err := openDevice(transport, desc, idx)
+	dev, err := openDeviceAttempts(transport, desc, idx, maxAttempts)
 	if err != nil {
 		_ = transport.Close()
 		return nil, err
@@ -138,11 +166,42 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	return dev, nil
 }
 
-// openDevice runs the full bring-up sequence: claim interface, warm up
-// the USB endpoint, init demod, detect tuner, run any tuner-specific
-// demod prep, init the tuner, set IF freq. Factored out of Open so
-// tests can drive it directly with a mock transport without going
-// through the enumerator.
+// maxOpenAttempts is the bring-up attempt budget for a daemon Open: one
+// initial pass plus up to four reset+retry passes for the cold-boot
+// stall classes isBringupResetable covers.
+const maxOpenAttempts = 5
+
+// probeOpenAttempts is the bring-up budget for the `sdr list --probe`
+// fast path: a SINGLE pass, no reset. See [Driver.OpenProbe] and issue
+// #1135 for why probing must never run the reset envelope.
+const probeOpenAttempts = 1
+
+// bringupBackoffs[attempt] is the sleep that runs BEFORE the
+// (attempt+1)th bring-up pass — exponential with a soft cap at 1200ms so
+// a pathologically wedged dongle still surfaces the error in ~3s rather
+// than dragging out into a 10s tail. Indexed 0..maxOpenAttempts-2; the
+// final attempt's failure surfaces immediately with no further sleep
+// (we're out of retries). probeOpenAttempts never indexes it.
+var bringupBackoffs = [maxOpenAttempts - 1]time.Duration{
+	200 * time.Millisecond,
+	400 * time.Millisecond,
+	800 * time.Millisecond,
+	1200 * time.Millisecond,
+}
+
+// openDevice runs the full daemon bring-up (maxOpenAttempts). It is a
+// thin wrapper over [openDeviceAttempts] retained so tests can drive the
+// standard reset+retry envelope directly with a mock transport without
+// going through the enumerator.
+func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
+	return openDeviceAttempts(transport, desc, idx, maxOpenAttempts)
+}
+
+// openDeviceAttempts runs the full bring-up sequence: claim interface,
+// warm up the USB endpoint, init demod, detect tuner, run any
+// tuner-specific demod prep, init the tuner, set IF freq. Factored out
+// of Open so tests can drive it directly with a mock transport without
+// going through the enumerator.
 //
 // Each step manages its own I²C repeater state. Detect wraps the
 // probe sweep in a single on/off pair (off-on-return); PrepareDemod's
@@ -181,24 +240,18 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 //
 // Non-resetable errors (validation failures, ErrClosed) return
 // immediately — reset is the wrong hammer for them.
-func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
+//
+// The attempt budget is parameterised: a daemon Open passes
+// maxOpenAttempts (the full reset+retry envelope described above); the
+// read-only `sdr list --probe` fast path passes probeOpenAttempts (a
+// single pass, NO reset) so probing one dongle can never reset-storm a
+// sibling on the same host controller — see [Driver.OpenProbe] and
+// issue #1135.
+func openDeviceAttempts(transport usb.Transport, desc usb.Descriptor, idx, maxAttempts int) (*Device, error) {
 	if err := transport.ClaimInterface(0); err != nil {
 		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w%s", err, claimBusyHint(err))
 	}
 
-	const maxAttempts = 5
-	// backoff[attempt] is the sleep that runs BEFORE the (attempt+1)th
-	// bring-up pass — exponential with a soft cap at 1200ms so a
-	// pathologically wedged dongle still surfaces the error in ~3s
-	// rather than dragging out into a 10s tail. Indexed 0..maxAttempts-2;
-	// the last attempt's failure surfaces immediately with no further
-	// sleep (we're out of retries).
-	backoffs := [maxAttempts - 1]time.Duration{
-		200 * time.Millisecond,
-		400 * time.Millisecond,
-		800 * time.Millisecond,
-		1200 * time.Millisecond,
-	}
 	var (
 		demod *rtl2832u.Demod
 		tuner tuners.Tuner
@@ -216,7 +269,7 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		if resetErr := transport.Reset(); resetErr != nil {
 			return nil, fmt.Errorf("rtlsdr: bring-up hit %w; reset failed: %w", err, resetErr)
 		}
-		time.Sleep(backoffs[attempt])
+		time.Sleep(bringupBackoffs[attempt])
 		_ = transport.ReleaseInterface(0)
 		if claimErr := transport.ClaimInterface(0); claimErr != nil {
 			return nil, fmt.Errorf("rtlsdr: re-claim interface 0 after reset: %w", claimErr)

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -666,6 +666,42 @@ func TestOpenDevice_BringupTransferAbortedFiveTimes_ReturnsHintError(t *testing.
 	}
 }
 
+// Regression for the issue #1135 follow-up ("still fails on v1.1.0:
+// probe rtlsdr[N] timed out after 5s, and which dongle probes swaps run
+// to run"): the `sdr list --probe` fast path runs a SINGLE bring-up pass
+// and must NEVER reset the device, even for an error class the daemon
+// Open reset+retries (here the macOS ErrTransferAborted from #1137). On
+// the reporter's two-dongle Mac the reset+retry envelope turned a
+// transient bring-up abort during probe into up to four IOKit
+// ResetDevice re-enumerations, which both blew past the 5 s probe
+// deadline and — because a reset re-enumerates the shared bus —
+// perturbed the sibling dongle so the successful probe alternated
+// between the two. openDeviceAttempts(..., probeOpenAttempts) must
+// surface the abort immediately with ZERO resets, so probing never
+// reset-storms. The daemon budget (maxOpenAttempts) still resets, pinned
+// by TestOpenDevice_BringupTransferAborted_TriggersFullReset above.
+func TestOpenDeviceAttempts_ProbeBudgetNeverResets(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),                    // warmup OK (swallowed)
+		warmupUSBSysctlExchange(usb.ErrTransferAborted), // InitBaseband step 0 aborts
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-probe-noreset"}
+	_, err := openDeviceAttempts(m, desc, 0, probeOpenAttempts)
+	if err == nil {
+		t.Fatal("openDeviceAttempts(probe) succeeded; expected the aborted bring-up to fail")
+	}
+	if !errors.Is(err, usb.ErrTransferAborted) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrTransferAborted) (cause stays inspectable)", err)
+	}
+	if m.ResetCalls != 0 {
+		t.Errorf("ResetCalls = %d, want 0 (the probe fast path must never reset a device — issue #1135)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 1 {
+		t.Errorf("ClaimCalls = %d, want 1 (single claim, no post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
 // Regression: when ErrTimeout recurs on every bring-up pass (warmup
 // swallowed, then InitBaseband step 0 times out), the surfaced error
 // must carry the Windows-aware hint that points at the WinUSB / Zadig


### PR DESCRIPTION
## Summary

On macOS with two RTL-SDR dongles, `sdr list --probe` intermittently prints `probe rtlsdr[N]: timed out after 5s` and the successful probe alternates between the two dongles run to run (reported against v1.1.0 on #1135, after the #1137 abort-retry fix). Probing opened each dongle through the **daemon** bring-up envelope, which reset+retries a transient macOS control-transfer abort (the #1137 `ErrTransferAborted` class) up to four times. On macOS every `transport.Reset()` is an IOKit `ResetDevice` that **re-enumerates the device**, so a transient abort while probing one dongle both blew past the fixed 5 s probe deadline *and* perturbed the sibling dongle on the same host controller — hence the timeouts and the which-dongle-probes swapping.

Probing is a best-effort, read-only listing (a dongle that doesn't come up just keeps the empty tuner/gain fields from `Enumerate`), so it has no business running the daemon's cold-boot reset recovery. This makes probe a single bring-up pass with no reset; the daemon `Open` path that must actually get a dongle streaming keeps the full reset+retry envelope unchanged.

## Changes

- `internal/sdr/device.go` — add optional `sdr.ProbeOpener` extension (`OpenProbe(idx)`), following the existing `FreqRanger` / `TunerDiagnoser` optional-interface pattern.
- `internal/sdr/rtlsdr/purego/driver.go` — parameterise the bring-up attempt budget: refactor `openDevice` → `openDeviceAttempts(..., maxAttempts)`; `Open` uses `maxOpenAttempts` (5, unchanged), new `OpenProbe` uses `probeOpenAttempts` (1, no reset). Both share a new `openIndex`.
- `cmd/gophertrunk/main.go` — `probeDevice` prefers `OpenProbe` when the driver implements `ProbeOpener`, falling back to `Open`.
- Tests + CHANGELOG.

## Test plan

- [x] `make vet test` is green locally (full `-race ./...` suite, exit 0)
- [ ] `make integration` — n/a (no daemon/DSP/replay path touched)
- [x] Added tests where appropriate:
  - `TestOpenDeviceAttempts_ProbeBudgetNeverResets` — probe budget surfaces a macOS abort with **zero** resets (fails with `ResetCalls = 1` under the old envelope).
  - `TestProbeDevicePrefersProbeOpener` / `TestProbeDeviceFallsBackToOpen` — `probeDevice` uses `OpenProbe` when available, else `Open` (the "prefers" case fails against the pre-fix `probeDevice`).
  - Daemon-open reset behaviour stays pinned by the existing `TestOpenDevice_BringupTransferAborted*` tests.
- [ ] Smoke-tested against real hardware — **not possible in this environment** (no macOS + dual RTL-SDR rig). This is the outstanding verification gate; see below.

## Breaking changes

None. `sdr.ProbeOpener` is an optional, additive interface; drivers that don't implement it are probed via `Open` exactly as before. The daemon open path is byte-for-byte unchanged.

## Docs / CHANGELOG

- [x] Added an `## [Unreleased]` → Fixed bullet to `CHANGELOG.md`
- [ ] No operator-facing docs change needed

## Linked issues

Refs #1135 — kept as `Refs` (not `Closes`) pending on-hardware confirmation on the reporter's two-dongle Mac, per the verify-before-close policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GbXeAjTr6xSFTRtELDmYS

---
_Generated by [Claude Code](https://claude.ai/code/session_014GbXeAjTr6xSFTRtELDmYS)_