### PR TITLE
dmr/tier2: stop voice bursts forging terminators; add embedded-LC late entry; cs16/wav/flac in RF Scope, flac in SigLab capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -637,6 +637,43 @@ confirmation before any close-as-completed.
   `debug.log` (interleaved never reaching the decoder; per-superframe log spam) corroborate the bug.
   Sharp edge to watch on air: if the embedded LC never decodes (#644), both same-carrier taps'
   `slotRouter`s fall back to phase parity and could bind the same phase (one slot recorded twice).
+- **Conventional DMR "false call ended" (9 Sep IPSC report) was a FORGED TERMINATOR from a voice
+  burst, root-caused on the operator's own captures; the missed continuation was the absence of
+  late entry.** The Tier II slicer (`tier2/process.go`) parsed a slot type on EVERY sync match, but
+  only DATA bursts carry one — a voice burst A has AMBE bits in the slot-type positions, and
+  Golay(20,8) decodes ~1/3 of arbitrary 20-bit words to SOME codeword, so ~1 voice burst A in 12
+  read as (cc, TerminatorWithLC) and the single-call fallback ("LC undecodable but only one call
+  active ⇒ unambiguous") ended the live call mid-sentence. Measured on `dmr_tests_9sep` (25 kS/s
+  cs16 SigLab slices, 442.3875 MHz, tg 11): a terminator exactly 6 bursts (1728 dibits) before the
+  next voice superframe of the SAME over, and 11 grants for 5 transmissions. Fixes, all in
+  `internal/radio/dmr/tier2` and pinned failing-first by `conventional_lateentry_test.go`:
+  (1) slot types are read only from data-sync bursts — per polarity, because DMR's data/voice sync
+  words are each other's `PolarityFlip` image (`dmr.SyncIsDataAtPolarity`), and the stream's
+  polarity is LOCKED by the first FEC-valid burst so the voice-sync gate becomes exact;
+  (2) the undecodable-terminator fallback now requires a BPTC-valid payload (a repeater repeats
+  the real Terminator-with-LC for its whole hang time — 50–170 copies on these captures — so a
+  genuine end never hinges on one uncorrectable burst); (3) **late entry**: the channel now runs
+  the voice superframe assembler beside the burst slicer and grants from two agreeing CRC-valid
+  embedded LCs (`ingestVoiceSuperframe`, ~720 ms in) when a transmission's Voice LC Headers were
+  lost — what every subscriber radio does, and why the operator's radio "still heard the
+  conversation" (their weak −60 dBFS bin-edge tap lost headers at keyup; the composer only
+  starts on a grant). Gates that cost time: a late-entry LC whose superframe STARTED BEFORE the
+  destination's last terminator is the closing superframe of the ended call (the assembler runs a
+  span behind the slicer) — without `endedAtDibit` it re-granted every dead call (7 phantoms/120 s);
+  and the IPSC `color_code` filter is honoured via the superframe's majority EMB colour code
+  (`VoiceSuperframe.EMBColorCode`). Capture-verified with `TestDMRIPSCReplay`: `GT_DMR_DROP_HEADERS=1`
+  scrubs every header burst from the real dibit stream and all 5/5 transmissions are still granted
+  (late_entries=5); un-scrubbed runs grant exactly once per over; capture 1's mid-PTT start is
+  late-entered. The synthetic Tier I fixtures (`siglab/fixtures.go`, `integration_cc_dmr_tier1_test.go`)
+  framed a Voice LC Header with the DM VOICE sync and only passed because of the old parse-everything
+  slicer — a data burst uses the data sync (ETSI TS 102 361-1 Table 9.1); fixed. **The "CSBK CRC
+  mismatch" storm is NOT resolved**: the operator's 443.2375 MHz log shows a 30 ms-cadence (both
+  slots) train of BPTC-clean, CRC-failing CSBKs at cc=7 for ~4 s on a cc=12 system — a real
+  proprietary train, not noise (the CRC convention itself is pinned by real Tier III vectors). The
+  Debug line is now parked (first + summary per 10 s, `csbk_crc_fail` in the activity line) and
+  carries csbko/fid/lb/pf + `info_hex`, the instrument for the next log; a capture of that
+  frequency idle is what pins it. The CSBK/FEC failures that DID appear in these captures (7/120 s)
+  were the same voice-burst forgery and are gone.
 - **DMR group calls are no longer relabeled "individual."** The engine's known-radio →
   individual reclassification (`HandleGrant`, `internal/trunking/engine.go`) and `noteRadio`'s
   talkgroup retraction rest on a TETRA-only invariant (GSSIs and ISSIs never overlap). DMR shares

--- a/cmd/gophertrunk/dmr_ipsc_replay_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_replay_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
 	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
@@ -39,6 +41,13 @@ import (
 // GT_DMR_INTERLEAVED=1 decodes the carrier as 2-slot interleaved (two talkers,
 // one per timeslot) — the common IPSC case — and reports per-phase superframe
 // counts so slot separation is visible.
+//
+// GT_DMR_DROP_HEADERS=1 scrubs every Voice LC Header burst out of the recovered
+// dibit stream before the Tier II state machine sees it — the on-air model of
+// a keyup lost to a fade on a marginal tap. With late entry the transmissions
+// must still be granted from their embedded LC (grants ≈ the un-scrubbed run,
+// late_entries > 0); without it the run decodes voice but grants nothing —
+// exactly the "GT said the call ended but the conversation continued" report.
 func TestDMRIPSCReplay(t *testing.T) {
 	path := os.Getenv("GT_DMR_IQ")
 	if path == "" {
@@ -53,6 +62,7 @@ func TestDMRIPSCReplay(t *testing.T) {
 		inRate = f
 	}
 	interleaved := os.Getenv("GT_DMR_INTERLEAVED") == "1" || os.Getenv("GT_DMR_INTERLEAVED") == "true"
+	dropHeaders := os.Getenv("GT_DMR_DROP_HEADERS") == "1"
 
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -123,7 +133,13 @@ func TestDMRIPSCReplay(t *testing.T) {
 		}
 	}()
 
-	cc := tier2.New(tier2.Options{Bus: bus, SystemName: "dmr-ipsc-replay", FrequencyHz: 0})
+	// GT_DMR_DEBUG=1 prints the Tier II state machine's Debug lines (grants,
+	// terminators, the parked CSBK-failure diagnostics with their info hex).
+	var ccLog *slog.Logger
+	if os.Getenv("GT_DMR_DEBUG") == "1" {
+		ccLog = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
+	cc := tier2.New(tier2.Options{Bus: bus, Log: ccLog, SystemName: "dmr-ipsc-replay", FrequencyHz: 0, InterleavedVoice: interleaved})
 
 	var voiceDec *dmrvoice.Decoder
 	if interleaved {
@@ -145,11 +161,17 @@ func TestDMRIPSCReplay(t *testing.T) {
 		// router reject the call's own audio and record nothing.
 		lcGroups = map[uint32]int{}
 	)
+	var allDibits []uint8
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: outRate,
 		DeviationHz:  1944.0,
 		ClockGain:    0.015,
-		DibitSink: func(dibits []uint8, baseIdx int) {
+		DibitSink: func(dibits []uint8, _ int) {
+			allDibits = append(allDibits, dibits...)
+		},
+	})
+	feed := func(dibits []uint8, baseIdx int) {
+		{
 			cc.Process(dibits, baseIdx)
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
 				superframes++
@@ -169,8 +191,8 @@ func TestDMRIPSCReplay(t *testing.T) {
 					}
 				}
 			}
-		},
-	})
+		}
+	}
 
 	const chunk = 65536
 	var scratch []complex64
@@ -182,6 +204,19 @@ func TestDMRIPSCReplay(t *testing.T) {
 		scratch = ddc.Process(scratch[:0], iq[i:e])
 		rx.Process(scratch)
 	}
+	scrubbed := 0
+	if dropHeaders {
+		scrubbed = scrubVoiceLCHeaders(allDibits)
+	}
+	// Re-feed the (possibly scrubbed) dibit stream in receiver-sized chunks.
+	const dibitChunk = 4096
+	for i := 0; i < len(allDibits); i += dibitChunk {
+		e := i + dibitChunk
+		if e > len(allDibits) {
+			e = len(allDibits)
+		}
+		feed(allDibits[i:e], i)
+	}
 	cancel()
 	<-drainDone
 
@@ -189,7 +224,9 @@ func TestDMRIPSCReplay(t *testing.T) {
 	defer grantsMu.Unlock()
 	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs interleaved=%v",
 		inRate, outRate, len(iq), float64(len(iq))/inRate, interleaved)
-	t.Logf("grants=%d", len(grants))
+	t.Logf("grants=%d late_entries=%d fec_pass=%d fec_fail=%d csbk_crc_fail=%d scrubbed_headers=%d",
+		len(grants), cc.Counters().LateEntries, cc.Counters().FECPass, cc.Counters().FECFail,
+		cc.Counters().CSBKCRCFail, scrubbed)
 	seen := map[grantRec]int{}
 	for _, g := range grants {
 		seen[grantRec{tg: g.tg, src: g.src, indiv: g.indiv}]++
@@ -217,4 +254,35 @@ func TestDMRIPSCReplay(t *testing.T) {
 			t.Fatalf("%s", msg)
 		}
 	}
+}
+
+// scrubVoiceLCHeaders overwrites every Voice-LC-Header burst in dibits (found
+// via the data-sync detector + slot type, exactly as the Tier II adapter
+// slices them) with a pseudo-random dibit pattern that matches no sync word,
+// and returns how many bursts were scrubbed. It models a keyup whose header
+// bursts were lost on air.
+func scrubVoiceLCHeaders(dibits []uint8) int {
+	det := dmr.NewSyncDetector(nil, 2)
+	matches, _ := det.Process(nil, dibits, 0)
+	n := 0
+	seed := uint32(0x9E3779B9)
+	for _, m := range matches {
+		start := m.Index - (dmr.HalfPayloadDibits + dmr.SlotTypeDibits + dmr.SyncDibits - 1)
+		end := start + dmr.BurstDibits
+		if start < 0 || end > len(dibits) {
+			continue
+		}
+		var b dmr.Burst
+		copy(b.Dibits[:], dibits[start:end])
+		slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
+		if err != nil || slot.DataType != dmr.DTVoiceLCHeader {
+			continue
+		}
+		for i := start; i < end; i++ {
+			seed = seed*1664525 + 1013904223
+			dibits[i] = uint8(seed >> 30)
+		}
+		n++
+	}
+	return n
 }

