### PR TITLE
fleetsync: clean-room FleetSync / FleetSync II protocol decoder (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **FleetSync / FleetSync II protocol decoder (clean-room core)** (#437). A new
+  `internal/radio/fleetsync` package decodes Kenwood FleetSync in-band ANI: the
+  16-bit sync hunt, the FleetSync I block check (CRC), the FleetSync II
+  single-error-correcting ECC, and the Fleet/Unit field extraction, plus a
+  bus-free bit framer. Ported clean-room from the multimon-ng `fsync` framing
+  (cross-checked against a working reference contributed on the issue) and
+  pinned with reference-literal + single-bit-correction tests. This is the
+  protocol core only; wiring it to a live 1200-baud FFSK front end and the
+  events/storage/REST/web surface is staged pending an on-air A/B against a real
+  Kenwood capture, so no operator-facing decode ships yet.
 - **Terms of Service, acknowledged once at install/first run**
   (`TERMS_OF_SERVICE.md`). A short, plain-language ToS in line with other
   open SDR software: lawful monitoring is the operator's responsibility, no

--- a/internal/radio/fleetsync/fleetsync.go
+++ b/internal/radio/fleetsync/fleetsync.go
@@ -1,0 +1,272 @@
+// Package fleetsync decodes Kenwood FleetSync (and FleetSync II)
+// in-band ANI signaling.
+//
+// FleetSync is the analog in-band data burst Kenwood commercial two-way
+// radios key at the start of a PTT transmission. It carries the
+// transmitting radio's identity — a Fleet number and a Unit ID (the ANI,
+// automatic number identification) — plus status and messaging, on
+// otherwise-analog conventional NBFM voice channels. Scanner operators
+// use it to see *which* radio is transmitting on a system that is
+// otherwise just FM voice, the same role MDC1200 plays for Motorola.
+//
+// On the air it is a 1200-baud FFSK burst (CCIR tones: mark = 1200 Hz,
+// space = 1800 Hz) carried inside the narrowband-FM voice channel — the
+// same modulation class GopherTrunk already demodulates for MDC1200 and
+// MPT 1327, so a DSP front end can reuse internal/dsp/demod.FFSK. This
+// package owns the protocol layer only: a stream of sliced FSK bits is
+// framed by [Framer] (sync hunt → capture), and each captured frame is
+// handed to [DecodeFrame] here, which validates it and returns a typed
+// [Message] carrying the Fleet/Unit ANI.
+//
+// Frame layout, after a ≥24-bit alternating preamble and the 16-bit sync
+// word 0xA23E (most-significant bit first, read straight off the FSK
+// slicer): the payload begins 4 bits into the captured stream and is two
+// 32-bit words —
+//
+//	word1[31:0], word2[31:16] : data (fleet / unit / status)
+//	word2[15:0]               : the 16-bit block check (CRC)
+//
+// FleetSync I validates word2's low 16 bits against [fsyncCRC]. FleetSync
+// II adds forward error correction: four consecutive 64-bit blocks, each
+// 16-bit half-word carrying a single-error-correcting code ([fs2ECCRepair]);
+// the corrected nibbles reassemble word1/word2, which are then CRC-checked
+// the same way. The ANI is read identically from the recovered words.
+//
+// The Fleet/Unit field extraction, the CRC (polynomial 0x6815, parity
+// bit, 0x0002 final term) and the FS-II parity-check / repair tables are
+// the FleetSync framing facts as implemented by the multimon-ng `fsync`
+// decoder, which is proven on air; this is a clean-room Go port of that
+// framing, cross-checked against a working Python reference contributed
+// on issue #437. No third-party source is incorporated.
+//
+// Verification status: the protocol constants below are pinned to the
+// multimon-ng reference and exercised by reference-literal + single-bit
+// ECC-correction tests, but this decoder has NOT yet been confirmed
+// against a real Kenwood off-air capture. Wiring it to a live DSP front
+// end, the events bus, storage and the REST/web surface is deliberately
+// staged for after that on-air A/B (issue #437).
+package fleetsync
+
+import (
+	"fmt"
+	"math/bits"
+)
+
+const (
+	// SyncWord is the 16-bit FleetSync frame synchronization word, most-
+	// significant bit first, read directly off the FSK slicer.
+	SyncWord uint16 = 0xA23E
+
+	// SyncBits is the length of SyncWord in bits.
+	SyncBits = 16
+
+	// FrameBits is the number of payload bits captured after the sync
+	// word. This is the FleetSync II maximum (a 4-bit lead-in plus four
+	// 64-bit ECC blocks); a FleetSync I frame uses only the first
+	// fs1FrameBits of them.
+	FrameBits = frameOffset + 4*64 // 260
+
+	// frameOffset is the number of bits between the end of the sync word
+	// and the first payload word (empirically fixed by the reference).
+	frameOffset = 4
+
+	// fs1FrameBits is the payload length a FleetSync I frame needs: the
+	// lead-in plus the two 32-bit words.
+	fs1FrameBits = frameOffset + 64 // 68
+)
+
+// fsyncPoly is the FleetSync block-check polynomial used by the bit-
+// serial CRC (multimon-ng fsync_common.c).
+const fsyncPoly uint16 = 0x6815
+
+// fs2ParityCheck are the eight parity-check masks of the FleetSync II
+// single-error-correcting code; fs2RepairPos maps a non-zero syndrome to
+// the bit to flip. Both are transcribed verbatim from the multimon-ng
+// fsync2 tables and pinned by TestFS2ECCRepairCorrectsEverySingleBit.
+var (
+	fs2ParityCheck = [8]uint16{0x4045, 0x2067, 0x1076, 0x083b, 0x0458, 0x022c, 0x0116, 0x008b}
+	fs2RepairPos   = [15]uint16{
+		0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,
+		0x17, 0x2e, 0x5c, 0xb8, 0x67, 0xce, 0x8b,
+	}
+)
+
+// Message is one decoded FleetSync ANI burst.
+type Message struct {
+	Fleet  int    // transmitting radio's Fleet number
+	Unit   int    // transmitting radio's Unit ID
+	IsFS2  bool   // decoded via the FleetSync II ECC path
+	CRCOK  bool   // the block check validated
+	RawHex string // hex of the two recovered 32-bit words
+	Body   string // one-line summary for logs / panel
+}
+
+// DecodeFrame decodes the raw FSK bits captured immediately after the
+// 16-bit sync word (one byte per bit; only bit 0 of each is read). It
+// tries FleetSync I first, then falls back to the FleetSync II ECC path
+// when enough bits are present. The bool reports whether the block check
+// validated; a failure still returns the best-effort FleetSync I words
+// with CRCOK=false so a caller can surface marginal bursts.
+func DecodeFrame(raw []byte) (Message, bool) {
+	if len(raw) < fs1FrameBits {
+		return Message{Body: "incomplete"}, false
+	}
+	word1 := bitsToUint32(raw[frameOffset : frameOffset+32])
+	word2 := bitsToUint32(raw[frameOffset+32 : frameOffset+64])
+
+	if fsyncCRC(word1, word2) == uint16(word2&0xFFFF) {
+		return newMessage(word1, word2, false, true), true
+	}
+
+	if len(raw) >= FrameBits {
+		if w1, w2, ok := decodeFS2(raw); ok {
+			return newMessage(w1, w2, true, true), true
+		}
+	}
+
+	// Best-effort: return the FleetSync I words uncorrected.
+	return newMessage(word1, word2, false, false), false
+}
+
+// decodeFS2 runs the FleetSync II path: four 64-bit blocks, each 16-bit
+// half-word ECC-repaired, the corrected high-nibbles reassembled into the
+// two data words and CRC-checked. Returns (word1, word2, true) on a clean
+// FS-II decode, or (_, _, false) if any half-word is uncorrectable or the
+// reassembled CRC fails.
+func decodeFS2(raw []byte) (uint32, uint32, bool) {
+	var nibblesW1, nibblesW2 []uint32
+	for blk := 0; blk < 4; blk++ {
+		boff := frameOffset + blk*64
+		bw1 := bitsToUint32(raw[boff : boff+32])
+		bw2 := bitsToUint32(raw[boff+32 : boff+64])
+
+		ec1, ok1 := fs2ECCRepair(uint16(bw1 & 0xFFFF))
+		ec2, ok2 := fs2ECCRepair(uint16((bw1 >> 16) & 0xFFFF))
+		ec3, ok3 := fs2ECCRepair(uint16(bw2 & 0xFFFF))
+		ec4, ok4 := fs2ECCRepair(uint16((bw2 >> 16) & 0xFFFF))
+		if !(ok1 && ok2 && ok3 && ok4) {
+			return 0, 0, false
+		}
+
+		nibs := [4]uint32{
+			uint32((ec1 >> 8) & 0xF),
+			uint32((ec2 >> 8) & 0xF),
+			uint32((ec3 >> 8) & 0xF),
+			uint32((ec4 >> 8) & 0xF),
+		}
+		if blk < 2 {
+			nibblesW1 = append(nibblesW1, nibs[:]...)
+		} else {
+			nibblesW2 = append(nibblesW2, nibs[:]...)
+		}
+	}
+
+	var w1, w2 uint32
+	for _, n := range nibblesW1 {
+		w1 = (w1 << 4) | n
+	}
+	for _, n := range nibblesW2 {
+		w2 = (w2 << 4) | n
+	}
+	if fsyncCRC(w1, w2) != uint16(w2&0xFFFF) {
+		return 0, 0, false
+	}
+	return w1, w2, true
+}
+
+// newMessage extracts the Fleet/Unit ANI from the two recovered data
+// words. The field layout — fleet from word1 byte 2 (+99), unit from
+// word1 byte 3 and the high nibble of word2 byte 0 (+999) — matches the
+// multimon-ng fsync_decode dispatch.
+func newMessage(word1, word2 uint32, isFS2, crcOK bool) Message {
+	b2 := int((word1 >> 8) & 0xFF)  // fleet source byte
+	b3 := int(word1 & 0xFF)         // unit high byte
+	b4 := int((word2 >> 24) & 0xFF) // unit low nibble carrier
+
+	m := Message{
+		Fleet:  b2 + 99,
+		Unit:   (b3 << 4) + ((b4 >> 4) & 0x0F) + 999,
+		IsFS2:  isFS2,
+		CRCOK:  crcOK,
+		RawHex: fmt.Sprintf("%08X%08X", word1, word2),
+	}
+	m.Body = m.summary()
+	return m
+}
+
+// summary renders the one-line Body string used by logs and the panel.
+func (m Message) summary() string {
+	label := "FleetSync"
+	if m.IsFS2 {
+		label = "FleetSync II"
+	}
+	s := fmt.Sprintf("%s ANI: fleet=%d unit=%d", label, m.Fleet, m.Unit)
+	if !m.CRCOK {
+		s += " (CRC?)"
+	}
+	return s
+}
+
+// fsyncCRC computes the FleetSync block check over the two 32-bit words.
+// The first 48 bits (word1, then word2's high 16) clock a bit-serial LFSR
+// with polynomial 0x6815; word2's low 15 bits (the received check field)
+// contribute only to a running parity bit. The final value is
+// (lfsr ^ 0x0002 + parity) & 0xFFFF, compared by the caller against
+// word2's low 16 bits. Ported bit-for-bit from multimon-ng fsync_common.c.
+func fsyncCRC(word1, word2 uint32) uint16 {
+	var paritybit, crcsr uint16
+	for bit := 0; bit < 48; bit++ {
+		var cur uint16
+		if bit < 32 {
+			cur = uint16((word1 >> (31 - bit)) & 1)
+		} else {
+			cur = uint16((word2 >> (31 - (bit - 32))) & 1)
+		}
+		if cur != 0 {
+			paritybit ^= 1
+		}
+		if (cur ^ ((crcsr >> 15) & 1)) != 0 {
+			crcsr ^= fsyncPoly
+		}
+		crcsr <<= 1 // uint16 truncates to 16 bits, matching (<<1)&0xFFFF
+	}
+	for bit := 48; bit < 63; bit++ {
+		if uint16((word2>>(31-(bit-32)))&1) != 0 {
+			paritybit ^= 1
+		}
+	}
+	crcsr ^= 0x0002
+	return uint16((uint32(crcsr) + uint32(paritybit)) & 0xFFFF)
+}
+
+// fs2ECCRepair corrects a single bit error in one 15-bit FleetSync II
+// code word. It returns (val, true) when the syndrome is zero (no error),
+// (corrected, true) when a single-bit syndrome is found, and (0, false)
+// when the error is uncorrectable. Ported from multimon-ng fsync2.
+func fs2ECCRepair(val uint16) (uint16, bool) {
+	var syndrome uint16
+	for i := 0; i < 8; i++ {
+		if bits.OnesCount16(fs2ParityCheck[i]&val)&1 == 1 {
+			syndrome |= 1 << uint(i)
+		}
+	}
+	if syndrome == 0 {
+		return val, true
+	}
+	for i := 0; i < 15; i++ {
+		if syndrome == fs2RepairPos[i] {
+			return val ^ (1 << uint(14-i)), true
+		}
+	}
+	return 0, false
+}
+
+// bitsToUint32 packs up to 32 one-bit-per-byte values MSB-first into a
+// uint32. Only bit 0 of each input byte is read.
+func bitsToUint32(b []byte) uint32 {
+	var v uint32
+	for _, x := range b {
+		v = (v << 1) | uint32(x&1)
+	}
+	return v
+}

--- a/internal/radio/fleetsync/fleetsync_test.go
+++ b/internal/radio/fleetsync/fleetsync_test.go
@@ -1,0 +1,257 @@
+package fleetsync
+
+import (
+	"math/bits"
+	"testing"
+)
+
+// ---- FleetSync II ECC ------------------------------------------------
+
+// TestFS2ECCRepairPassesValidCodeword: a code word whose syndrome is zero
+// is returned unchanged. The all-zero word is the trivial valid codeword.
+func TestFS2ECCRepairPassesValidCodeword(t *testing.T) {
+	got, ok := fs2ECCRepair(0x0000)
+	if !ok || got != 0x0000 {
+		t.Fatalf("fs2ECCRepair(0) = (0x%04x, %v), want (0x0000, true)", got, ok)
+	}
+}
+
+// TestFS2ECCRepairCorrectsEverySingleBit is the reference-literal check of
+// the parity-check / repair tables: for a valid codeword, flipping ANY
+// single one of its 15 code bits must be corrected back to the original.
+// Applied to the all-zero codeword, every single-bit error 1<<i must
+// repair to 0. If either table were mistranscribed this fails, so it pins
+// the FleetSync II ECC against the multimon-ng reference.
+func TestFS2ECCRepairCorrectsEverySingleBit(t *testing.T) {
+	for i := 0; i < 15; i++ {
+		corrupted := uint16(1) << uint(i)
+		got, ok := fs2ECCRepair(corrupted)
+		if !ok {
+			t.Errorf("bit %d: fs2ECCRepair(0x%04x) reported uncorrectable; a single-bit error must be correctable", i, corrupted)
+			continue
+		}
+		if got != 0 {
+			t.Errorf("bit %d: fs2ECCRepair(0x%04x) = 0x%04x, want 0x0000 (restore the valid codeword)", i, corrupted, got)
+		}
+	}
+}
+
+// TestFS2ECCRepairRejectsUncorrectable: a two-bit error that lands on no
+// single-bit syndrome must be rejected rather than silently "corrected"
+// to a wrong codeword.
+func TestFS2ECCRepairRejectsUncorrectable(t *testing.T) {
+	// Two bits flipped in the zero codeword. Its syndrome is the XOR of
+	// the two single-bit syndromes; find a pair whose combined syndrome is
+	// not itself a single-bit repair position.
+	found := false
+	for a := 0; a < 15 && !found; a++ {
+		for b := a + 1; b < 15; b++ {
+			corrupted := uint16(1)<<uint(a) | uint16(1)<<uint(b)
+			if _, ok := fs2ECCRepair(corrupted); !ok {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected at least one two-bit pattern to be flagged uncorrectable")
+	}
+}
+
+// ---- FleetSync I CRC + ANI extraction --------------------------------
+
+// buildFS1Frame lays out a valid FleetSync I capture: a 4-bit lead-in,
+// word1, then word2 whose low 16 bits are the block check computed over
+// word1 and word2's high 16 bits. The check is found by search (it is a
+// one-bit fixed point because word2's low bits feed only the parity bit),
+// which keeps the builder honest: it does not assume the CRC value, it
+// solves fsyncCRC(word1, word2) == word2&0xFFFF the way a real transmitter
+// must. Returns the 260-bit capture and the assembled word2.
+func buildFS1Frame(t *testing.T, word1 uint32, dataHi16 uint16) ([]byte, uint32) {
+	t.Helper()
+	for crc := 0; crc <= 0xFFFF; crc++ {
+		word2 := uint32(dataHi16)<<16 | uint32(crc)
+		if fsyncCRC(word1, word2) == uint16(crc) {
+			return layoutFrame(word1, word2), word2
+		}
+	}
+	t.Fatalf("no valid CRC found for word1=0x%08x dataHi16=0x%04x", word1, dataHi16)
+	return nil, 0
+}
+
+// layoutFrame renders a 260-bit capture: 4 zero lead-in bits, then word1
+// and word2 MSB-first, then zero padding to FrameBits.
+func layoutFrame(word1, word2 uint32) []byte {
+	raw := make([]byte, FrameBits)
+	appendUint32(raw[frameOffset:], word1)
+	appendUint32(raw[frameOffset+32:], word2)
+	return raw
+}
+
+// appendUint32 writes v MSB-first as one byte per bit into dst[:32].
+func appendUint32(dst []byte, v uint32) {
+	for i := 0; i < 32; i++ {
+		dst[i] = byte((v >> (31 - i)) & 1)
+	}
+}
+
+func TestDecodeFrameFS1ExtractsANI(t *testing.T) {
+	// fleet = byte2 + 99; unit = (byte3<<4) + (byte4_hi_nibble) + 999.
+	// byte2 = 51 → fleet 150; byte3 = 0x7D, byte4 hi nibble = 0x2
+	//   → unit = (0x7D<<4) + 0x2 + 999 = 2000 + 2 + 999 = 3001.
+	const (
+		byte0, byte1 = 0x00, 0x00
+		byte2        = 51   // fleet 150
+		byte3        = 0x7D // unit high byte
+		byte4        = 0x2F // high nibble 0x2 is the unit low nibble; low nibble ignored
+		byte5        = 0x00
+	)
+	word1 := uint32(byte0)<<24 | uint32(byte1)<<16 | uint32(byte2)<<8 | uint32(byte3)
+	dataHi16 := uint16(byte4)<<8 | uint16(byte5)
+
+	raw, _ := buildFS1Frame(t, word1, dataHi16)
+	msg, ok := DecodeFrame(raw)
+	if !ok {
+		t.Fatalf("DecodeFrame reported CRC failure on a frame built with a valid check")
+	}
+	if msg.CRCOK != true || msg.IsFS2 {
+		t.Errorf("msg = %+v, want CRCOK=true IsFS2=false", msg)
+	}
+	if msg.Fleet != 150 {
+		t.Errorf("Fleet = %d, want 150", msg.Fleet)
+	}
+	if msg.Unit != 3001 {
+		t.Errorf("Unit = %d, want 3001", msg.Unit)
+	}
+}
+
+// TestDecodeFrameFS1RejectsCorruptedCheck: flipping a payload bit must
+// break the block check so DecodeFrame reports CRCOK=false rather than a
+// bogus ANI passing as valid.
+func TestDecodeFrameFS1RejectsCorruptedCheck(t *testing.T) {
+	word1 := uint32(0x0033_7D00)
+	raw, _ := buildFS1Frame(t, word1, 0x2F00)
+
+	// Flip a bit inside word1 (payload) — the check no longer matches.
+	raw[frameOffset+10] ^= 1
+	if _, ok := DecodeFrame(raw); ok {
+		t.Error("DecodeFrame accepted a frame with a corrupted payload bit; the CRC must reject it")
+	}
+}
+
+// TestDecodeFrameShortIsIncomplete: a capture shorter than a FleetSync I
+// frame is reported incomplete, not decoded from garbage.
+func TestDecodeFrameShortIsIncomplete(t *testing.T) {
+	if _, ok := DecodeFrame(make([]byte, fs1FrameBits-1)); ok {
+		t.Error("DecodeFrame accepted a too-short capture")
+	}
+}
+
+// ---- FleetSync II round-trip -----------------------------------------
+
+// fs2EncodeHalf finds a valid 15-bit FleetSync II code word (syndrome 0)
+// whose data nibble (bits 11..8) equals nibble. Every nibble has several
+// codewords; returns the first.
+func fs2EncodeHalf(t *testing.T, nibble uint32) uint16 {
+	t.Helper()
+	for v := uint16(0); v < 0x8000; v++ {
+		if (uint32(v)>>8)&0xF != nibble {
+			continue
+		}
+		if syndromeZero(v) {
+			return v
+		}
+	}
+	t.Fatalf("no valid FS2 codeword carries nibble 0x%x", nibble)
+	return 0
+}
+
+func syndromeZero(v uint16) bool {
+	for i := 0; i < 8; i++ {
+		if bits.OnesCount16(fs2ParityCheck[i]&v)&1 == 1 {
+			return false
+		}
+	}
+	return true
+}
+
+// buildFS2Frame lays out a FleetSync II capture that ECC-decodes to the
+// given word1/word2. Each of the two words contributes 8 high-nibbles
+// spread across four 64-bit blocks; each nibble becomes a valid 15-bit
+// code word in one 16-bit half-word.
+func buildFS2Frame(t *testing.T, word1, word2 uint32) []byte {
+	t.Helper()
+	// nibbles(word) yields the 8 high-nibbles MSB-first.
+	nibbles := func(w uint32) [8]uint32 {
+		var n [8]uint32
+		for i := 0; i < 8; i++ {
+			n[i] = (w >> uint(28-4*i)) & 0xF
+		}
+		return n
+	}
+	n1 := nibbles(word1)
+	n2 := nibbles(word2)
+
+	raw := make([]byte, FrameBits)
+	// Blocks 0,1 carry word1's 8 nibbles; blocks 2,3 carry word2's.
+	// Per block, four half-words in the order (bw1 lo, bw1 hi, bw2 lo, bw2 hi)
+	// — matching decodeFS2's extraction order.
+	writeBlock := func(blk int, nibs [4]uint32) {
+		boff := frameOffset + blk*64
+		h0 := uint32(fs2EncodeHalf(t, nibs[0]))
+		h1 := uint32(fs2EncodeHalf(t, nibs[1]))
+		h2 := uint32(fs2EncodeHalf(t, nibs[2]))
+		h3 := uint32(fs2EncodeHalf(t, nibs[3]))
+		bw1 := (h1 << 16) | h0
+		bw2 := (h3 << 16) | h2
+		appendUint32(raw[boff:], bw1)
+		appendUint32(raw[boff+32:], bw2)
+	}
+	writeBlock(0, [4]uint32{n1[0], n1[1], n1[2], n1[3]})
+	writeBlock(1, [4]uint32{n1[4], n1[5], n1[6], n1[7]})
+	writeBlock(2, [4]uint32{n2[0], n2[1], n2[2], n2[3]})
+	writeBlock(3, [4]uint32{n2[4], n2[5], n2[6], n2[7]})
+	return raw
+}
+
+func TestDecodeFrameFS2RoundTrip(t *testing.T) {
+	// A CRC-valid word pair, then re-encoded through the FS2 ECC blocks.
+	word1 := uint32(0x0000_337D) // fleet 150 (byte2=0x33=51), unit high 0x7D
+	var word2 uint32
+	{
+		_, w2 := buildFS1Frame(t, word1, 0x2F00) // solves the CRC for us
+		word2 = w2
+	}
+	raw := buildFS2Frame(t, word1, word2)
+
+	msg, ok := DecodeFrame(raw)
+	if !ok {
+		t.Fatalf("DecodeFrame(FS2) reported failure on a valid FleetSync II frame")
+	}
+	if !msg.IsFS2 {
+		t.Errorf("IsFS2 = false, want true (FS2 path must be taken when FS1 CRC fails)")
+	}
+	if msg.Fleet != 150 || msg.Unit != 3001 {
+		t.Errorf("ANI = fleet %d unit %d, want fleet 150 unit 3001", msg.Fleet, msg.Unit)
+	}
+}
+
+// TestDecodeFrameFS2CorrectsSingleBit: a single sliced-bit error in one
+// FS2 half-word must be corrected by the ECC and still yield the right ANI
+// — the whole reason FleetSync II carries the code.
+func TestDecodeFrameFS2CorrectsSingleBit(t *testing.T) {
+	word1 := uint32(0x0000_337D)
+	_, word2 := buildFS1Frame(t, word1, 0x2F00)
+	raw := buildFS2Frame(t, word1, word2)
+
+	// Corrupt one bit inside block 0's first half-word (raw[frameOffset..]).
+	raw[frameOffset+20] ^= 1
+
+	msg, ok := DecodeFrame(raw)
+	if !ok {
+		t.Fatalf("DecodeFrame(FS2) failed to correct a single-bit error")
+	}
+	if !msg.IsFS2 || msg.Fleet != 150 || msg.Unit != 3001 {
+		t.Errorf("after single-bit correction: msg = %+v, want FS2 fleet 150 unit 3001", msg)
+	}
+}

--- a/internal/radio/fleetsync/framer.go
+++ b/internal/radio/fleetsync/framer.go
@@ -1,0 +1,165 @@
+package fleetsync
+
+import "math/bits"
+
+// Framer turns a demodulated FleetSync bit stream into decoded [Message]
+// bursts. It hunts the 24-bit alternating preamble plus 16-bit sync word,
+// captures the FrameBits payload that follows, hands it to [DecodeFrame],
+// and invokes the OnMessage callback for each burst.
+//
+// This is the protocol-side framer only: the DSP layer above it (a
+// 1200-baud FFSK demodulator + slicer, e.g. internal/dsp/demod.FFSK)
+// feeds it one wire bit per Push call. Keeping the framer callback-based
+// and free of the events bus / storage lets it be unit-tested in
+// isolation; the bus/REST/web wiring is a separate, on-air-gated step
+// (issue #437).
+//
+// Polarity: an FM discriminator can present the burst with either tone
+// sense depending on tuning, so the sync hunt accepts both the sync word
+// and its bitwise complement; when it locks on the complement the
+// captured payload bits are inverted to recover the true data — the same
+// approach internal/radio/mdc1200/receiver uses.
+type Framer struct {
+	onMsg func(Message)
+
+	st       framerState
+	reg      uint64 // sliding preamble+sync shift register (huntBits wide)
+	inverted bool   // locked on the complemented sync word
+	buf      [FrameBits]byte
+	n        int // bits captured into buf
+
+	burstsIn uint64 // sync words detected
+	emitted  uint64 // messages passed to OnMessage
+	badCRC   uint64 // frames whose block check failed
+}
+
+type framerState uint8
+
+const (
+	stateHunt    framerState = iota // searching for preamble + sync
+	stateCapture                    // collecting the FrameBits payload
+)
+
+const (
+	// preambleBits is the alternating lead-in checked ahead of the sync
+	// word (three 0xAA bytes, per the reference).
+	preambleBits = 24
+
+	// huntBits is the width of the sync-hunt shift register.
+	huntBits = preambleBits + SyncBits // 40
+
+	// preambleMaxErrors tolerates a few sliced-bit errors in the
+	// alternating preamble (matches the reference's tolerance).
+	preambleMaxErrors = 3
+
+	// syncMaxErrors tolerates at most one bit error in the 16-bit sync
+	// word. The 16-bit block check downstream is the real gate, so this
+	// stays tight to keep the false-lock rate low.
+	syncMaxErrors = 1
+)
+
+const (
+	huntMask     = (uint64(1) << huntBits) - 1
+	preambleMask = (uint64(1) << preambleBits) - 1
+	// preambleAlt is the 24-bit alternating pattern 0b1010...; its
+	// complement covers the opposite phase.
+	preambleAlt uint64 = 0xAAAAAA
+)
+
+// NewFramer constructs a Framer. onMsg is invoked once per decoded burst
+// (including CRC-failed bursts, with Message.CRCOK == false, so a caller
+// can choose to surface marginal signals); it must not be nil.
+func NewFramer(onMsg func(Message)) *Framer {
+	if onMsg == nil {
+		panic("fleetsync: OnMessage callback is required")
+	}
+	return &Framer{onMsg: onMsg}
+}
+
+// Push feeds one sliced wire bit through the framer. Bits outside {0, 1}
+// are masked to their low bit.
+func (f *Framer) Push(bit byte) {
+	bit &= 1
+	switch f.st {
+	case stateHunt:
+		f.reg = ((f.reg << 1) | uint64(bit)) & huntMask
+		if f.syncMatched() {
+			f.st = stateCapture
+			f.n = 0
+			f.burstsIn++
+		}
+	case stateCapture:
+		if f.inverted {
+			bit ^= 1
+		}
+		f.buf[f.n] = bit
+		f.n++
+		if f.n == FrameBits {
+			f.finish()
+		}
+	}
+}
+
+// syncMatched reports whether the shift register's low huntBits hold a
+// valid alternating preamble followed by the sync word (or its
+// complement). It sets f.inverted when locked on the complement.
+func (f *Framer) syncMatched() bool {
+	pre := (f.reg >> SyncBits) & preambleMask
+	if !preambleOK(pre) {
+		return false
+	}
+	syn := uint16(f.reg & 0xFFFF)
+	if hamming16(syn, SyncWord) <= syncMaxErrors {
+		f.inverted = false
+		return true
+	}
+	if hamming16(syn, ^SyncWord) <= syncMaxErrors {
+		f.inverted = true
+		return true
+	}
+	return false
+}
+
+// preambleOK reports whether a 24-bit window is close enough to either
+// phase of the alternating preamble.
+func preambleOK(pre uint64) bool {
+	dA := bits.OnesCount64(pre ^ preambleAlt)
+	dB := bits.OnesCount64(pre ^ (^preambleAlt & preambleMask))
+	return min(dA, dB) <= preambleMaxErrors
+}
+
+// finish decodes the captured payload, emits the burst, and returns the
+// framer to the sync hunt with a cleared register so the just-decoded
+// frame can't immediately re-trigger.
+func (f *Framer) finish() {
+	msg, ok := DecodeFrame(f.buf[:])
+	if !ok {
+		f.badCRC++
+	}
+	f.onMsg(msg)
+	f.emitted++
+
+	f.st = stateHunt
+	f.reg = 0
+	f.n = 0
+	f.inverted = false
+}
+
+// hamming16 counts the differing bits between two 16-bit words.
+func hamming16(a, b uint16) int { return bits.OnesCount16(a ^ b) }
+
+// Stats reports cumulative framer counters for metrics / debugging.
+type Stats struct {
+	BurstsIn      uint64 // preamble+sync locks
+	BurstsBadCRC  uint64 // decoded frames that failed the block check
+	BurstsEmitted uint64 // messages passed to OnMessage
+}
+
+// Stats returns the current counters.
+func (f *Framer) Stats() Stats {
+	return Stats{
+		BurstsIn:      f.burstsIn,
+		BurstsBadCRC:  f.badCRC,
+		BurstsEmitted: f.emitted,
+	}
+}

--- a/internal/radio/fleetsync/framer_test.go
+++ b/internal/radio/fleetsync/framer_test.go
@@ -1,0 +1,114 @@
+package fleetsync
+
+import "testing"
+
+// pushBitsMSB feeds v's low n bits, most-significant first.
+func pushBitsMSB(f *Framer, v uint64, n int, invert bool) {
+	for i := n - 1; i >= 0; i-- {
+		b := byte((v >> uint(i)) & 1)
+		if invert {
+			b ^= 1
+		}
+		f.Push(b)
+	}
+}
+
+// pushSlice feeds a one-byte-per-bit slice, optionally inverted.
+func pushSlice(f *Framer, bitsSlice []byte, invert bool) {
+	for _, b := range bitsSlice {
+		if invert {
+			b ^= 1
+		}
+		f.Push(b)
+	}
+}
+
+// feedBurst drives preamble + sync + payload through a framer, optionally
+// with inverted tone sense.
+func feedBurst(f *Framer, payload []byte, invert bool) {
+	// 32 alternating preamble bits (1,0,1,0,…) — more than the 24 the
+	// framer checks, so the register is clean by the time sync arrives.
+	pushBitsMSB(f, 0xAAAAAAAA, 32, invert)
+	pushBitsMSB(f, uint64(SyncWord), SyncBits, invert)
+	pushSlice(f, payload, invert)
+}
+
+func TestFramerDecodesFS1Burst(t *testing.T) {
+	word1 := uint32(0x0000_337D) // fleet 150, unit high 0x7D
+	payload, _ := buildFS1Frame(t, word1, 0x2F00)
+
+	var got []Message
+	f := NewFramer(func(m Message) { got = append(got, m) })
+	feedBurst(f, payload, false)
+
+	if len(got) != 1 {
+		t.Fatalf("emitted %d messages, want 1", len(got))
+	}
+	m := got[0]
+	if !m.CRCOK || m.Fleet != 150 || m.Unit != 3001 {
+		t.Errorf("decoded %+v, want CRCOK fleet 150 unit 3001", m)
+	}
+	if s := f.Stats(); s.BurstsIn != 1 || s.BurstsEmitted != 1 || s.BurstsBadCRC != 0 {
+		t.Errorf("stats = %+v, want 1 in / 1 emitted / 0 bad-CRC", s)
+	}
+}
+
+// TestFramerDecodesInvertedPolarity: an FM discriminator can present the
+// burst with the opposite tone sense, complementing every bit including
+// the sync word. The framer must lock on the complemented sync and
+// de-invert the payload to recover the same ANI.
+func TestFramerDecodesInvertedPolarity(t *testing.T) {
+	word1 := uint32(0x0000_337D)
+	payload, _ := buildFS1Frame(t, word1, 0x2F00)
+
+	var got []Message
+	f := NewFramer(func(m Message) { got = append(got, m) })
+	feedBurst(f, payload, true) // inverted
+
+	if len(got) != 1 {
+		t.Fatalf("emitted %d messages, want 1", len(got))
+	}
+	if m := got[0]; !m.CRCOK || m.Fleet != 150 || m.Unit != 3001 {
+		t.Errorf("inverted-polarity decode = %+v, want CRCOK fleet 150 unit 3001", m)
+	}
+}
+
+// TestFramerIgnoresIdleAndPreambleOnly: neither a long idle (all zeros)
+// nor a pure alternating preamble with no sync word may trigger a lock —
+// the 16-bit sync gates capture.
+func TestFramerIgnoresIdleAndPreambleOnly(t *testing.T) {
+	var got []Message
+	f := NewFramer(func(m Message) { got = append(got, m) })
+
+	for i := 0; i < 2000; i++ { // idle
+		f.Push(0)
+	}
+	pushBitsMSB(f, 0xAAAAAAAAAAAAAAAA, 64, false) // preamble, no sync
+	pushBitsMSB(f, 0x5555555555555555, 64, false) // opposite phase, no sync
+
+	if len(got) != 0 {
+		t.Fatalf("emitted %d messages on idle/preamble-only input, want 0", len(got))
+	}
+	if s := f.Stats(); s.BurstsIn != 0 {
+		t.Errorf("BurstsIn = %d, want 0 (no sync word was present)", s.BurstsIn)
+	}
+}
+
+// TestFramerReframesAfterBurst: two back-to-back bursts each decode, so a
+// decoded frame returns the framer cleanly to the sync hunt.
+func TestFramerReframesAfterBurst(t *testing.T) {
+	p1, _ := buildFS1Frame(t, 0x0000_337D, 0x2F00) // fleet 150 unit 3001
+	p2, _ := buildFS1Frame(t, 0x0000_647D, 0x2F00) // byte2=0x64=100 → fleet 199
+
+	var got []Message
+	f := NewFramer(func(m Message) { got = append(got, m) })
+	feedBurst(f, p1, false)
+	feedBurst(f, p2, false)
+
+	if len(got) != 2 {
+		t.Fatalf("emitted %d messages, want 2", len(got))
+	}
+	if got[0].Fleet != 150 || got[1].Fleet != 199 {
+		t.Errorf("fleets = %d, %d, want 150, 199", got[0].Fleet, got[1].Fleet)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `internal/radio/fleetsync`, the protocol core for Kenwood FleetSync in-band ANI decode. On #437 the DSP front end was never the blocker — FleetSync is a 1200-baud FFSK burst in the NBFM voice channel, the same modulation class already handled for MDC1200 / MPT-1327 — the blocker was the **exact framing**, which a contributor supplied on the issue as a working, capture-verified decoder (its CRC/ECC lineage is multimon-ng's `fsync`). This ports that framing to Go, clean-room, so the ANI decode is verified rather than guessed.

## Changes

- `internal/radio/fleetsync/fleetsync.go` — protocol layer: 16-bit sync word `0xA23E`; FleetSync I block check (`fsyncCRC`, polynomial `0x6815` + parity bit + `0x0002` term); FleetSync II single-error-correcting ECC (`fs2ECCRepair`, the 8-entry parity-check + 15-entry repair tables); Fleet/Unit field extraction; `DecodeFrame` (FS1 first, FS2 ECC fallback).
- `internal/radio/fleetsync/framer.go` — a bus-free bit `Framer`: preamble + sync hunt (both tone-sense polarities, like the MDC1200 receiver), fixed-length capture, callback per burst. Kept free of the events bus / storage so it unit-tests in isolation and is ready to wire.
- Tests + a CHANGELOG `## [Unreleased]` → Added bullet.

## Test plan

- [x] `make vet test` is green locally (full `-race ./...` suite, exit 0)
- [ ] `make integration` — n/a (nothing wired to the daemon yet)
- [x] Added tests:
  - `TestFS2ECCRepairCorrectsEverySingleBit` — **reference-literal pin**: every single-bit error in a valid FS-II code word must be corrected. Verified failing-first (mutating one repair-table entry makes it fail), so a mistranscribed CRC/ECC table can't slip through.
  - `TestFS2ECCRepairRejectsUncorrectable`, `TestDecodeFrameFS1ExtractsANI`, `TestDecodeFrameFS1RejectsCorruptedCheck`, FS2 round-trip + single-bit-correction, and framer tests (FS1 burst, inverted polarity, idle/preamble-only rejection, back-to-back reframing).
- [ ] Smoke-tested against real hardware — **not possible in this environment**. This is the verification gate (see Breaking/Docs).

## Breaking changes

None. New package with no callers yet; nothing else in the tree is touched. Config keys, CLI, REST, gRPC and default behaviour are all unchanged.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` → Added bullet to `CHANGELOG.md`, explicitly stating no operator-facing decode ships until on-air validation.
- [ ] No operator-facing docs yet — deliberately deferred until the decoder is wired and verified.

## Why staged, not fully wired

A green synthetic decode is **not** on-air verification — the project has been bitten by exactly that (#764/#771, the TETRA class-2 CRC, the DMO colour-0 descramble). So this PR ships the verifiable protocol core only. Wiring it to a live 1200-baud FFSK front end (reusing `internal/dsp/demod.FFSK`) and the events bus → storage → REST → web surface is the follow-up, gated on an on-air A/B: the reporter offered to run the decoder against a real Kenwood ANI/status burst in their lab, which is the confirmation that lets the full path close #437.

## Linked issues

Refs #437 — `Refs`, not `Closes`, pending that on-air A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GbXeAjTr6xSFTRtELDmYS

---
_Generated by [Claude Code](https://claude.ai/code/session_014GbXeAjTr6xSFTRtELDmYS)_