### PR TITLE
docs: update the Discord invite to the permanent link (#1168)

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -374,7 +374,7 @@ groups:
 
 external:
   - title: Discord
-    url: https://discord.gg/fB77PQA4yk
+    url: https://discord.gg/hZG4XUHpeG
     icon: discord
   - title: Reddit
     url: https://www.reddit.com/r/GopherTrunk

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -13,7 +13,7 @@
     <div class="site-footer__col">
       <h2 class="site-footer__heading">Community</h2>
       <ul>
-        <li><a href="https://discord.gg/fB77PQA4yk" rel="noopener">Discord</a></li>
+        <li><a href="https://discord.gg/hZG4XUHpeG" rel="noopener">Discord</a></li>
         <li><a href="https://www.reddit.com/r/GopherTrunk" rel="noopener">Reddit — r/GopherTrunk</a></li>
         <li><a href="https://github.com/sponsors/MattCheramie" rel="noopener">GitHub Sponsors</a></li>
         <li><a href="https://ko-fi.com/Mrcheramie" rel="noopener">Ko-fi</a></li>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -83,7 +83,7 @@ consolidate with jekyll-seo-tag's WebSite node rather than duplicate it.
       "sameAs": [
         "https://github.com/MattCheramie/GopherTrunk",
         "https://www.reddit.com/r/GopherTrunk",
-        "https://discord.gg/fB77PQA4yk"
+        "https://discord.gg/hZG4XUHpeG"
       ]
     },
     {

--- a/docs/_includes/join-cta.html
+++ b/docs/_includes/join-cta.html
@@ -17,7 +17,7 @@
         {% include icons/forum.svg %}
         <span>Visit the Forum</span>
       </a>
-      <a class="btn btn--discord" href="https://discord.gg/fB77PQA4yk" rel="noopener" data-cta-event="cta_join_discord">
+      <a class="btn btn--discord" href="https://discord.gg/hZG4XUHpeG" rel="noopener" data-cta-event="cta_join_discord">
         {% include icons/discord.svg %}
         <span>Join the Discord</span>
       </a>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -22,7 +22,7 @@ layout: default
             {% include icons/forum.svg %}
             <span>Visit the Forum</span>
           </a>
-          <a class="btn btn--discord" href="https://discord.gg/fB77PQA4yk" rel="noopener">
+          <a class="btn btn--discord" href="https://discord.gg/hZG4XUHpeG" rel="noopener">
             {% include icons/discord.svg %}
             <span>Join the Discord</span>
           </a>

--- a/docs/_posts/2026-05-27-welcome-to-the-gophertrunk-blog.md
+++ b/docs/_posts/2026-05-27-welcome-to-the-gophertrunk-blog.md
@@ -66,4 +66,4 @@ back here whenever you want.
 
 If there's a topic you'd like a deep dive on, open a discussion on
 [GitHub](https://github.com/MattCheramie/GopherTrunk/discussions) or
-say hi on [Discord](https://discord.gg/fB77PQA4yk).
+say hi on [Discord](https://discord.gg/hZG4XUHpeG).

--- a/docs/forum.md
+++ b/docs/forum.md
@@ -11,7 +11,7 @@ hide_ctas: true
 
 Ask questions, share systems and talkgroups, and swap notes with other operators.
 Reading is open to everyone; posting needs a free [account](/account/). Prefer chat?
-The [Discord](https://discord.gg/fB77PQA4yk) and [r/GopherTrunk](https://www.reddit.com/r/GopherTrunk)
+The [Discord](https://discord.gg/hZG4XUHpeG) and [r/GopherTrunk](https://www.reddit.com/r/GopherTrunk)
 are still there too.
 
 <div class="forum" data-forum-list>


### PR DESCRIPTION
## Summary

Update the GopherTrunk Discord invite across the Pages site to the maintainer's permanent link `discord.gg/hZG4XUHpeG`, resolving the expired-invite report (#1168). This supersedes the community-supplied link that was on the site.

## Changes

Swapped the invite URL in all 7 places it occurs:

- `docs/_includes/head.html` — the Organization JSON-LD `sameAs` list
- `docs/_includes/footer.html` — site footer link
- `docs/_includes/join-cta.html` — the "Join the Discord" call-to-action button
- `docs/_layouts/home.html` — home-page hero CTA button
- `docs/_data/nav.yml` — nav data entry
- `docs/forum.md` — the community/forum page
- `docs/_posts/2026-05-27-welcome-to-the-gophertrunk-blog.md` — the welcome post

## Test plan

- [x] `grep` confirms zero stale invite codes remain and all 7 links now point to `hZG4XUHpeG`
- [x] Docs/site-only change — no Go/TS code touched, so `make vet test` is not applicable
- [x] Verified the JSON-LD block in `head.html` stays syntactically valid

## Breaking changes

None — a link-target change on the docs site.

## Linked issues

Refs #1168 — the invite link was provided by the maintainer directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GbXeAjTr6xSFTRtELDmYS

---
_Generated by [Claude Code](https://claude.ai/code/session_014GbXeAjTr6xSFTRtELDmYS)_