--- a/cmd/gophertrunk/integration_cc_dmr_tier1_test.go
+++ b/cmd/gophertrunk/integration_cc_dmr_tier1_test.go
@@ -158,7 +158,12 @@ func buildDMRTier1VoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sou
 	burst := make([]uint8, 0, dmr.BurstDibits)
 	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
 	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
-	burst = append(burst, dmr.DMVoice1.Dibits[:]...)
+	// A Voice LC Header is a DATA burst, framed in direct mode by the DM data
+	// sync (ETSI TS 102 361-1 Table 9.1). This fixture used DMVoice1 and only
+	// passed while the slicer parsed a slot type on every sync match; slot
+	// types are now read from data-sync bursts only (voice bursts carry AMBE
+	// bits there, which forged terminators on air).
+	burst = append(burst, dmr.DMData1.Dibits[:]...)
 	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
 	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
 

--- a/cmd/gophertrunk/rfscope.go
+++ b/cmd/gophertrunk/rfscope.go
@@ -111,7 +111,7 @@ func runRFScopeAnalyze(args []string) {
 	fs := flag.NewFlagSet("rfscope analyze", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	in := fs.String("in", "", "raw IQ capture file (required)")
-	format := fs.String("format", "f32", "sample format: u8 | f32")
+	format := fs.String("format", "f32", "sample format: u8 | f32 | cs16 | wav | flac (wav/flac carry their own rate and are also sniffed from content behind any label)")
 	sampleRate := fs.Float64("sample-rate", 2_000_000, "IQ sample rate in Hz")
 	freq := fs.Uint64("freq", 0, "capture centre frequency in Hz")
 	window := fs.Float64("window", 0, "analyze only the first N seconds (0 ⇒ whole capture)")
@@ -120,7 +120,7 @@ func runRFScopeAnalyze(args []string) {
 		fmt.Fprintln(fs.Output(), `gophertrunk rfscope analyze — segment + analyze a recorded IQ capture.
 
 USAGE:
-  gophertrunk rfscope analyze -in <path> [-format u8|f32] [-sample-rate Hz] [-freq Hz]
+  gophertrunk rfscope analyze -in <path> [-format u8|f32|cs16|wav|flac] [-sample-rate Hz] [-freq Hz]
                              [-window sec] [-analyzers a,b] [-out-format fmt] [-out path]
 
 FLAGS:`)
@@ -134,12 +134,12 @@ FLAGS:`)
 		fs.Usage()
 		rep.Fatalf(2, "-in is required")
 	}
-	if *sampleRate <= 0 {
-		rep.Fatalf(2, "-sample-rate must be > 0")
-	}
 	sampleFormat, err := siglab.ParseSampleFormat(*format)
 	if err != nil {
 		rep.Fatal(2, err)
+	}
+	if *sampleRate <= 0 && sampleFormat != siglab.FormatWAV && sampleFormat != siglab.FormatFLAC {
+		rep.Fatalf(2, "-sample-rate must be > 0 for a headerless (u8/f32/cs16) capture")
 	}
 
 	src, err := rfscope.OpenFile(*in, sampleFormat, uint32(*freq), *sampleRate)
@@ -148,9 +148,11 @@ FLAGS:`)
 	}
 	defer src.Close()
 
+	// A wav/flac container's header rate wins over -sample-rate (see OpenFile).
+	rate := src.SampleRateHz()
 	maxSamples := 0
 	if *window > 0 {
-		maxSamples = int(*window * *sampleRate)
+		maxSamples = int(*window * rate)
 	}
 	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), *in, *af.outFormat, *af.out, *af.framesOut)
 }

--- a/docs/rfscope.md
+++ b/docs/rfscope.md
@@ -51,7 +51,9 @@ gophertrunk rfscope serve [-addr host:port] [-open]          web console (browse
 gophertrunk rfscope list                                     list registered analyzers
 ```
 
-Common flags (shared by `analyze` and `live`): `-format u8|f32`, `-sample-rate`,
+Common flags (shared by `analyze` and `live`): `-format u8|f32|cs16|wav|flac` (a
+wav/flac capture carries its own rate; the container is also sniffed from the
+file content whatever the label), `-sample-rate`,
 `-freq` (capture centre), `-fft`, `-peak-threshold-db`, `-min-spacing`,
 `-channel-rate`, `-analyzers hierarchy,timing,…` (default: all),
 `-out-format summary|json|jsonl|yaml|csv`, `-out <path>`, and `-frames-out

--- a/internal/api/handlers_siglab.go
+++ b/internal/api/handlers_siglab.go
@@ -103,6 +103,10 @@ func (s *Server) handleSiglabProtocols(w http.ResponseWriter, r *http.Request) {
 		"protocols": decode,
 		"fixtures":  synth,
 		"formats":   []string{"u8", "f32", "cs16"},
+		// capture_formats is the superset the live capture-from-tuner route
+		// accepts: the headerless encodings plus the wav/flac containers
+		// (siglab.IQContainer). synth/upload stay on the headerless trio.
+		"capture_formats": []string{"u8", "f32", "cs16", "wav", "flac"},
 	})
 }
 

--- a/internal/radio/dmr/sync.go
+++ b/internal/radio/dmr/sync.go
@@ -124,3 +124,37 @@ func (s *SyncDetector) Process(dst []Match, src []uint8, baseIndex int) ([]Match
 	}
 	return dst, baseIndex + len(src)
 }
+
+// IsDataSync reports whether p is one of the data-burst sync words (BS/MS/DM
+// data). Only data bursts carry a slot type; voice bursts carry the voice
+// sync in burst A and embedded signalling in B–F, with AMBE bits in the
+// slot-type positions.
+func IsDataSync(p SyncPattern) bool {
+	switch p.Hex {
+	case BSData.Hex, MSData.Hex, DMData1.Hex, DMData2.Hex:
+		return true
+	}
+	return false
+}
+
+// IsVoiceSync reports whether p is one of the voice-burst sync words (BS/MS/DM
+// voice). The four data/voice pairs are each other's PolarityFlip image, so a
+// voice-sync match on a spectrum-inverted stream is really a data burst.
+func IsVoiceSync(p SyncPattern) bool {
+	switch p.Hex {
+	case BSVoice.Hex, MSVoice.Hex, DMVoice1.Hex, DMVoice2.Hex:
+		return true
+	}
+	return false
+}
+
+// SyncIsDataAtPolarity reports whether a burst framed by sync p carries a
+// slot type once its dibits are rotated by polarity k: at identity that is a
+// data sync; at PolarityFlip it is a voice sync (whose flip image is the
+// paired data sync). MS-RC is neither and never carries a slot type.
+func SyncIsDataAtPolarity(p SyncPattern, k uint8) bool {
+	if k == 0 {
+		return IsDataSync(p)
+	}
+	return IsVoiceSync(p)
+}

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -13,7 +13,9 @@ package tier2
 
 import (
 	"encoding/hex"
+	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -22,6 +24,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -31,6 +34,29 @@ import (
 // itself once, then stays quiet — the Beacons counter keeps the exact
 // count. See handleCSBK.
 const beaconLogInterval = 30 * time.Second
+
+// csbkFailLogInterval parks the Debug log for CSBK bursts that BPTC-decode
+// but fail the CSBK CRC (or are BPTC-uncorrectable). A keyed idle IPSC
+// repeater can put such a burst on BOTH timeslots every 30 ms (field
+// report: one identical "CSBK CRC mismatch" line per burst for seconds at
+// a time), so the first failure logs immediately — with the block's
+// opcode/FID/LB/PF and raw info hex, the instrument that lets the next
+// report pin what those bursts actually are — and unchanged repeats are
+// summarised at this interval with the suppressed count. Mirrors the Tier
+// III csbkRepeatLogInterval parking.
+const csbkFailLogInterval = 10 * time.Second
+
+// lateEntryConfirm is how many CRC-valid embedded-LC superframes must name
+// the same (destination, source) before a transmission whose Voice LC
+// Header was never decoded is granted by late entry. The embedded LC repeats
+// every superframe (360 ms), so two agreeing copies cost ~720 ms of the
+// transmission and rule out a lone miscorrected LC forging a phantom call.
+const lateEntryConfirm = 2
+
+// lateEntryWindow bounds how long a single unconfirmed late-entry candidate
+// stays valid: a second agreeing LC must land within this much of the first
+// or the candidate is restarted.
+const lateEntryWindow = 3 * time.Second
 
 // LockState is the payload of cc.locked / cc.lost events emitted by
 // the Tier II per-repeater state machine. DMR Tier II is conventional
@@ -69,6 +95,17 @@ type Counters struct {
 	// IPSC / linked-repeater profile) to ignore other systems sharing the
 	// wideband passband.
 	DroppedOffCC uint64
+	// LateEntries counts grants raised by late entry — a transmission whose
+	// Voice LC Header bursts never decoded (lost to a fade / bin-edge SNR at
+	// keyup) but whose embedded Link Control, repeated every voice
+	// superframe, named the call. Zero when every transmission's header
+	// decodes; a steadily climbing value on a live repeater is the signature
+	// of a weak tap (the conversation is being caught mid-transmission).
+	LateEntries uint64
+	// CSBKCRCFail counts CSBK-typed bursts that passed BPTC(196,96) but failed
+	// the CSBK CRC — either between-beacon noise, or a real proprietary CSBK
+	// train GT does not yet understand (see handleCSBK's parked log).
+	CSBKCRCFail uint64
 }
 
 // LockedFrequencyHz / LockedNAC make LockState satisfy
@@ -146,6 +183,51 @@ type ConventionalChannel struct {
 	// atomic cnt below.
 	calls map[uint32]*convCall
 
+	// voice assembles voice superframes from the same dibit stream Process
+	// slices bursts from, so the embedded Link Control (bursts B–E of every
+	// superframe) can grant a transmission whose Voice LC Header never
+	// decoded — DMR late entry, the mechanism every subscriber radio uses to
+	// join a call in progress. Without it the conventional path had exactly
+	// one chance per transmission (the header bursts at keyup, the weakest
+	// moment of a PTT on a marginal tap): a header lost to a fade dropped the
+	// whole over, which an operator with a radio beside the scanner sees as
+	// "GT said the call ended but the conversation continued". Lazily built
+	// on the first Process call (interleaved when InterleavedVoice is set,
+	// single-slot for direct mode); nil until then, so IngestBurst-only
+	// callers (tests, the Tier III adapter) are unaffected.
+	voice *dmrvoice.Decoder
+
+	// lateEntry holds the unconfirmed late-entry candidates keyed by
+	// destination: the (source, first-seen) of an embedded LC that named a
+	// call not in calls. A second agreeing LC within lateEntryWindow grants.
+	lateEntry map[uint32]*lateEntryCandidate
+
+	// endedAtDibit records, per destination, the absolute dibit index of the
+	// Terminator-with-LC burst that last released its call. The voice
+	// superframe assembler runs a span behind the burst slicer, so the
+	// closing superframes of a transmission can surface AFTER its terminator
+	// was processed; their embedded LCs belong to the call that just ended
+	// and must not seed a late-entry re-grant of it (measured on air: 7
+	// phantom grant/release pairs in a 120 s capture without this gate). An
+	// LC whose superframe started before the terminator is ignored.
+	endedAtDibit map[uint32]int
+	// ingestDibit is the absolute dibit index of the burst IngestBurst is
+	// currently handling when driven from Process (−1 otherwise).
+	ingestDibit int
+
+	// polarity is the discriminator polarity (0 identity, dmr.PolarityFlip)
+	// this stream decodes at, learned from the first FEC-valid burst; −1 while
+	// unknown, when both candidates are tried. DMR's data and voice sync
+	// words are each other's flip image, so until the polarity is known a
+	// voice burst A at the untried polarity looks like a data burst and gets
+	// its (AMBE-bit) slot type parsed; once known, only real data-sync bursts
+	// reach the slot-type path. A front end's inversion is a fixed property
+	// of the stream, so the lock is never dropped.
+	polarity int
+	// burstValid is set by the FEC-validated decode paths (header BPTC+RS,
+	// CSBK CRC, terminator LC) so Process can learn the polarity.
+	burstValid bool
+
 	// cnt holds the lock-free decode-activity counters exposed via
 	// Counters(). Incremented on the existing hot paths with atomic
 	// adds so any goroutine can snapshot them without taking c.mu.
@@ -157,11 +239,30 @@ type ConventionalChannel struct {
 		locks        atomic.Uint64
 		beacons      atomic.Uint64
 		droppedOffCC atomic.Uint64
+		lateEntries  atomic.Uint64
+		csbkCRCFail  atomic.Uint64
 	}
 
 	// beaconLogAt is the last time handleCSBK emitted an Info "site alive"
 	// line; guarded by mu and used only to rate-limit that log.
 	beaconLogAt time.Time
+
+	// csbkFailLog parks the CSBK-failure Debug log (see csbkFailLogInterval).
+	// Touched only on the decode goroutine.
+	csbkFailLog struct {
+		at         time.Time
+		suppressed int
+		lastKey    string
+	}
+}
+
+// lateEntryCandidate is one unconfirmed late-entry call: the source the
+// first embedded LC named for a destination, when it was seen, and how many
+// agreeing LCs have accumulated.
+type lateEntryCandidate struct {
+	src     uint32
+	firstAt time.Time
+	seen    int
 }
 
 // Counters returns a snapshot of this channel's decode-activity
@@ -175,6 +276,8 @@ func (c *ConventionalChannel) Counters() Counters {
 		Locks:        c.cnt.locks.Load(),
 		Beacons:      c.cnt.beacons.Load(),
 		DroppedOffCC: c.cnt.droppedOffCC.Load(),
+		LateEntries:  c.cnt.lateEntries.Load(),
+		CSBKCRCFail:  c.cnt.csbkCRCFail.Load(),
 	}
 }
 
@@ -222,6 +325,8 @@ func New(opts Options) *ConventionalChannel {
 		tag = "dmr-tier2"
 	}
 	return &ConventionalChannel{
+		ingestDibit:      -1,
+		polarity:         -1,
 		bus:              opts.Bus,
 		log:              log,
 		systemName:       opts.SystemName,
@@ -298,15 +403,24 @@ func (c *ConventionalChannel) handleCSBK(b *dmr.Burst, slot dmr.SlotType) {
 	payload := b.PayloadBits()
 	bits, errs := framing.DecodeBPTC196_96(payload)
 	if errs < 0 {
-		c.log.Debug("dmr/tier2: CSBK BPTC uncorrectable (between-beacon noise)", "cc", slot.ColorCode)
+		c.logCSBKFailure("dmr/tier2: CSBK BPTC uncorrectable (between-beacon noise)", slot, nil, nil)
 		return
 	}
-	csbk, err := tier3.ParseCSBK(infoBitsToBytes(bits))
+	info := infoBitsToBytes(bits)
+	csbk, err := tier3.ParseCSBK(info)
 	if err != nil {
-		c.log.Debug("dmr/tier2: CSBK CRC mismatch (between-beacon noise)", "cc", slot.ColorCode)
+		// BPTC(196,96) passed — the burst is well received — but the 16-bit
+		// CSBK CRC (ETSI mask, pinned by real Tier III vectors) does not check.
+		// On a keyed idle IPSC repeater this can be EVERY burst on both slots
+		// for seconds (a vendor-proprietary CSBK train, not noise), so the log
+		// is parked and carries the decoded header + raw block so the next
+		// field log pins what the train is. Not a decode error on the bus.
+		c.cnt.csbkCRCFail.Add(1)
+		c.logCSBKFailure("dmr/tier2: CSBK CRC mismatch (between-beacon noise or proprietary CSBK train)", slot, &csbk, info)
 		return
 	}
 	c.cnt.beacons.Add(1)
+	c.burstValid = true
 
 	// Rate-limit the operator-facing Info line so a fast beacon interval
 	// doesn't flood the log; the counter still records every beacon.
@@ -324,6 +438,140 @@ func (c *ConventionalChannel) handleCSBK(b *dmr.Burst, slot dmr.SlotType) {
 	} else {
 		c.log.Debug("dmr/tier2: beacon", "cc", slot.ColorCode, "csbk", csbk.Opcode.String())
 	}
+}
+
+// logCSBKFailure emits the parked Debug line for a CSBK burst that failed
+// BPTC or CRC: the first occurrence of a (message, cc, opcode, fid) key logs
+// at once with the block's header fields + raw info hex; repeats within
+// csbkFailLogInterval are counted and summarised on the next emit. A change
+// of key (different colour code / opcode) logs immediately so a real
+// transition is never hidden behind the parking.
+func (c *ConventionalChannel) logCSBKFailure(msg string, slot dmr.SlotType, csbk *tier3.CSBK, info []byte) {
+	key := msg + "|" + strconv.Itoa(int(slot.ColorCode))
+	attrs := []any{"cc", slot.ColorCode}
+	if csbk != nil {
+		key += "|" + strconv.Itoa(int(csbk.Opcode)) + "|" + strconv.Itoa(int(csbk.FID))
+		attrs = append(attrs,
+			"csbko", fmt.Sprintf("0x%02x", uint8(csbk.Opcode)), "fid", fmt.Sprintf("0x%02x", csbk.FID),
+			"lb", csbk.LB, "pf", csbk.PF, "info_hex", hex.EncodeToString(info))
+	}
+	now := c.now()
+	st := &c.csbkFailLog
+	if !st.at.IsZero() && st.lastKey == key && now.Sub(st.at) < csbkFailLogInterval {
+		st.suppressed++
+		return
+	}
+	if st.suppressed > 0 {
+		attrs = append(attrs, "suppressed_repeats", st.suppressed)
+	}
+	st.at, st.lastKey, st.suppressed = now, key, 0
+	c.log.Debug(msg, attrs...)
+}
+
+// ingestVoiceSuperframe is the late-entry path: every CRC-valid embedded
+// Link Control that names a group / unit-to-unit voice call either refreshes
+// the tracked call it belongs to or, for a destination no Voice LC Header
+// ever granted, accumulates towards a late-entry grant (lateEntryConfirm
+// agreeing superframes within lateEntryWindow). The optional colour-code
+// filter is honoured through the superframe's majority EMB colour code.
+func (c *ConventionalChannel) ingestVoiceSuperframe(sf dmrvoice.VoiceSuperframe) {
+	if !sf.HasLC {
+		return
+	}
+	if c.colorFilter != nil && (!sf.HasEMB || sf.EMBColorCode != *c.colorFilter) {
+		c.cnt.droppedOffCC.Add(1)
+		return
+	}
+	var dest, src uint32
+	var prio uint8
+	var enc, emer, individual bool
+	if gv, ok := sf.LC.AsGroupVoiceUser(); ok {
+		dest, src, enc, emer, prio = gv.GroupAddress, gv.SourceID, gv.Encrypted, gv.Emergency, gv.Priority
+	} else if uu, ok := sf.LC.AsUnitToUnitVoice(); ok {
+		dest, src, enc, emer, individual, prio = uu.DestinationID, uu.SourceID, uu.Encrypted, uu.Emergency, true, uu.Priority
+	} else {
+		return
+	}
+	if dest == 0 || src == 0 {
+		return
+	}
+	if end, ok := c.endedAtDibit[dest]; ok && sf.StartDibit < end {
+		// Closing superframe of a call whose terminator already released it.
+		return
+	}
+	now := c.now()
+	if existing, ok := c.calls[dest]; ok {
+		// The call is already tracked (header-granted or late-entered): the
+		// LC is liveness for slot reuse. A source change mid-call is a talker
+		// change on the same slot — republish, as the header path does.
+		existing.lastAt = now
+		if existing.src != src {
+			existing.src = src
+			c.publishGrant(dest, src, individual, enc, emer, prio, existing.slot, sf.EMBColorCode, true)
+		}
+		return
+	}
+	if c.lateEntry == nil {
+		c.lateEntry = make(map[uint32]*lateEntryCandidate)
+	}
+	cand := c.lateEntry[dest]
+	if cand == nil || cand.src != src || now.Sub(cand.firstAt) > lateEntryWindow {
+		c.lateEntry[dest] = &lateEntryCandidate{src: src, firstAt: now, seen: 1}
+		if lateEntryConfirm > 1 {
+			return
+		}
+		cand = c.lateEntry[dest]
+	} else {
+		cand.seen++
+		if cand.seen < lateEntryConfirm {
+			return
+		}
+	}
+	delete(c.lateEntry, dest)
+	// Two agreeing CRC-valid embedded LCs are as strong an on-air proof as a
+	// BPTC+RS-clean header: declare the lock too, so a camped channel whose
+	// first transmission lost its header still reports locked.
+	c.cnt.lateEntries.Add(1)
+	if c.polarity < 0 {
+		// The assembler ran on identity-polarity dibits (see Process), so two
+		// CRC-valid LCs also fix the stream's polarity at identity.
+		c.polarity = 0
+	}
+	c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: sf.EMBColorCode})
+	if c.calls == nil {
+		c.calls = make(map[uint32]*convCall)
+	}
+	ts := c.assignSlot(now)
+	c.calls[dest] = &convCall{src: src, slot: ts, lastAt: now}
+	c.publishGrant(dest, src, individual, enc, emer, prio, ts, sf.EMBColorCode, true)
+}
+
+// publishGrant publishes one trunking.Grant for this channel and logs it.
+// lateEntry marks a grant raised from the embedded LC rather than a header.
+func (c *ConventionalChannel) publishGrant(dest, src uint32, individual, enc, emer bool, prio uint8, ts uint8, cc uint8, lateEntry bool) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:              c.systemName,
+			Protocol:            c.protocolTag,
+			GroupID:             dest,
+			SourceID:            src,
+			Individual:          individual,
+			FrequencyHz:         c.freqHz,
+			ChannelID:           cc,
+			Timeslot:            ts,
+			DMRInterleavedVoice: c.interleavedVoice,
+			Encrypted:           enc,
+			Emergency:           emer,
+			Priority:            prio,
+			At:                  c.now(),
+		},
+	})
+	c.log.Debug("dmr/tier2: grant",
+		"system", c.systemName, "freq_hz", c.freqHz,
+		"cc", cc, "dst", dest, "src", src,
+		"individual", individual, "enc", enc, "emer", emer,
+		"late_entry", lateEntry)
 }
 
 func (c *ConventionalChannel) maybeLock(s LockState) {
@@ -362,6 +610,16 @@ func (c *ConventionalChannel) MarkLost() {
 	}
 	c.locked = false
 	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}
+
+// ResetLateEntry drops any unconfirmed late-entry candidates and the voice
+// superframe assembler's buffered state, e.g. after a retune.
+func (c *ConventionalChannel) ResetLateEntry() {
+	c.lateEntry = nil
+	c.endedAtDibit = nil
+	if c.voice != nil {
+		c.voice.Reset()
+	}
 }
 
 func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType) {
@@ -414,6 +672,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 	// tuned frequency. Declare the lock here (not on the slot type alone)
 	// so a false sync / miscorrected slot type can't forge it.
 	c.cnt.fecPass.Add(1)
+	c.burstValid = true
 	c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: slot.ColorCode})
 	flc, err := dmr.ParseFLC(infoBytes)
 	if err != nil {
@@ -460,28 +719,10 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		ts = c.assignSlot(now)
 		c.calls[dest] = &convCall{src: src, slot: ts, lastAt: now}
 	}
-	c.bus.Publish(events.Event{
-		Kind: events.KindGrant,
-		Payload: trunking.Grant{
-			System:              c.systemName,
-			Protocol:            c.protocolTag,
-			GroupID:             dest,
-			SourceID:            src,
-			Individual:          individual,
-			FrequencyHz:         c.freqHz,
-			ChannelID:           slot.ColorCode,
-			Timeslot:            ts,
-			DMRInterleavedVoice: c.interleavedVoice,
-			Encrypted:           enc,
-			Emergency:           emer,
-			Priority:            prio,
-			At:                  c.now(),
-		},
-	})
-	c.log.Debug("dmr/tier2: grant",
-		"system", c.systemName, "freq_hz", c.freqHz,
-		"cc", slot.ColorCode, "dst", dest, "src", src,
-		"individual", individual, "enc", enc, "emer", emer)
+	// A header grant supersedes any pending late-entry candidate for the
+	// destination (the header is the stronger evidence and arrives first).
+	delete(c.lateEntry, dest)
+	c.publishGrant(dest, src, individual, enc, emer, prio, ts, slot.ColorCode, false)
 }
 
 func (c *ConventionalChannel) handleTerminator(b *dmr.Burst, slot dmr.SlotType) {
@@ -493,14 +734,27 @@ func (c *ConventionalChannel) handleTerminator(b *dmr.Burst, slot dmr.SlotType) 
 	// TS2 call. The Terminator-with-LC carries the same FLC as the Voice LC
 	// Header — group talkgroup or unit-to-unit destination — protected by
 	// BPTC(196,96) + RS(12,9) with the terminator parity seed.
-	dest, ok := c.terminatorDest(b)
+	dest, ok, bptcOK := c.terminatorDest(b)
+	if ok {
+		c.burstValid = true
+	}
 	if !ok {
 		// The terminator's Full LC did not decode. With a single call active the
 		// terminator is unambiguous, so end that call (preserving the prompt
-		// teardown Tier II has always done). With two concurrent calls it is
-		// ambiguous — releasing by a guess could cross-tear the other slot — so
-		// release nothing and let each voice chain's own terminator detector +
-		// hangtime end its call.
+		// teardown Tier II has always done) — but only if its BPTC(196,96)
+		// block decoded (an RS/FLC mismatch on a well-received burst). A burst
+		// whose slot type says Terminator but whose payload is not even a BPTC
+		// codeword is a forged slot type, not a weak terminator: a repeater
+		// repeats the real Terminator-with-LC for its whole hang time (50–170
+		// copies on the 9 Sep captures), so a genuine end never depends on one
+		// uncorrectable burst, while a false one ends a live call mid-sentence.
+		// With two concurrent calls it is ambiguous — releasing by a guess could
+		// cross-tear the other slot — so release nothing and let each voice
+		// chain's own terminator detector + hangtime end its call.
+		if !bptcOK {
+			c.log.Debug("dmr/tier2: terminator slot type without a BPTC-valid payload ignored", "cc", slot.ColorCode)
+			return
+		}
 		if len(c.calls) != 1 {
 			c.log.Debug("dmr/tier2: ambiguous terminator (LC undecodable, two calls active); leaving to hangtime",
 				"cc", slot.ColorCode)
@@ -517,6 +771,14 @@ func (c *ConventionalChannel) handleTerminator(b *dmr.Burst, slot dmr.SlotType) 
 		return
 	}
 	delete(c.calls, dest)
+	delete(c.lateEntry, dest)
+	if c.ingestDibit >= 0 {
+		if c.endedAtDibit == nil {
+			c.endedAtDibit = make(map[uint32]int)
+		}
+		c.endedAtDibit[dest] = c.ingestDibit
+	}
+
 	// A Terminator with LC is the explicit end of the transmission. Publish a
 	// call release so the engine ends the call at once, rather than waiting out
 	// the composer's hangtime / no-voice timers — the same prompt-teardown path
@@ -540,26 +802,30 @@ func (c *ConventionalChannel) handleTerminator(b *dmr.Burst, slot dmr.SlotType) 
 // call destination it names (talkgroup or called subscriber), or ok=false if
 // the embedded LC fails FEC. It mirrors handleVoiceHeader's BPTC + RS(12,9)
 // pipeline but with the terminator parity seed.
-func (c *ConventionalChannel) terminatorDest(b *dmr.Burst) (uint32, bool) {
+//
+// bptcOK reports whether the burst's BPTC(196,96) block decoded at all, so
+// the caller can tell a weak-but-real terminator (BPTC ok, RS/FLC mismatch)
+// from a forged slot type on a non-BPTC payload.
+func (c *ConventionalChannel) terminatorDest(b *dmr.Burst) (dest uint32, ok bool, bptcOK bool) {
 	bits, errs := framing.DecodeBPTC196_96(b.PayloadBits())
 	if errs < 0 {
-		return 0, false
+		return 0, false, false
 	}
 	infoBytes := infoBitsToBytes(bits)
 	if !framing.VerifyRS12_9(infoBytes, framing.RS129SeedTerminatorLC) {
-		return 0, false
+		return 0, false, true
 	}
 	flc, err := dmr.ParseFLC(infoBytes)
 	if err != nil {
-		return 0, false
+		return 0, false, true
 	}
 	if gv, ok := flc.AsGroupVoiceUser(); ok {
-		return gv.GroupAddress, true
+		return gv.GroupAddress, true, true
 	}
 	if uu, ok := flc.AsUnitToUnitVoice(); ok {
-		return uu.DestinationID, true
+		return uu.DestinationID, true, true
 	}
-	return 0, false
+	return 0, false, true
 }
 
 // convCall is one in-progress conventional-DMR call. slot is the synthetic

--- a/internal/radio/dmr/tier2/conventional_lateentry_test.go
+++ b/internal/radio/dmr/tier2/conventional_lateentry_test.go
@@ -1,0 +1,418 @@
+package tier2
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// --- synthetic outbound-carrier builders (mirror voice/superframe_test.go) ---
+
+// lcFragmentsFor encodes a Full LC into the four 32-bit embedded fragments
+// bursts B–E carry.
+func lcFragmentsFor(t *testing.T, f dmr.FLC) [4][]byte {
+	t.Helper()
+	info := dmr.AssembleFLC(f)
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	ch := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = ch[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+func embeddedSyncField(emb dmr.EMB, frag []byte) [24]uint8 {
+	field := dmr.AssembleEmbeddedField(emb, frag)
+	var d [24]uint8
+	for i := 0; i < 24; i++ {
+		d[i] = field[2*i]<<1 | field[2*i+1]
+	}
+	return d
+}
+
+func lcssFor(b int) dmr.LCSS {
+	switch b {
+	case 1:
+		return dmr.LCSSFirst
+	case 4:
+		return dmr.LCSSLast
+	default:
+		return dmr.LCSSCont
+	}
+}
+
+// voiceBurstDibits assembles a 132-dibit voice burst: 108 bits + 24-dibit
+// sync/EMB field + 108 bits, with deterministic (non-codeword) AMBE bits.
+func voiceBurstDibits(seed int, sync [24]uint8) []uint8 {
+	bits := make([]byte, 216)
+	for i := range bits {
+		bits[i] = byte((seed*3 + i*5) & 1)
+	}
+	toDibits := func(b []byte) []uint8 {
+		d := make([]uint8, len(b)/2)
+		for i := range d {
+			d[i] = b[2*i]<<1 | b[2*i+1]
+		}
+		return d
+	}
+	out := make([]uint8, 0, dmr.BurstDibits)
+	out = append(out, toDibits(bits[:108])...)
+	out = append(out, sync[:]...)
+	out = append(out, toDibits(bits[108:])...)
+	return out
+}
+
+// idleBurstDibits is a BS-Data-synced burst whose slot type says Idle at
+// colour code cc — what the unused timeslot of a keyed repeater carries.
+func idleBurstDibits(cc uint8) []uint8 {
+	b := burstWithInfo96(make([]byte, 12))
+	stampSlotType(b, cc, dmr.DTIdle)
+	return b.Dibits[:]
+}
+
+// stampSlotType writes the BS-Data sync + a (cc, dt) slot type into b.
+func stampSlotType(b *dmr.Burst, cc uint8, dt dmr.DataType) {
+	copy(b.Dibits[dmr.HalfPayloadDibits+dmr.SlotTypeDibits:], dmr.BSData.Dibits[:])
+	st := dmr.AssembleSlotType(dmr.SlotType{ColorCode: cc, DataType: dt})
+	// 20 bits: 10 before the sync, 10 after.
+	for i := 0; i < 5; i++ {
+		b.Dibits[dmr.HalfPayloadDibits+i] = (st[2*i] << 1) | st[2*i+1]
+		b.Dibits[dmr.HalfPayloadDibits+dmr.SlotTypeDibits+dmr.SyncDibits+i] = (st[10+2*i] << 1) | st[10+2*i+1]
+	}
+}
+
+// outboundTransmission weaves one slot's transmission onto a 2-slot outbound
+// carrier with a 12-dibit CACH before every burst (the 288-dibit same-slot
+// cadence of real air): headers Voice-LC-Header bursts, then superframes
+// voice superframes carrying lc in their embedded signalling, then
+// terminators Terminator-with-LC bursts. The other slot idles throughout.
+func outboundTransmission(t *testing.T, lc dmr.FLC, cc uint8, headers, superframes, terminators int) []uint8 {
+	t.Helper()
+	frags := lcFragmentsFor(t, lc)
+	cach := make([]uint8, 12)
+	var s []uint8
+	weave := func(slotA []uint8) {
+		s = append(s, cach...)
+		s = append(s, slotA...)
+		s = append(s, cach...)
+		s = append(s, idleBurstDibits(cc)...)
+	}
+	for i := 0; i < headers; i++ {
+		b := burstWithFLC(lc)
+		stampSlotType(b, cc, dmr.DTVoiceLCHeader)
+		weave(b.Dibits[:])
+	}
+	seed := 0
+	for sf := 0; sf < superframes; sf++ {
+		for b := 0; b < dmrvoice.BurstsPerSuperframe; b++ {
+			sync := dmr.BSVoice.Dibits
+			if b >= 1 && b <= 4 {
+				sync = embeddedSyncField(dmr.EMB{ColorCode: cc, LCSS: lcssFor(b)}, frags[b-1])
+			} else if b == 5 {
+				sync = embeddedSyncField(dmr.EMB{ColorCode: cc, LCSS: dmr.LCSSSingle}, make([]byte, 32))
+			}
+			weave(voiceBurstDibits(seed, sync))
+			seed++
+		}
+	}
+	for i := 0; i < terminators; i++ {
+		b := burstWithTerminatorFLC(lc)
+		stampSlotType(b, cc, dmr.DTTerminatorWithLC)
+		weave(b.Dibits[:])
+	}
+	// Trailing idle so the interleaved decoder has a full span buffered
+	// behind the last superframe anchor (a live carrier is continuous).
+	for i := 0; i < 8; i++ {
+		weave(idleBurstDibits(cc))
+	}
+	return s
+}
+
+func feedChunks(c *ConventionalChannel, stream []uint8, chunk int) {
+	idx := 0
+	for idx < len(stream) {
+		e := idx + chunk
+		if e > len(stream) {
+			e = len(stream)
+		}
+		c.Process(stream[idx:e], idx)
+		idx = e
+	}
+}
+
+func groupLC(tg, src uint32) dmr.FLC {
+	return dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: tg, SrcAddr: src}
+}
+
+// TestConventionalLateEntryGrantsHeaderlessTransmission pins DMR late entry
+// (field report: "GT said the call ended but the conversation continued for
+// 20 s" — the next transmissions' Voice LC Headers were lost to a fade on a
+// −60 dBFS tap, and the conventional path had no other way to grant). A
+// transmission with ZERO decodable headers must still be granted from its
+// embedded Link Control, and the terminator must still release it. Before
+// late entry this produced no grant at all.
+func TestConventionalLateEntryGrantsHeaderlessTransmission(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	c := New(Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 442387500, InterleavedVoice: true})
+
+	stream := outboundTransmission(t, groupLC(11, 199), 12, 0, 4, 3)
+	feedChunks(c, stream, 1000)
+
+	evs := drainEvents(sub, 100*time.Millisecond)
+	grants := grantsOf(evs)
+	if len(grants) != 1 {
+		t.Fatalf("late entry: got %d grants, want exactly 1 (%+v)", len(grants), grants)
+	}
+	g := grants[0]
+	if g.GroupID != 11 || g.SourceID != 199 || g.Protocol != "dmr-tier2" || !g.DMRInterleavedVoice {
+		t.Errorf("late-entry grant = %+v, want tg=11 src=199 dmr-tier2 interleaved", g)
+	}
+	if g.ChannelID != 12 {
+		t.Errorf("late-entry grant colour code = %d, want 12 (majority EMB CC)", g.ChannelID)
+	}
+	if c.Counters().LateEntries != 1 {
+		t.Errorf("LateEntries = %d, want 1", c.Counters().LateEntries)
+	}
+	var released, locked bool
+	for _, ev := range evs {
+		switch ev.Kind {
+		case events.KindCallRelease:
+			released = true
+		case events.KindCCLocked:
+			locked = true
+		}
+	}
+	if !released {
+		t.Error("terminator after a late-entered call did not publish call.release")
+	}
+	if !locked {
+		t.Error("late entry did not declare the channel locked")
+	}
+}
+
+// TestConventionalLateEntryNeedsTwoAgreeingLCs pins the confirm-twice gate: a
+// single embedded LC (one superframe) is not enough to grant, so a lone
+// miscorrected LC cannot forge a phantom call.
+func TestConventionalLateEntryNeedsTwoAgreeingLCs(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	c := New(Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 1, InterleavedVoice: true})
+
+	feedChunks(c, outboundTransmission(t, groupLC(11, 199), 12, 0, 1, 0), 1000)
+	if n := len(grantsOf(drainEvents(sub, 50*time.Millisecond))); n != 0 {
+		t.Fatalf("one embedded LC granted %d call(s); want 0 until a second agreeing LC", n)
+	}
+}
+
+// TestConventionalHeaderAndEmbeddedLCGrantOnce pins no-harm on the normal
+// path: a transmission whose headers decode is granted exactly once — the
+// following superframes' embedded LCs refresh the tracked call instead of
+// re-granting — and LateEntries stays 0.
+func TestConventionalHeaderAndEmbeddedLCGrantOnce(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	c := New(Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 1, InterleavedVoice: true})
+
+	feedChunks(c, outboundTransmission(t, groupLC(11, 199), 12, 4, 4, 3), 1000)
+	grants := grantsOf(drainEvents(sub, 100*time.Millisecond))
+	if len(grants) != 1 {
+		t.Fatalf("header-granted transmission produced %d grants, want 1", len(grants))
+	}
+	if c.Counters().LateEntries != 0 {
+		t.Errorf("LateEntries = %d on a header-granted call, want 0", c.Counters().LateEntries)
+	}
+	if c.Counters().FECPass != 4 {
+		t.Errorf("FECPass = %d, want 4 (one per header burst)", c.Counters().FECPass)
+	}
+}
+
+// TestConventionalLateEntryHonoursColorCodeFilter pins that the IPSC
+// colour-code filter still applies to a header-less transmission: the
+// majority EMB colour code of the LC-bearing bursts is what gets filtered.
+func TestConventionalLateEntryHonoursColorCodeFilter(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	want := uint8(12)
+	c := New(Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 1, InterleavedVoice: true, ColorCodeFilter: &want})
+
+	feedChunks(c, outboundTransmission(t, groupLC(11, 199), 7, 0, 4, 0), 1000)
+	if n := len(grantsOf(drainEvents(sub, 50*time.Millisecond))); n != 0 {
+		t.Fatalf("colour-code 7 transmission late-entered %d call(s) through a cc=12 filter", n)
+	}
+	if c.Counters().DroppedOffCC == 0 {
+		t.Error("off-colour embedded LCs were not counted as DroppedOffCC")
+	}
+}
+
+// TestConventionalCSBKFailureLogIsParked pins the log parking for the
+// field-reported "CSBK CRC mismatch" storm: a keyed idle IPSC repeater put
+// one identical Debug line on the log every 30 ms. Now the first failure
+// logs once (with the decoded header + info hex for diagnosis), unchanged
+// repeats within csbkFailLogInterval are suppressed and summarised, and the
+// counter keeps the exact count.
+func TestConventionalCSBKFailureLogIsParked(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	bus := events.NewBus(8)
+	defer bus.Close()
+	clock := time.Unix(1_700_000_000, 0)
+	c := New(Options{Bus: bus, Log: log, SystemName: "ipsc", FrequencyHz: 1,
+		Now: func() time.Time { return clock }})
+
+	// A CSBK-shaped block whose CRC does not check (bytes from a Motorola-FID
+	// looking header, trailer deliberately wrong).
+	info := tier3.AssembleCSBK(tier3.CSBK{LB: true, Opcode: 0x3E, FID: 0x10})
+	info[11] ^= 0xFF
+	b := burstWithInfo96(info)
+	slot := dmr.SlotType{ColorCode: 7, DataType: dmr.DTCSBK}
+	for i := 0; i < 100; i++ {
+		c.IngestBurst(b, slot)
+		clock = clock.Add(30 * time.Millisecond)
+	}
+	lines := strings.Count(buf.String(), "CSBK CRC mismatch")
+	if lines != 1 {
+		t.Fatalf("100 identical CSBK CRC failures in 3 s logged %d lines, want 1 (parked)\n%s", lines, buf.String())
+	}
+	if !strings.Contains(buf.String(), "csbko=0x3e") || !strings.Contains(buf.String(), "fid=0x10") || !strings.Contains(buf.String(), "info_hex=") {
+		t.Errorf("parked CSBK failure line lacks the diagnostic header/info fields:\n%s", buf.String())
+	}
+	if got := c.Counters().CSBKCRCFail; got != 100 {
+		t.Errorf("CSBKCRCFail = %d, want 100", got)
+	}
+	// Past the interval the summary carries the suppressed count.
+	clock = clock.Add(csbkFailLogInterval)
+	c.IngestBurst(b, slot)
+	if !strings.Contains(buf.String(), "suppressed_repeats=99") {
+		t.Errorf("summary line after the interval lacks suppressed_repeats=99:\n%s", buf.String())
+	}
+}
+
+// TestConventionalVoiceBurstCannotForgeTerminator pins the root cause of the
+// 9 Sep "false call ended" report. A voice burst A carries the BS-Voice sync
+// with AMBE bits in the slot-type positions; when those bits happen to form a
+// Golay(20,8) codeword reading Terminator-with-LC, the old slicer parsed it and
+// the single-call fallback ("LC undecodable but only one call active") ended
+// the live call mid-transmission — measured on the operator's capture as a
+// terminator six bursts before the next voice superframe of the same over.
+// Slot types must only be read from data-sync bursts, and an undecodable
+// terminator must at least be a BPTC codeword to end a call.
+func TestConventionalVoiceBurstCannotForgeTerminator(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	c := New(Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 1, InterleavedVoice: true})
+
+	lc := groupLC(11, 199)
+	frags := lcFragmentsFor(t, lc)
+	cach := make([]uint8, 12)
+	var s []uint8
+	weave := func(slotA []uint8) {
+		s = append(s, cach...)
+		s = append(s, slotA...)
+		s = append(s, cach...)
+		s = append(s, idleBurstDibits(12)...)
+	}
+	hdr := burstWithFLC(lc)
+	stampSlotType(hdr, 12, dmr.DTVoiceLCHeader)
+	weave(hdr.Dibits[:])
+	// Forged terminator slot type: the AMBE bits around burst A's voice sync
+	// happen to spell (cc=12, TerminatorWithLC).
+	forged := dmr.AssembleSlotType(dmr.SlotType{ColorCode: 12, DataType: dmr.DTTerminatorWithLC})
+	seed := 0
+	for sf := 0; sf < 3; sf++ {
+		for b := 0; b < dmrvoice.BurstsPerSuperframe; b++ {
+			sync := dmr.BSVoice.Dibits
+			if b >= 1 && b <= 4 {
+				sync = embeddedSyncField(dmr.EMB{ColorCode: 12, LCSS: lcssFor(b)}, frags[b-1])
+			} else if b == 5 {
+				sync = embeddedSyncField(dmr.EMB{ColorCode: 12, LCSS: dmr.LCSSSingle}, make([]byte, 32))
+			}
+			burst := voiceBurstDibits(seed, sync)
+			if b == 0 {
+				for i := 0; i < 5; i++ {
+					burst[dmr.HalfPayloadDibits+i] = (forged[2*i] << 1) | forged[2*i+1]
+					burst[dmr.HalfPayloadDibits+dmr.SlotTypeDibits+dmr.SyncDibits+i] = (forged[10+2*i] << 1) | forged[10+2*i+1]
+				}
+			}
+			weave(burst)
+			seed++
+		}
+	}
+	for i := 0; i < 8; i++ {
+		weave(idleBurstDibits(12))
+	}
+	feedChunks(c, s, 1000)
+
+	evs := drainEvents(sub, 100*time.Millisecond)
+	if n := len(grantsOf(evs)); n != 1 {
+		t.Fatalf("got %d grants, want 1", n)
+	}
+	for _, ev := range evs {
+		if ev.Kind == events.KindCallRelease {
+			t.Fatalf("a voice burst whose AMBE bits spell a Terminator slot type released the live call: %+v", ev.Payload)
+		}
+	}
+	if len(c.calls) != 1 {
+		t.Fatalf("call was dropped from tracking by the forged terminator")
+	}
+}
+
+// TestConventionalUndecodableTerminatorNeedsBPTC pins the hardened fallback:
+// with one active call, a burst whose slot type says Terminator but whose
+// payload is not a BPTC codeword does not end the call; one whose BPTC
+// decodes but RS mismatches (a weak real terminator) still does.
+func TestConventionalUndecodableTerminatorNeedsBPTC(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	c := New(Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 1})
+	lc := groupLC(11, 199)
+	c.IngestBurst(burstWithFLC(lc), dmr.SlotType{ColorCode: 12, DataType: dmr.DTVoiceLCHeader})
+
+	var garbage dmr.Burst
+	for i := range garbage.Dibits {
+		garbage.Dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	c.IngestBurst(&garbage, dmr.SlotType{ColorCode: 12, DataType: dmr.DTTerminatorWithLC})
+	for _, ev := range drainEvents(sub, 50*time.Millisecond) {
+		if ev.Kind == events.KindCallRelease {
+			t.Fatalf("non-BPTC garbage with a Terminator slot type released the call")
+		}
+	}
+
+	// BPTC-valid, RS-mismatching terminator (wrong seed): still releases.
+	weak := burstWithFLC(lc) // Voice LC Header seed ≠ terminator seed ⇒ RS fails
+	c.IngestBurst(weak, dmr.SlotType{ColorCode: 12, DataType: dmr.DTTerminatorWithLC})
+	released := false
+	for _, ev := range drainEvents(sub, 50*time.Millisecond) {
+		if ev.Kind == events.KindCallRelease {
+			released = true
+		}
+	}
+	if !released {
+		t.Fatal("BPTC-valid terminator with an RS mismatch did not release the single active call")
+	}
+}

--- a/internal/radio/dmr/tier2/process.go
+++ b/internal/radio/dmr/tier2/process.go
@@ -2,6 +2,7 @@ package tier2
 
 import (
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
 )
 
 // burstLookback is the number of dibits the burst extends BEFORE the
@@ -52,6 +53,16 @@ func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 		c.proc = &processState{
 			det: dmr.NewSyncDetector(c.syncPatterns, 2),
 		}
+		// Late entry (see ConventionalChannel.voice): the embedded-LC
+		// assembler runs beside the burst slicer on the same dibits. A
+		// base-station carrier interleaves two timeslots, so the interleaved
+		// decoder is used whenever the system decodes interleaved voice;
+		// direct mode (Tier I) is genuinely single-slot.
+		if c.interleavedVoice {
+			c.voice = dmrvoice.NewInterleavedDecoder()
+		} else {
+			c.voice = dmrvoice.NewDecoder()
+		}
 	}
 	p := c.proc
 
@@ -63,6 +74,25 @@ func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 	matches, _ := p.det.Process(nil, dibits, baseIdx)
 	c.cnt.syncHits.Add(uint64(len(matches)))
 	p.pending = append(p.pending, matches...)
+
+	// Late entry: assemble voice superframes and hand every CRC-valid
+	// embedded LC to the state machine. Runs BEFORE the burst pass so the
+	// closing superframes of a transmission (emitted a span behind the
+	// slicer) refresh their still-tracked call rather than trailing its
+	// terminator; the endedAtDibit gate in ingestVoiceSuperframe covers the
+	// chunkings where they still trail it.
+	voiceIn := dibits
+	if c.polarity == int(dmr.PolarityFlip) {
+		// Spectrum-inverted front end: undo the flip for the voice assembler
+		// (its voice syncs and AMBE bits are canonical-polarity).
+		voiceIn = make([]uint8, len(dibits))
+		for i, d := range dibits {
+			voiceIn[i] = (d + dmr.PolarityFlip) & 3
+		}
+	}
+	for _, sf := range c.voice.Process(voiceIn, baseIdx) {
+		c.ingestVoiceSuperframe(sf)
+	}
 
 	bufEnd := p.bufStart + len(p.buf)
 	keep := p.pending[:0]
@@ -81,8 +111,27 @@ func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 		// spectrum-inverted reception (issue #264, RTL-SDR Blog V4 /
 		// R828D); IngestBurst's FEC drops the wrong polarity with no
 		// state change. Identity (k=0) is tried first. Same as the Tier
-		// III adapter.
+		// III adapter — except that once a FEC-valid burst has fixed the
+		// stream's polarity, only that polarity is tried.
+		//
+		// Only DATA-sync bursts carry a slot type. A voice burst A has AMBE
+		// bits in the slot-type positions, and Golay(20,8) decodes ~1/3 of
+		// arbitrary 20-bit words to SOME codeword — so one voice burst A in
+		// ~12 used to parse as a Terminator-with-LC and, through the
+		// single-call fallback, end a live call mid-transmission (the 9 Sep
+		// "false call ended" report; measured on the operator's captures: a
+		// terminator 6 bursts before the next voice superframe of the same
+		// over). Voice bursts are the late-entry assembler's business
+		// (above), never the slot-type path's. Because data and voice syncs
+		// are each other's flip image the check is per polarity; the
+		// polarity lock makes it exact.
 		for _, k := range dmr.CandidatePolarities {
+			if c.polarity >= 0 && uint8(c.polarity) != k {
+				continue
+			}
+			if !dmr.SyncIsDataAtPolarity(m.Pattern, k) {
+				continue
+			}
 			var b dmr.Burst
 			copy(b.Dibits[:], p.buf[offset:offset+dmr.BurstDibits])
 			dmr.RotateBurstDibits(&b, k)
@@ -91,7 +140,15 @@ func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 			if err != nil {
 				continue
 			}
+			c.ingestDibit = burstStart
+			c.burstValid = false
 			c.IngestBurst(&b, slot)
+			c.ingestDibit = -1
+			if c.burstValid && c.polarity < 0 {
+				c.polarity = int(k)
+				c.log.Debug("dmr/tier2: discriminator polarity fixed by first FEC-valid burst",
+					"polarity", k, "sync", m.Pattern.Name)
+			}
 		}
 	}
 	p.pending = keep

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -59,6 +59,16 @@ type VoiceSuperframe struct {
 	// publishes it on the location bus.
 	HasGPS bool
 	GPS    dmr.GPSInfo
+	// HasEMB reports that the EMB headers of bursts B–E carried a colour code
+	// and EMBColorCode is their majority value. The EMB is read systematically
+	// (no QR(16,7) correction), so a single bursts' bit error can flip its
+	// nibble — the majority over the four LC-bearing bursts makes the value
+	// usable as the IPSC colour-code filter's input on a late-entry grant
+	// (voice bursts carry no slot type, so this is the only colour code a
+	// header-less transmission has). Only set when HasLC is true, i.e. the
+	// same four bursts also passed the embedded-LC BPTC + CRC.
+	HasEMB       bool
+	EMBColorCode uint8
 }
 
 // voiceSyncs are the sync words that frame burst A of a voice
@@ -354,6 +364,7 @@ func (d *Decoder) sliceAt(start, step int, syncName string) VoiceSuperframe {
 	// frags maps the four embedded-LC-bearing bursts B,C,D,E (burst
 	// indices 1..4) to their fragment slot 0..3; A and F carry none.
 	var frags [4][]byte
+	var embCC [16]uint8
 	for b := 0; b < BurstsPerSuperframe; b++ {
 		var burst dmr.Burst
 		copy(burst.Dibits[:], d.buf[off+b*step:off+b*step+dmr.BurstDibits])
@@ -364,6 +375,7 @@ func (d *Decoder) sliceAt(start, step int, syncName string) VoiceSuperframe {
 		if b >= 1 && b <= 4 {
 			emb, frag := dmr.SplitEmbeddedField(dibitsToBits(burst.Sync()))
 			frags[b-1] = frag
+			embCC[emb.ColorCode&0x0F]++
 			// A single-fragment (LCSS==Single) embedded field is not part of
 			// the four-fragment Full LC: it carries either a Reverse Channel
 			// word or the null idle. Decode the first RC seen in the
@@ -380,6 +392,8 @@ func (d *Decoder) sliceAt(start, step int, syncName string) VoiceSuperframe {
 	if info, lc, ok := dmr.ReassembleEmbeddedLCInfo(frags); ok {
 		sf.HasLC = true
 		sf.LC = lc
+		sf.HasEMB = true
+		sf.EMBColorCode = majorityColorCode(embCC)
 		// A talker-alias header/block reuses the Full LC framing but its
 		// octets 2..8 are alias text, not the group/source addresses the
 		// generic LC view reads. Surface the parsed fragment so the voice
@@ -405,4 +419,17 @@ func dibitsToBits(dibits []uint8) []byte {
 		out = append(out, (d>>1)&1, d&1)
 	}
 	return out
+}
+
+// majorityColorCode returns the most frequent colour-code nibble among the
+// EMB headers of bursts B–E (ties resolve to the lowest value). Used to
+// stamp VoiceSuperframe.EMBColorCode.
+func majorityColorCode(counts [16]uint8) uint8 {
+	best := uint8(0)
+	for cc := 1; cc < 16; cc++ {
+		if counts[cc] > counts[best] {
+			best = uint8(cc)
+		}
+	}
+	return best
 }

--- a/internal/rfscope/source.go
+++ b/internal/rfscope/source.go
@@ -27,11 +27,16 @@ type Source interface {
 	SampleRateHz() float64
 }
 
-// FileSource streams an on-disk IQ capture (u8/f32) in chunks, decoding through
-// the same siglab.SampleFormat decoders the replay path uses so rfscope and
-// replay read captures identically.
+// FileSource streams an on-disk IQ capture in chunks, decoding through the
+// same siglab.SampleFormat decoders the replay path uses so rfscope and replay
+// read captures identically. Headerless u8/f32/cs16 bodies stream straight
+// from the file; the wav/flac containers are unwrapped (header skipped /
+// FLAC decoded) into the same 16-bit body, with the sample rate taken from
+// the container — an rfscope upload of a SigLab or `capture -format flac`
+// recording no longer needs the operator to retype the rate.
 type FileSource struct {
 	f        *os.File
+	r        io.Reader
 	decode   siglab.SampleDecoder
 	bytesPer int
 	centerHz uint32
@@ -41,17 +46,44 @@ type FileSource struct {
 
 // OpenFile opens an IQ capture for streaming. centerHz/rateHz describe the
 // capture (the segmentation engine stamps absolute frequencies from them).
+// The file content is sniffed for a wav/flac container signature, which
+// overrides format — content decides, never the extension or the label — and
+// a container's own sample rate overrides rateHz; rateHz may then be 0. A
+// headerless format with rateHz <= 0 is an error.
 func OpenFile(path string, format siglab.SampleFormat, centerHz uint32, rateHz float64) (*FileSource, error) {
-	if rateHz <= 0 {
-		return nil, fmt.Errorf("rfscope: sample rate must be positive, got %g", rateHz)
-	}
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("rfscope: open capture: %w", err)
 	}
+	head := make([]byte, 12)
+	n, _ := io.ReadFull(f, head)
+	if sniffed, ok := siglab.SniffContainer(head[:n]); ok {
+		format = sniffed
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("rfscope: rewind capture: %w", err)
+	}
+	var r io.Reader = f
+	if format == siglab.FormatWAV || format == siglab.FormatFLAC {
+		body, bodyFormat, headerRate, err := siglab.UnwrapContainer(f, format)
+		if err != nil {
+			f.Close()
+			return nil, fmt.Errorf("rfscope: %w", err)
+		}
+		r, format = body, bodyFormat
+		if headerRate > 0 {
+			rateHz = float64(headerRate)
+		}
+	}
+	if rateHz <= 0 {
+		f.Close()
+		return nil, fmt.Errorf("rfscope: sample rate must be positive, got %g", rateHz)
+	}
 	decode, bytesPer := format.Decoder()
 	return &FileSource{
 		f:        f,
+		r:        r,
 		decode:   decode,
 		bytesPer: bytesPer,
 		centerHz: centerHz,
@@ -76,7 +108,7 @@ func (s *FileSource) Next(ctx context.Context, n int) ([]complex64, error) {
 		s.rbuf = make([]byte, want)
 	}
 	buf := s.rbuf[:want]
-	got, err := io.ReadFull(s.f, buf)
+	got, err := io.ReadFull(s.r, buf)
 	switch {
 	case err == nil:
 		// full read

--- a/internal/rfscope/source_test.go
+++ b/internal/rfscope/source_test.go
@@ -113,3 +113,96 @@ func TestSourceContextCancel(t *testing.T) {
 		t.Fatalf("want context error")
 	}
 }
+
+// TestFileSourceContainers pins that rfscope reads the wav and flac IQ
+// containers the rest of GT writes (SigLab capture-from-tuner, `capture
+// -format flac`): the body decodes to the same samples as the headerless cs16
+// twin, the sample rate comes from the container header (rateHz 0 is fine),
+// and the container is sniffed from CONTENT — a flac uploaded under the
+// "cs16" label (the reporter's ".cs16.raw" habit) still decodes.
+func TestFileSourceContainers(t *testing.T) {
+	t.Parallel()
+	const n = 4000
+	iq := makeIQ(n)
+	dir := t.TempDir()
+
+	rawPath := filepath.Join(dir, "cap.cs16")
+	if err := os.WriteFile(rawPath, siglab.EncodeCapture(iq, siglab.FormatS16), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := readAll(t, rawPath, siglab.FormatS16, 25_000)
+
+	for _, tc := range []struct {
+		name    string
+		format  siglab.SampleFormat
+		declare siglab.SampleFormat
+		rate    float64
+	}{
+		{"wav declared", siglab.FormatWAV, siglab.FormatWAV, 0},
+		{"flac declared", siglab.FormatFLAC, siglab.FormatFLAC, 0},
+		{"flac sniffed behind cs16 label", siglab.FormatFLAC, siglab.FormatS16, 0},
+		{"wav sniffed behind f32 label, bogus rate overridden", siglab.FormatWAV, siglab.FormatF32, 999},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".bin")
+			f, err := os.Create(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cont, err := siglab.NewIQContainer(f, tc.format, 25_000)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cont.Write(iq); err != nil {
+				t.Fatal(err)
+			}
+			if err := cont.Finalize(); err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+
+			src, err := OpenFile(path, tc.declare, 1, tc.rate)
+			if err != nil {
+				t.Fatalf("OpenFile: %v", err)
+			}
+			defer src.Close()
+			if src.SampleRateHz() != 25_000 {
+				t.Fatalf("rate = %g, want 25000 from the container header", src.SampleRateHz())
+			}
+			got := drain(t, src)
+			if len(got) != len(want) {
+				t.Fatalf("samples: got %d want %d", len(got), len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("sample %d: got %v want %v (container body differs from cs16 twin)", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func readAll(t *testing.T, path string, format siglab.SampleFormat, rate float64) []complex64 {
+	t.Helper()
+	src, err := OpenFile(path, format, 1, rate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	return drain(t, src)
+}
+
+func drain(t *testing.T, src *FileSource) []complex64 {
+	t.Helper()
+	var got []complex64
+	for {
+		c, err := src.Next(context.Background(), 1000)
+		got = append(got, c...)
+		if err == io.EOF {
+			return got
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+}

--- a/internal/rfscope/webserver/server.go
+++ b/internal/rfscope/webserver/server.go
@@ -139,7 +139,7 @@ func (s *Server) handleAnalyzers(w http.ResponseWriter, _ *http.Request) {
 	for _, a := range rfscope.Analyzers() {
 		out = append(out, analyzerDTO{Name: a.Name(), Synopsis: a.Synopsis(), DependsOn: a.DependsOn()})
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"analyzers": out, "formats": []string{"u8", "f32"}})
+	writeJSON(w, http.StatusOK, map[string]any{"analyzers": out, "formats": []string{"u8", "f32", "cs16", "wav", "flac"}})
 }
 
 // analyzeResponse is the body of a successful analyze: the Scene plus the
@@ -169,8 +169,11 @@ func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rate, _ := strconv.ParseFloat(r.FormValue("sample_rate_hz"), 64)
-	if rate <= 0 {
-		writeErr(w, http.StatusBadRequest, "rfscope: sample_rate_hz is required")
+	// A wav/flac container carries its own rate (OpenFile reads it, and also
+	// sniffs a container behind a headerless label); headerless formats need
+	// the field.
+	if rate <= 0 && format != siglab.FormatWAV && format != siglab.FormatFLAC {
+		writeErr(w, http.StatusBadRequest, "rfscope: sample_rate_hz is required for a headerless (u8/f32/cs16) capture")
 		return
 	}
 	freq64, _ := strconv.ParseUint(r.FormValue("freq"), 10, 32)

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -1411,6 +1411,8 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 						"fec_pass", c.FECPass-ec.lastLogCnt.FECPass,
 						"fec_fail", c.FECFail-ec.lastLogCnt.FECFail,
 						"beacons", c.Beacons-ec.lastLogCnt.Beacons,
+						"late_entries", c.LateEntries-ec.lastLogCnt.LateEntries,
+						"csbk_crc_fail", c.CSBKCRCFail-ec.lastLogCnt.CSBKCRCFail,
 						"locks_total", c.Locks)
 					ec.activityLogAt = now
 					ec.activityCls = cls

--- a/internal/siglab/container.go
+++ b/internal/siglab/container.go
@@ -184,6 +184,45 @@ func (fr *flacSW16Reader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// SniffContainer inspects the first bytes of an IQ file and reports whether
+// they carry a container signature: FormatFLAC for the "fLaC" stream marker,
+// FormatWAV for a RIFF/WAVE header. ok=false means headerless (or too short
+// to tell) — the caller's declared format then stands. Content decides, never
+// the extension: an operator's ".cs16.raw" that is really a FLAC (or a
+// ".flac" that is a headerless raw) decodes by what is in it.
+func SniffContainer(head []byte) (SampleFormat, bool) {
+	switch {
+	case len(head) >= 4 && string(head[0:4]) == "fLaC":
+		return FormatFLAC, true
+	case len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "WAVE":
+		return FormatWAV, true
+	}
+	return FormatU8, false
+}
+
+// UnwrapContainer turns a wav/flac IQ stream into the headerless sw16 body
+// the plain FormatS16 decoder reads, returning the body reader, the format
+// to decode it with, and the container's sample rate (0 for a headerless
+// format, which is passed through untouched with rate 0).
+func UnwrapContainer(r io.Reader, format SampleFormat) (io.Reader, SampleFormat, uint32, error) {
+	switch format {
+	case FormatWAV:
+		info, err := baseband.ReadIQWavStreamHeader(r)
+		if err != nil {
+			return nil, format, 0, err
+		}
+		return r, FormatS16, info.SampleRate, nil
+	case FormatFLAC:
+		fr, rate, err := newFLACSW16Reader(r)
+		if err != nil {
+			return nil, format, 0, err
+		}
+		return fr, FormatS16, rate, nil
+	default:
+		return r, format, 0, nil
+	}
+}
+
 // DecodeContainerFile reads a wav or flac IQ capture (as written by
 // IQContainer) back to complex64 samples plus the container's sample rate,
 // sniffing the container from the file content. Small-file convenience for

--- a/internal/siglab/fixtures.go
+++ b/internal/siglab/fixtures.go
@@ -86,7 +86,11 @@ var fixtures = map[trunking.Protocol]fixture{
 	},
 	trunking.ProtocolDMRTier1: {
 		build: func() []uint8 {
-			return buildDMRConventionalVoiceLCHeaderDibits(80, 0x7, 0x123, 0x456789, dmr.DMVoice1.Dibits[:])
+			// A Voice LC Header is a DATA burst: in direct mode it is framed by the
+			// DM data sync (ETSI TS 102 361-1 Table 9.1), never the DM voice sync.
+			// The fixture used DMVoice1 and only passed because the slicer once
+			// parsed a slot type on every sync match (the self-consistent trap).
+			return buildDMRConventionalVoiceLCHeaderDibits(80, 0x7, 0x123, 0x456789, dmr.DMData1.Dibits[:])
 		},
 		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1944.0) },
 		sampleRate: 48_000,
@@ -270,7 +274,7 @@ func buildP25Phase2MACPTTStream(repeats int) []uint8 {
 // repeated Voice LC Header bursts. Lifted from integration_cc_dmr_tier2_test.go.
 // buildDMRConventionalVoiceLCHeaderDibits builds a DMR conventional /
 // direct-mode Voice LC Header stream. The sync word distinguishes Tier II
-// (base-station, dmr.BSData) from Tier I (direct-mode, dmr.DMVoice1); the rest
+// (base-station, dmr.BSData) from Tier I (direct-mode, dmr.DMData1); the rest
 // of the wire format is identical. Lifted from integration_cc_dmr_tier2_test.go.
 func buildDMRConventionalVoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sourceID uint32, sync []uint8) []uint8 {
 	flc := dmr.FLC{

--- a/web/rfscope/src/App.tsx
+++ b/web/rfscope/src/App.tsx
@@ -77,11 +77,19 @@ export function App() {
           <select className="input" value={format} onChange={(e) => setFormat(e.target.value)}>
             <option value="f32">f32 (cfile)</option>
             <option value="u8">u8 (rtl_sdr)</option>
+            <option value="cs16">cs16 (16-bit raw .cs16/.raw)</option>
+            <option value="wav">wav (baseband WAV, rate from header)</option>
+            <option value="flac">flac (compressed cs16, rate from header)</option>
           </select>
         </div>
         <div>
           <label className="label">Sample rate (Hz)</label>
-          <input className="input" value={sampleRate} onChange={(e) => setSampleRate(e.target.value)} />
+          <input
+            className="input"
+            value={sampleRate}
+            onChange={(e) => setSampleRate(e.target.value)}
+            title="Ignored for wav/flac uploads — the container header carries the rate"
+          />
         </div>
         <div>
           <label className="label">Center (Hz)</label>

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -336,6 +336,9 @@ export interface ProtocolsDTO {
   protocols: string[];
   fixtures: string[];
   formats: string[];
+  /** Formats the capture-from-tuner route accepts: `formats` plus the wav/flac
+   * containers. Optional so an older daemon still drives the panel. */
+  capture_formats?: string[];
 }
 
 // CaptureDevice mirrors api.SpectrumDevice — an SDR available to record from.

--- a/web/siglab/src/panels/Captures.tsx
+++ b/web/siglab/src/panels/Captures.tsx
@@ -119,7 +119,7 @@ function UploadForm() {
 function CaptureForm() {
   const config = useStore((s) => s.config);
   const captureFromTuner = useStore((s) => s.captureFromTuner);
-  const formats = useStore((s) => s.formats);
+  const formats = useStore((s) => s.captureFormats);
   const protocols = useStore((s) => s.protocols);
 
   const [devices, setDevices] = useState<CaptureDevice[] | null>(null);
@@ -256,7 +256,8 @@ function CaptureForm() {
       <p className="text-xs text-muted">
         Set a bandwidth to save a small narrowband slice around the centre (carved from the
         tuner&rsquo;s current span, no retune). Leave blank for a full-band grab. cs16 = 16-bit raw
-        (half the size of f32).
+        (half the size of f32); wav = cs16 in a RIFF container; flac = losslessly compressed cs16
+        (typically 30&ndash;50% smaller, replays and decodes like cs16).
       </p>
       <button className="btn" disabled={busy || !serial} onClick={onCapture}>
         {busy ? "Capturing…" : "Capture"}

--- a/web/siglab/src/store/shared.ts
+++ b/web/siglab/src/store/shared.ts
@@ -35,6 +35,8 @@ interface Store {
   protocols: string[];
   fixtures: string[];
   formats: string[];
+  /** Formats offered by the capture-from-tuner panel (formats + wav/flac). */
+  captureFormats: string[];
   loadProtocols: () => Promise<void>;
 
   captures: CaptureDTO[];
@@ -63,9 +65,17 @@ export const useStore = create<Store>((set, get) => ({
   protocols: [],
   fixtures: [],
   formats: ["u8", "f32", "cs16"],
+  captureFormats: ["u8", "f32", "cs16", "wav", "flac"],
   loadProtocols: async () => {
     const p = await api.protocols(get().config);
-    set({ protocols: p.protocols, fixtures: p.fixtures, formats: p.formats });
+    set({
+      protocols: p.protocols,
+      fixtures: p.fixtures,
+      formats: p.formats,
+      // An older daemon omits capture_formats; the tuner route has accepted
+      // wav/flac since the IQContainer landed, so fall back to formats + both.
+      captureFormats: p.capture_formats ?? [...p.formats, "wav", "flac"],
+    });
   },
 
   captures: [],


### PR DESCRIPTION
Conventional DMR (IPSC) "false call ended" field report, root-caused on the
operator's own 25 kS/s captures:

- The Tier II slicer parsed a slot type on EVERY sync match, but only data
  bursts carry one. A voice burst A has AMBE bits in the slot-type positions
  and Golay(20,8) decodes ~1/3 of arbitrary words, so ~1 voice burst A in 12
  read as Terminator-with-LC; the single-call fallback then ended the live
  call mid-transmission (measured: a terminator 6 bursts before the next
  voice superframe of the same over). Slot types are now read only from
  data-sync bursts, per polarity (data/voice syncs are each other's flip
  image), with the stream polarity locked by the first FEC-valid burst; the
  undecodable-terminator fallback now needs a BPTC-valid payload.
- Late entry: the channel runs the voice superframe assembler beside the
  slicer and grants from two agreeing CRC-valid embedded LCs when a
  transmission's Voice LC Headers were lost, gated so the closing superframes
  of a just-terminated call cannot re-grant it, and honouring the IPSC
  colour-code filter via the superframe's majority EMB colour code.
  Capture-verified: with every header scrubbed (GT_DMR_DROP_HEADERS=1 in
  TestDMRIPSCReplay) all 5/5 transmissions are still granted.
- The CSBK-failure Debug log is parked (first + 10 s summary) and carries
  csbko/fid/lb/pf + info hex; csbk_crc_fail / late_entries join the wideband
  activity line.
- Tier I synthetic fixtures framed a Voice LC Header with the DM voice sync
  and only passed because of the old parse-everything slicer; fixed.

RF Scope accepts cs16, wav and flac (containers sniffed from content, rate
from the header); SigLab's capture-from-tuner select offers wav/flac.

Refs #1036

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0115WzfMsgCjFPDjVBuAucs4