### PR TITLE
Fix the 10 Sep user-reported web/recording bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Play recordings by radio ID.** Each recent call in a radio's detail modal
+  that has a recording carries a ▶ button that expands the player inline,
+  plus an "All calls from this radio" link into History, which now accepts
+  a `source_id` filter (form field + `?source_id=` deep link) backed by a new
+  `source_id` query parameter on `GET /api/v1/calls/history`.
 - **dPMR and D-STAR voice now decode to PCM (experimental, unverified on
   air).** Following the NXDN precedent, both protocols gain end-to-end voice
   chains: dPMR anchors on the FS1/FS2 voice syncs, carves each 80 ms frame's
@@ -59,6 +64,38 @@ for tagged releases.
   never require acceptance.
 
 ### Fixed
+- **A multi-over call played only its first over.** In per-transmission
+  grouping (a TETRA talker change rolls the recording file) the recorder
+  announces one `call.complete` PER SEGMENT, each stamped with the over's own
+  start time — which matched no call row, so the call log kept the first
+  segment's file and orphaned the rest: a 30 s call with a 4 s "recording".
+  `call.complete` now also carries the CALL's start (`CallStartedAt`) and a
+  `Segment` index, every file lands in a new `call_recordings` table (swept
+  with its call row), and `GET /api/v1/calls/{id}/audio` concatenates the
+  segments into one WAV with the real inter-over silence restored (capped at
+  1.5 s), degrading to the first file when a segment cannot be decoded
+  (e.g. an MP3 transcode). Rows written before the table keep playing from
+  `recording_path`.
+- **Recording paths kept non-ASCII names.** The recorder's path sanitiser
+  passed only `[A-Za-z0-9._-]`, so a Cyrillic (Greek, CJK, …) talkgroup or
+  radio alias became a directory of underscores
+  (`Депо им.Русакова` → `_______.________`). Letters, digits and combining
+  marks from every script now survive; separators, whitespace, controls and
+  OS/shell metacharacters still map to `_`, and a bare `.`/`..` segment can
+  never traverse.
+- **Web: every timestamp is now the browser's local time.** History (table +
+  detail), Events, the Dashboard digest, Active, Tones, the scanner log and
+  Pagers rendered a raw slice of the daemon's UTC string, so an operator in
+  UTC+3 saw History three hours behind the live activity feed and read it as
+  "history stops updating" — the 00:15 row WAS the 03:15 call. All of them
+  share `formatLocalDateTime` / `formatClock`; Radio IDs' first/last seen
+  are formatted the same way instead of raw RFC3339.
+- **Web: History is live.** It refetches ~1.5 s after every `call.end` in
+  the event feed (so `has_recording` is right on first paint) and polls every
+  30 s while the tab is visible; it used to fetch once per filter change.
+- **Web: the floating audio player covered the table pager.** DataTable now
+  renders Prev/Next above the table as well as below, and the main content
+  keeps bottom clearance for the player at every width (desktop had 1 rem).
 - **Voice-calibration docs described a DSD-FME invocation that cannot work**:
   `dsd-fme -r <call>.raw -o reference.wav` (`-r` reads DSD-FME's cookie-headed
   `.imb`/`.amb` container written by `recordings.mbe_files`, not the flat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1155,6 +1155,30 @@ confirmation before any close-as-completed.
   that one IS in `unpackParams2450`, and needs the mbelib-neo 2450 frame diff. Measure with
   band fractions / centroid / LSD, never by ear alone; the "gt-shipped" WAVs had
   enhance+normalize+warm on top and hid all of this.
+- **10 Sep user-reported batch — five web/recording reports, one root cause each.**
+  (1) "History updates too slow / stops at 00:15 while activity shows 03:15" was the
+  UTC-render bug, not staleness: History/Events/Dashboard/Active/Tones/Scanner sliced
+  the daemon's RFC3339 string (`.replace("T"," ")`), so a UTC+3 operator saw every
+  table 3 h behind the (locally formatted) activity feed. `lib/formatTime.ts`
+  (`formatLocalDateTime`/`formatClock`) is now the ONLY way to render a timestamp —
+  grep for `replace("T", " ")` / `toISOString().slice` before shipping a panel. History
+  also refetches after each `call.end` (+30 s visible-tab poll). (2) "duration 30 s,
+  recording 4 s" = per-transmission segment rolls: the recorder publishes one
+  `CallComplete` PER OVER stamped with the over's own `StartedAt`, and the call log
+  keyed on it — only the first over matched the row, later files were orphaned.
+  `CallComplete.CallStartedAt`/`Segment` + the `call_recordings` table fix the keying;
+  `/calls/{id}/audio` concatenates the segments (`concatRecordingSegments`, inter-over
+  gap restored, capped 1.5 s). Pinned by `TestCallLogAttachesEverySegmentRecording`,
+  `TestCallAudioEndpointPlaysEverySegment`, `TestRecorderSegmentCompleteCarriesCallStart`.
+  The residual "1.7 s audio of a 5.6 s over, 58 frames, audio_pct=31" in the same log is
+  TETRA TCH/S decode yield on a −53 dBFS same-carrier signal (the existing
+  "recording shorter than call span" diagnostic) — RF/decode, not the recorder; do not
+  chase it from the recorder side. (3) Cyrillic recording folders as `_______`: the
+  recorder `sanitize` was `[A-Za-z0-9._-]`; it now keeps Unicode L/M/N categories.
+  (4) The floating AudioPlayer docks bottom-right exactly over DataTable's pager — pager
+  is now rendered top AND bottom, and `AppShell` main keeps `pb-24` at every width.
+  (5) Per-RID playback: `/calls/history?source_id=` + a ▶ per recent call in the RID
+  modal (`RecordingPlayer` inline).
 - **Capture ceilings**: siglab capture-from-tuner 120→1200 s (`maxCaptureSeconds`, byte
   budget 4 GiB estimated at the UNCOMPRESSED decoder width even for flac),
   `diversity_capture_seconds` 120→1200 (`maxDiversityCaptureSeconds`); the REST hunt capture

--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -177,6 +177,12 @@ Fires when the control channel decodes a voice/data channel grant.
 
 > `call.end` is the stream's completion event. `call.complete` also exists but is
 > a passthrough kind; prefer `call.end` for a stable duration/reason.
+>
+> `call.complete` announces one finished recording FILE. A call recorded in
+> per-transmission grouping (one file per over) emits several: each carries
+> its own `StartedAt`/`EndedAt` (the over's span), the call's start in
+> `CallStartedAt`, and a 0-based `Segment` index. `GET /api/v1/calls/{id}/audio`
+> plays every segment of the call back to back.
 
 ### `call.encryption`
 

--- a/docs/radio-ids.md
+++ b/docs/radio-ids.md
@@ -105,7 +105,7 @@ live RIDs.
 | --- | --- | --- | --- |
 | `GET`   | `/api/v1/rids`                  | open           | Merged list (configured ∪ live). |
 | `GET`   | `/api/v1/rids/{id}`             | open           | Single merged row. |
-| `GET`   | `/api/v1/rids/{id}/history`     | open           | `call_log` filtered by `source_id`. Same query params as `/api/v1/calls/history` (`limit`, `only_ended`, `system`). |
+| `GET`   | `/api/v1/rids/{id}/history`     | open           | `call_log` filtered by `source_id`. Same query params as `/api/v1/calls/history` (`limit`, `only_ended`, `system`). `/api/v1/calls/history?source_id={id}` is the equivalent on the main history route (the web History panel's "Source RID" filter / the "All calls from this radio" link). Rows with `has_recording` play via `GET /api/v1/calls/{id}/audio` — the ▶ button beside each recent call in the Radio IDs modal. |
 | `PATCH` | `/api/v1/rids/{id}`             | mutation-gated | Edit alias / description / tag / group / owner / priority / lockout / watch / icon. A radio with no catalogue row is **created**, so a radio seen only over the air can be named without editing a file first. Optional `?system=` scopes the persisted name to one system. |
 | `GET`   | `/api/v1/labels`                | open           | The persisted operator-applied names. `?kind=rid\|talkgroup`, `?system=`. 503 without `storage.path`. |
 | `GET`   | `/api/v1/labels/export`         | open           | Those names as a CSV that loads into `rid_alias_file` / `talkgroup_file`. `?kind=` (required), `?system=`, `?scope=labels\|all`. |

--- a/internal/api/call_audio_segments.go
+++ b/internal/api/call_audio_segments.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// Bounds on the silence restored between two consecutive segment recordings.
+// The recorder drops the dead air between overs (each file holds only decoded
+// speech), so the gap is re-inserted from the segments' own timestamps: the
+// real gap when it is short, capped so a call that idled for a minute between
+// overs does not play a minute of nothing, and a small default when the
+// timestamps cannot be trusted (an unset EndedAt, or overlapping spans).
+const (
+	segmentGapDefault = 250 * time.Millisecond
+	segmentGapMax     = 1500 * time.Millisecond
+)
+
+// concatRecordingSegments decodes every segment (WAV or FLAC, sniffed by
+// content) and returns one WAV holding them back to back in order, with the
+// inter-over silence restored. All segments must share a sample rate (they
+// do: one call, one vocoder). An undecodable segment (e.g. an MP3 transcode)
+// is an error — the caller degrades to serving the first file.
+func concatRecordingSegments(segs []RecordingSegment) ([]byte, error) {
+	if len(segs) == 0 {
+		return nil, errors.New("no segments")
+	}
+	var pcm []int16
+	var rate uint32
+	for i, seg := range segs {
+		samples, sr, err := voice.ReadAudioSamples(seg.Path)
+		if err != nil {
+			return nil, fmt.Errorf("segment %d (%s): %w", seg.Seq, seg.Path, err)
+		}
+		if sr == 0 {
+			return nil, fmt.Errorf("segment %d (%s): zero sample rate", seg.Seq, seg.Path)
+		}
+		if rate == 0 {
+			rate = sr
+		} else if sr != rate {
+			return nil, fmt.Errorf("segment %d (%s): sample rate %d != %d", seg.Seq, seg.Path, sr, rate)
+		}
+		if i > 0 {
+			gap := segmentGap(segs[i-1], seg)
+			pcm = append(pcm, make([]int16, int(gap.Seconds()*float64(rate)))...)
+		}
+		pcm = append(pcm, samples...)
+	}
+	return encodeWAV(pcm, rate), nil
+}
+
+// segmentGap is the silence to insert between prev and next.
+func segmentGap(prev, next RecordingSegment) time.Duration {
+	if prev.EndedAt.IsZero() || next.StartedAt.IsZero() {
+		return segmentGapDefault
+	}
+	gap := next.StartedAt.Sub(prev.EndedAt)
+	if gap < 0 {
+		return segmentGapDefault
+	}
+	if gap > segmentGapMax {
+		return segmentGapMax
+	}
+	return gap
+}
+
+// encodeWAV renders 16-bit mono PCM as a canonical 44-byte-header WAV.
+func encodeWAV(pcm []int16, rate uint32) []byte {
+	data := len(pcm) * 2
+	buf := make([]byte, 44+data)
+	le := binary.LittleEndian
+	copy(buf[0:], "RIFF")
+	le.PutUint32(buf[4:], uint32(36+data))
+	copy(buf[8:], "WAVE")
+	copy(buf[12:], "fmt ")
+	le.PutUint32(buf[16:], 16)
+	le.PutUint16(buf[20:], 1) // PCM
+	le.PutUint16(buf[22:], 1) // mono
+	le.PutUint32(buf[24:], rate)
+	le.PutUint32(buf[28:], rate*2)
+	le.PutUint16(buf[32:], 2)
+	le.PutUint16(buf[34:], 16)
+	copy(buf[36:], "data")
+	le.PutUint32(buf[40:], uint32(data))
+	for i, s := range pcm {
+		le.PutUint16(buf[44+2*i:], uint16(s))
+	}
+	return buf
+}

--- a/internal/api/call_audio_segments_test.go
+++ b/internal/api/call_audio_segments_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// writeTestWAV writes n samples of a constant value at rate to path.
+func writeTestWAV(t *testing.T, path string, rate uint32, n int, value int16) {
+	t.Helper()
+	w, err := voice.NewWavFile(path, rate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pcm := make([]int16, n)
+	for i := range pcm {
+		pcm[i] = value
+	}
+	if err := w.WriteSamples(pcm); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCallAudioEndpointPlaysEverySegment pins the multi-over playback fix:
+// a call recorded in per-transmission grouping has one file per over, and
+// /calls/{id}/audio used to serve only the row's single path — the first
+// over — so a 30 s call played 4 s. Now every segment is concatenated in order
+// with the real inter-over silence restored.
+func TestCallAudioEndpointPlaysEverySegment(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	db, err := storage.Open(filepath.Join(t.TempDir(), "calls.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	cl, err := storage.NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	const rate = 8000
+	dir := t.TempDir()
+	seg0 := filepath.Join(dir, "over1.wav")
+	seg1 := filepath.Join(dir, "over2.wav")
+	writeTestWAV(t, seg0, rate, 4*rate, 1000)  // talker A: 4 s
+	writeTestWAV(t, seg1, rate, 3*rate, -1000) // talker B: 3 s
+
+	callStart := time.Now().UTC().Truncate(time.Microsecond)
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "250_013", Protocol: "tetra", GroupID: 1020545, FrequencyHz: 467_912_500},
+		DeviceSerial: "cc:same-carrier:1",
+		StartedAt:    callStart,
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	// Over 1 spans the call start → +6 s; over 2 starts 0.5 s after it ends.
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: cs.Grant, DeviceSerial: cs.DeviceSerial,
+		StartedAt: callStart, EndedAt: callStart.Add(6 * time.Second),
+		CallStartedAt: callStart, Segment: 0, AudioPath: seg0,
+	}})
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: cs.Grant, DeviceSerial: cs.DeviceSerial,
+		StartedAt: callStart.Add(6500 * time.Millisecond), EndedAt: callStart.Add(30 * time.Second),
+		CallStartedAt: callStart, Segment: 1, AudioPath: seg1,
+	}})
+
+	var id int64
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rows, _ := db.History(context.Background(), storage.HistoryFilter{Limit: 1})
+		if len(rows) == 1 && rows[0].HasRecording {
+			if segs, _ := db.RecordingSegmentsByID(context.Background(), rows[0].ID); len(segs) == 2 {
+				id = rows[0].ID
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if id == 0 {
+		t.Fatal("setup: the two segments never attached to the call row")
+	}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, History: HistoryFromStorage(db)})
+	defer teardown()
+	resp := mustGet(t, base+"/api/v1/calls/"+strconv.FormatInt(id, 10)+"/audio")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "audio/wav" {
+		t.Errorf("content-type = %q, want audio/wav", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) < 44 || string(body[:4]) != "RIFF" || string(body[8:12]) != "WAVE" {
+		t.Fatalf("body is not a WAV (%d bytes)", len(body))
+	}
+	if got := binary.LittleEndian.Uint32(body[24:]); got != rate {
+		t.Errorf("sample rate = %d, want %d", got, rate)
+	}
+	dataLen := int(binary.LittleEndian.Uint32(body[40:]))
+	samples := dataLen / 2
+	// 4 s + 0.5 s restored gap + 3 s. The old handler served over 1 alone (4 s).
+	want := 4*rate + rate/2 + 3*rate
+	if samples != want {
+		t.Fatalf("samples = %d (%.2f s), want %d (%.2f s): every over must play",
+			samples, float64(samples)/rate, want, float64(want)/rate)
+	}
+	pcm := body[44:]
+	at := func(sec float64) int16 {
+		return int16(binary.LittleEndian.Uint16(pcm[2*int(sec*rate):]))
+	}
+	if v := at(2); v != 1000 {
+		t.Errorf("t=2s sample = %d, want talker A (1000)", v)
+	}
+	if v := at(4.25); v != 0 {
+		t.Errorf("t=4.25s sample = %d, want restored silence (0)", v)
+	}
+	if v := at(6); v != -1000 {
+		t.Errorf("t=6s sample = %d, want talker B (-1000)", v)
+	}
+}
+
+// TestSegmentGapIsBounded: the restored inter-over silence follows the
+// segments' own timestamps, falls back to a small default when they are
+// missing or overlap, and is capped so a long idle never plays as dead air.
+func TestSegmentGapIsBounded(t *testing.T) {
+	t0 := time.Date(2026, 9, 10, 0, 15, 18, 0, time.UTC)
+	seg := func(start, end time.Duration) RecordingSegment {
+		s := RecordingSegment{StartedAt: t0.Add(start)}
+		if end >= 0 {
+			s.EndedAt = t0.Add(end)
+		}
+		return s
+	}
+	cases := []struct {
+		name       string
+		prev, next RecordingSegment
+		want       time.Duration
+	}{
+		{"real short gap", seg(0, 6*time.Second), seg(6500*time.Millisecond, 30*time.Second), 500 * time.Millisecond},
+		{"long idle capped", seg(0, 6*time.Second), seg(66*time.Second, 90*time.Second), segmentGapMax},
+		{"unset ended_at", seg(0, -1), seg(6*time.Second, 30*time.Second), segmentGapDefault},
+		{"overlapping spans", seg(0, 6*time.Second), seg(5*time.Second, 30*time.Second), segmentGapDefault},
+		{"back to back", seg(0, 6*time.Second), seg(6*time.Second, 30*time.Second), 0},
+	}
+	for _, c := range cases {
+		if got := segmentGap(c.prev, c.next); got != c.want {
+			t.Errorf("%s: gap = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -330,6 +332,17 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 		}
 		f.GroupID = uint32(n)
 	}
+	// source_id narrows to calls FROM one radio (call_log.source_id): the
+	// per-RID view of the call log, so an operator can find and play a radio's
+	// recordings rather than only a talkgroup's.
+	if v := q.Get("source_id"); v != "" {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			s.writeError(w, http.StatusBadRequest, "invalid source_id")
+			return
+		}
+		f.SourceID = uint32(n)
+	}
 	if v := q.Get("since"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
@@ -374,9 +387,17 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 
 // handleCallAudio streams the finished recording for one call so the web UI
 // can play a past transmission (the call-history "play" button). The call id
-// is resolved to a path through the RecordingProvider capability — the
-// filesystem path is never exposed to the client — and the file is served with
-// range support (http.ServeContent) so the browser can seek.
+// is resolved to its file(s) through the RecordingProvider capability — the
+// filesystem path is never exposed to the client — and a single file is served
+// with range support (http.ServeContent) so the browser can seek.
+//
+// A call recorded in per-transmission grouping has one file PER OVER (the
+// recorder rolls the file on a talker change). Serving only the row's single
+// path played the first over and silently dropped the rest — a 30 s call with
+// a 4 s "recording". With a RecordingSegmentsProvider every segment is decoded
+// (WAV or FLAC, content-sniffed) and concatenated into one WAV, with the real
+// silence between overs restored (capped, see concatRecordingSegments) so the
+// talker change is audible and the timeline stays roughly honest.
 //
 //	GET /api/v1/calls/{id}/audio
 func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
@@ -394,36 +415,39 @@ func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "invalid call id")
 		return
 	}
-	path, err := prov.RecordingPathByID(r.Context(), id)
+	segs, err := s.recordingSegments(r.Context(), prov, id)
 	if err != nil {
 		s.log.Warn("api: recording path lookup failed", "err", err, "call", id)
 		s.writeError(w, http.StatusInternalServerError, "recording lookup failed")
 		return
 	}
-	if path == "" {
+	if len(segs) == 0 {
 		s.writeError(w, http.StatusNotFound, "no recording for this call")
 		return
 	}
-	// Rows written while recordings.dir resolved to a relative path (a
-	// relative -config invocation, before config.Load absolutized the resolve
-	// base) store cwd-relative recording paths. The recorder wrote them
-	// relative to the daemon's working directory, so resolving against the
-	// same cwd is exactly what makes the file reachable — without this every
-	// such row 404'd as "unavailable" while the file was on disk.
-	if !filepath.IsAbs(path) {
-		if abs, err := filepath.Abs(path); err == nil {
-			path = abs
+	// Validate every segment's path the same way (see validRecordingPath); a
+	// bad row must never make the endpoint serve a non-recording.
+	for i := range segs {
+		p, ok := validRecordingPath(segs[i].Path)
+		if !ok {
+			s.writeError(w, http.StatusNotFound, "recording unavailable")
+			return
 		}
+		segs[i].Path = p
 	}
-	// The path is daemon-generated, but validate defensively before opening:
-	// an absolute audio file, no traversal, actually a regular file. This keeps
-	// the endpoint from ever serving a non-recording even if the row is bad.
-	ext := strings.ToLower(filepath.Ext(path))
-	if !filepath.IsAbs(path) || strings.Contains(path, "..") ||
-		(ext != ".wav" && ext != ".mp3" && ext != ".flac") {
-		s.writeError(w, http.StatusNotFound, "recording unavailable")
-		return
+	if len(segs) > 1 {
+		wav, err := concatRecordingSegments(segs)
+		if err == nil {
+			w.Header().Set("Content-Type", "audio/wav")
+			http.ServeContent(w, r, "call.wav", time.Time{}, bytes.NewReader(wav))
+			return
+		}
+		// e.g. an MP3-transcoded segment the PCM reader can't decode —
+		// degrade to the first segment rather than 404 a call that has audio.
+		s.log.Warn("api: concatenating segment recordings failed; serving the first segment",
+			"call", id, "segments", len(segs), "err", err)
 	}
+	path := segs[0].Path
 	f, err := os.Open(path)
 	if err != nil {
 		// Retention may have deleted it, or the volume moved.
@@ -436,7 +460,7 @@ func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusNotFound, "recording unavailable")
 		return
 	}
-	switch ext {
+	switch strings.ToLower(filepath.Ext(path)) {
 	case ".mp3":
 		w.Header().Set("Content-Type", "audio/mpeg")
 	case ".flac":
@@ -445,6 +469,42 @@ func (s *Server) handleCallAudio(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "audio/wav")
 	}
 	http.ServeContent(w, r, filepath.Base(path), fi.ModTime(), f)
+}
+
+// recordingSegments resolves a call id to its recording file(s): every segment
+// when the provider can enumerate them, else the row's single path.
+func (s *Server) recordingSegments(ctx context.Context, prov RecordingProvider, id int64) ([]RecordingSegment, error) {
+	if sp, ok := prov.(RecordingSegmentsProvider); ok {
+		return sp.RecordingSegmentsByID(ctx, id)
+	}
+	path, err := prov.RecordingPathByID(ctx, id)
+	if err != nil || path == "" {
+		return nil, err
+	}
+	return []RecordingSegment{{Path: path}}, nil
+}
+
+// validRecordingPath makes a stored recording path absolute and checks it is
+// plausibly a recording before it is opened: an absolute audio file, no
+// traversal, one of the recorder's extensions. Returns the resolved path.
+func validRecordingPath(path string) (string, bool) {
+	// Rows written while recordings.dir resolved to a relative path (a
+	// relative -config invocation, before config.Load absolutized the resolve
+	// base) store cwd-relative recording paths. The recorder wrote them
+	// relative to the daemon's working directory, so resolving against the
+	// same cwd is exactly what makes the file reachable — without this every
+	// such row 404'd as "unavailable" while the file was on disk.
+	if !filepath.IsAbs(path) {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if !filepath.IsAbs(path) || strings.Contains(path, "..") ||
+		(ext != ".wav" && ext != ".mp3" && ext != ".flac") {
+		return "", false
+	}
+	return path, true
 }
 
 // handleListDevices returns the SDR pool snapshot — every opened

--- a/internal/api/history_test.go
+++ b/internal/api/history_test.go
@@ -285,6 +285,7 @@ func TestCallHistoryEndpointRejectsBadParams(t *testing.T) {
 
 	for _, q := range []string{
 		"group_id=abc",
+		"source_id=abc",
 		"since=not-a-date",
 		"until=not-a-date",
 		"limit=-1",
@@ -294,5 +295,65 @@ func TestCallHistoryEndpointRejectsBadParams(t *testing.T) {
 			t.Errorf("%s status = %d, want 400", q, resp.StatusCode)
 		}
 		resp.Body.Close()
+	}
+}
+
+// TestCallHistoryEndpointFiltersBySourceID: ?source_id= narrows the call log
+// to calls FROM one radio — the per-RID view (Radio IDs → "All calls from this
+// radio"), so recordings can be found by who was talking, not only by
+// talkgroup. The parameter used to be silently ignored (HistoryFilter.SourceID
+// existed but the handler never parsed it).
+func TestCallHistoryEndpointFiltersBySourceID(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	db, _ := storage.Open(":memory:")
+	defer db.Close()
+	cl, _ := storage.NewCallLog(db, bus, nil)
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	for i, src := range []uint32{1005492, 1005546, 1005492} {
+		bus.Publish(events.Event{
+			Kind: events.KindCallStart,
+			Payload: trunking.CallStart{
+				Grant:        trunking.Grant{System: "250_013", GroupID: 1020543, SourceID: src, FrequencyHz: 467_912_500},
+				DeviceSerial: "TETRA-" + string(rune('A'+i)),
+				StartedAt:    startedAt.Add(time.Duration(i) * time.Second),
+			},
+		})
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		rows, _ := db.History(context.Background(), storage.HistoryFilter{Limit: 10})
+		if len(rows) == 3 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, History: HistoryFromStorage(db)})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/calls/history?source_id=1005492")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var body struct {
+		Calls []CallRow `json:"calls"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Calls) != 2 {
+		t.Fatalf("source-filtered rows = %d, want 2 (source_id is ignored)", len(body.Calls))
+	}
+	for _, r := range body.Calls {
+		if r.SourceID != 1005492 {
+			t.Errorf("row source_id = %d, want 1005492", r.SourceID)
+		}
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -557,6 +557,25 @@ type RecordingProvider interface {
 	RecordingPathByID(ctx context.Context, id int64) (string, error)
 }
 
+// RecordingSegment is one recording file of a call, in playback order. A call
+// recorded in per-transmission grouping (one file per over — a TETRA talker
+// change rolls the file) has several; a single-file call has one.
+type RecordingSegment struct {
+	Seq       int
+	Path      string
+	StartedAt time.Time
+	EndedAt   time.Time
+}
+
+// RecordingSegmentsProvider is the optional, richer form of RecordingProvider:
+// every recording file of a call rather than the row's single path, so the
+// audio endpoint can play a multi-over call end to end instead of only its
+// first segment (the "30 s call with a 4 s recording" report). A provider
+// without it serves the single RecordingPathByID file as before.
+type RecordingSegmentsProvider interface {
+	RecordingSegmentsByID(ctx context.Context, id int64) ([]RecordingSegment, error)
+}
+
 // LocationFix is one geographic fix returned by GET /api/v1/locations.
 type LocationFix struct {
 	System     string  `json:"system"`

--- a/internal/api/storage_adapter.go
+++ b/internal/api/storage_adapter.go
@@ -141,3 +141,17 @@ func (s *storageHistory) History(ctx context.Context, f HistoryFilter) ([]CallRo
 func (s *storageHistory) RecordingPathByID(ctx context.Context, id int64) (string, error) {
 	return s.db.RecordingPathByID(ctx, id)
 }
+
+// RecordingSegmentsByID delegates to storage.DB so the audio endpoint can play
+// every segment of a multi-over call (RecordingSegmentsProvider).
+func (s *storageHistory) RecordingSegmentsByID(ctx context.Context, id int64) ([]RecordingSegment, error) {
+	segs, err := s.db.RecordingSegmentsByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RecordingSegment, len(segs))
+	for i, seg := range segs {
+		out[i] = RecordingSegment{Seq: seg.Seq, Path: seg.Path, StartedAt: seg.StartedAt, EndedAt: seg.EndedAt}
+	}
+	return out, nil
+}

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -220,21 +220,38 @@ UPDATE call_log
 	return err
 }
 
-// recordComplete stamps the finished recording's path onto the matching call
-// row. Keyed by (device_serial, started_at) exactly like recordEnd. The
-// COALESCE(NULLIF(...)) update keeps an empty path from clobbering a value
-// already written, mirroring the never-downgrade discipline elsewhere in this
-// file. A CallComplete with no matching row (a recording without a persisted
-// call, e.g. replay tooling) updates nothing and is not an error.
+// recordComplete attaches a finished recording file to its call row. Keyed
+// by (device_serial, CALL started_at) — cc.CallStart(), not cc.StartedAt —
+// because a per-transmission segment roll announces each over with its OWN
+// start time, which matched no row: a multi-over call kept only its first
+// segment's recording and every later over was orphaned on disk (the "30 s
+// call with a 4 s recording" report). Every file lands in call_recordings
+// (ordered by segment, deduped on path so a replayed event is harmless), and
+// call_log.recording_path keeps the FIRST file so HasRecording / the legacy
+// single-path readers see the call as recorded. A CallComplete with no
+// matching row (a recording without a persisted call, e.g. replay tooling)
+// attaches nothing and is not an error.
 func (c *CallLog) recordComplete(cc trunking.CallComplete) error {
 	if cc.AudioPath == "" {
 		return nil
 	}
+	callKey := cc.CallStart().UnixNano()
 	const q = `
 UPDATE call_log
-   SET recording_path = COALESCE(NULLIF(?, ''), recording_path)
+   SET recording_path = COALESCE(recording_path, NULLIF(?, ''))
  WHERE device_serial = ? AND started_at = ?`
-	_, err := c.db.sql.Exec(q, cc.AudioPath, cc.DeviceSerial, cc.StartedAt.UnixNano())
+	if _, err := c.db.sql.Exec(q, cc.AudioPath, cc.DeviceSerial, callKey); err != nil {
+		return err
+	}
+	var endedAt any
+	if !cc.EndedAt.IsZero() {
+		endedAt = cc.EndedAt.UnixNano()
+	}
+	const ins = `
+INSERT OR IGNORE INTO call_recordings (call_id, seq, path, started_at, ended_at)
+SELECT id, ?, ?, ?, ? FROM call_log WHERE device_serial = ? AND started_at = ?`
+	_, err := c.db.sql.Exec(ins, cc.Segment, cc.AudioPath, cc.StartedAt.UnixNano(), endedAt,
+		cc.DeviceSerial, callKey)
 	return err
 }
 
@@ -415,6 +432,61 @@ func (d *DB) RecordingPathByID(ctx context.Context, id int64) (string, error) {
 		return "", nil
 	}
 	return p.String, nil
+}
+
+// RecordingSegment is one recording file of a call, in playback order.
+type RecordingSegment struct {
+	// Seq is the 0-based segment index within the call.
+	Seq int
+	// Path is the on-disk recording (WAV/FLAC/MP3 — the container is sniffed
+	// by whoever reads it, never assumed from the extension).
+	Path string
+	// StartedAt / EndedAt bound the audio in this file (EndedAt zero when the
+	// recorder did not report one). The gap between one segment's end and the
+	// next's start is the silence between overs the files do not contain.
+	StartedAt time.Time
+	EndedAt   time.Time
+}
+
+// RecordingSegmentsByID returns every recording file attached to one call, in
+// segment order — several for a call recorded in per-transmission grouping
+// (one file per over), one for a single-file call. Rows written before the
+// call_recordings table existed fall back to call_log.recording_path. nil when
+// the call has no recording or the id is unknown.
+func (d *DB) RecordingSegmentsByID(ctx context.Context, id int64) ([]RecordingSegment, error) {
+	rows, err := d.sql.QueryContext(ctx,
+		`SELECT seq, path, started_at, ended_at FROM call_recordings
+		  WHERE call_id = ? ORDER BY seq, started_at, id`, id)
+	if err != nil {
+		return nil, fmt.Errorf("storage: recording segments for call %d: %w", id, err)
+	}
+	defer rows.Close()
+	var out []RecordingSegment
+	for rows.Next() {
+		var seg RecordingSegment
+		var startNs int64
+		var endNs sql.NullInt64
+		if err := rows.Scan(&seg.Seq, &seg.Path, &startNs, &endNs); err != nil {
+			return nil, err
+		}
+		seg.StartedAt = time.Unix(0, startNs).UTC()
+		if endNs.Valid {
+			seg.EndedAt = time.Unix(0, endNs.Int64).UTC()
+		}
+		out = append(out, seg)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) > 0 {
+		return out, nil
+	}
+	// Pre-table rows: the single path on the call row.
+	p, err := d.RecordingPathByID(ctx, id)
+	if err != nil || p == "" {
+		return nil, err
+	}
+	return []RecordingSegment{{Path: p}}, nil
 }
 
 // RIDSummary is one aggregated per-radio (source_id) row derived from the

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -936,3 +936,129 @@ CREATE TABLE call_log (
 	}
 	db2.Close()
 }
+
+// TestCallLogAttachesEverySegmentRecording pins the multi-over fix: a call
+// recorded in per-transmission grouping announces one KindCallComplete PER
+// SEGMENT, each with its own StartedAt (the over's start, later than the
+// call's). The old recordComplete keyed on that StartedAt, so only the first
+// over matched the call row and every later segment was orphaned — the
+// operator's "duration 30 s, recording 4 s" call. Now every segment lands on
+// the row in order, and the first file stays on recording_path.
+func TestCallLogAttachesEverySegmentRecording(t *testing.T) {
+	db := openTestDB(t)
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cl, err := NewCallLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go cl.Run(ctx)
+
+	callStart := time.Now().UTC().Truncate(time.Microsecond)
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "250_013", Protocol: "tetra", GroupID: 1020545, SourceID: 1005546,
+			FrequencyHz: 467_912_500,
+		},
+		DeviceSerial: "cc:same-carrier:1",
+		StartedAt:    callStart,
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitFor := func(cond func() bool) bool {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if cond() {
+				return true
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return cond()
+	}
+	var id int64
+	if !waitFor(func() bool {
+		rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1})
+		if len(rows) == 1 {
+			id = rows[0].ID
+			return true
+		}
+		return false
+	}) {
+		t.Fatal("call row never landed")
+	}
+
+	// Over 1 (talker A): the file spans the call start → +6 s.
+	const seg0 = "/rec/250_013/Депо_им.Русакова/20260910_031518_1020545.flac"
+	// Over 2 (talker B): a segment roll — StartedAt is the OVER's start.
+	const seg1 = "/rec/250_013/Депо_им.Русакова/20260910_031524_1020545.flac"
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: cs.Grant, DeviceSerial: cs.DeviceSerial,
+		StartedAt: callStart, EndedAt: callStart.Add(6 * time.Second),
+		CallStartedAt: callStart, Segment: 0, AudioPath: seg0,
+	}})
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: cs.Grant, DeviceSerial: cs.DeviceSerial,
+		StartedAt: callStart.Add(6 * time.Second), EndedAt: callStart.Add(30 * time.Second),
+		CallStartedAt: callStart, Segment: 1, AudioPath: seg1,
+	}})
+	// A replayed duplicate of the second announcement must not double it.
+	bus.Publish(events.Event{Kind: events.KindCallComplete, Payload: trunking.CallComplete{
+		Grant: cs.Grant, DeviceSerial: cs.DeviceSerial,
+		StartedAt: callStart.Add(6 * time.Second), EndedAt: callStart.Add(30 * time.Second),
+		CallStartedAt: callStart, Segment: 1, AudioPath: seg1,
+	}})
+
+	var segs []RecordingSegment
+	if !waitFor(func() bool {
+		segs, _ = db.RecordingSegmentsByID(context.Background(), id)
+		return len(segs) == 2
+	}) {
+		t.Fatalf("RecordingSegmentsByID = %d segments (%+v), want 2 — the second over was orphaned", len(segs), segs)
+	}
+	if segs[0].Path != seg0 || segs[1].Path != seg1 {
+		t.Errorf("segment order = %q, %q; want %q, %q", segs[0].Path, segs[1].Path, seg0, seg1)
+	}
+	if segs[0].Seq != 0 || segs[1].Seq != 1 {
+		t.Errorf("segment seq = %d, %d; want 0, 1", segs[0].Seq, segs[1].Seq)
+	}
+	if !segs[1].StartedAt.Equal(callStart.Add(6*time.Second)) || !segs[1].EndedAt.Equal(callStart.Add(30*time.Second)) {
+		t.Errorf("segment 1 span = %v..%v, want +6s..+30s", segs[1].StartedAt, segs[1].EndedAt)
+	}
+	// The row's single recording_path stays the FIRST file (has_recording +
+	// legacy readers), never a later over.
+	if p, _ := db.RecordingPathByID(context.Background(), id); p != seg0 {
+		t.Errorf("RecordingPathByID = %q, want the first segment %q", p, seg0)
+	}
+	rows, _ := db.History(context.Background(), HistoryFilter{Limit: 1})
+	if len(rows) != 1 || !rows[0].HasRecording {
+		t.Errorf("HasRecording = false after segment recordings")
+	}
+}
+
+// TestRecordingSegmentsFallsBackToRowPath: rows written before the
+// call_recordings table existed carry only call_log.recording_path — they must
+// still play as a single segment rather than reading as "no recording".
+func TestRecordingSegmentsFallsBackToRowPath(t *testing.T) {
+	db := openTestDB(t)
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := db.sql.Exec(`INSERT INTO call_log (system, group_id, device_serial, started_at, recording_path)
+		VALUES ('A', 1, 'V1', ?, '/rec/old.wav')`, startedAt.UnixNano()); err != nil {
+		t.Fatal(err)
+	}
+	var id int64
+	if err := db.sql.QueryRow(`SELECT id FROM call_log`).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	segs, err := db.RecordingSegmentsByID(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(segs) != 1 || segs[0].Path != "/rec/old.wav" {
+		t.Errorf("segments = %+v, want the row's own path", segs)
+	}
+	if segs, err := db.RecordingSegmentsByID(context.Background(), 999999); err != nil || segs != nil {
+		t.Errorf("unknown id: segs=%v err=%v", segs, err)
+	}
+}

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -141,6 +141,12 @@ func (r *Retention) deleteOldRows(ctx context.Context) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	// The per-segment recording rows belong to their call row; drop the ones
+	// whose call just went (no FK cascade — foreign keys are off by default).
+	if _, err := r.db.sql.ExecContext(ctx,
+		`DELETE FROM call_recordings WHERE call_id NOT IN (SELECT id FROM call_log)`); err != nil {
+		return 0, err
+	}
 	return res.RowsAffected()
 }
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -99,6 +99,23 @@ CREATE INDEX IF NOT EXISTS idx_call_log_system  ON call_log(system, started_at);
 CREATE INDEX IF NOT EXISTS idx_call_log_group   ON call_log(group_id, started_at);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_call_log_active ON call_log(device_serial, started_at);
 
+-- One row per finished recording FILE of a call. A call recorded in
+-- "transmission" grouping (per-over segment rolls, e.g. a TETRA talker
+-- change) produces several files; call_log.recording_path keeps only the
+-- first, this table keeps them all in order so /calls/{id}/audio can play
+-- the whole call. Rows are attached by the recorder's KindCallComplete and
+-- swept with their call row (retention).
+CREATE TABLE IF NOT EXISTS call_recordings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    call_id     INTEGER NOT NULL,
+    seq         INTEGER NOT NULL,           -- 0-based segment index within the call
+    path        TEXT    NOT NULL,
+    started_at  INTEGER NOT NULL,           -- unix nanoseconds, this file's span
+    ended_at    INTEGER,
+    UNIQUE(call_id, path)
+);
+CREATE INDEX IF NOT EXISTS idx_call_recordings_call ON call_recordings(call_id, seq);
+
 CREATE TABLE IF NOT EXISTS location_log (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     system      TEXT    NOT NULL DEFAULT '',

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -364,11 +364,34 @@ type CallComplete struct {
 	Grant        Grant
 	Talkgroup    *TalkGroup
 	DeviceSerial string
-	StartedAt    time.Time
-	EndedAt      time.Time
-	Reason       EndReason
-	AudioPath    string
-	SampleRate   uint32
+	// StartedAt / EndedAt bound the RECORDING this event announces. For a
+	// single-file call that is the call span; for a per-transmission segment
+	// roll (KindCallSegment) it is the span of this one over, so StartedAt is
+	// later than the call's own start.
+	StartedAt time.Time
+	EndedAt   time.Time
+	Reason    EndReason
+	AudioPath string
+	// CallStartedAt is the originating call's start (CallStart.StartedAt) —
+	// the key the call log's row was written under. It is what lets a second,
+	// third, … segment recording be attached to the SAME call row: keying on
+	// StartedAt alone matched only the first over, so a multi-over call kept
+	// one segment's recording and orphaned the rest (the "30 s call with a
+	// 4 s recording" report). Zero means "same as StartedAt" (single file).
+	CallStartedAt time.Time
+	// Segment is this recording's 0-based index within the call (0 for the
+	// only/first file, 1 for the second over, …).
+	Segment    int
+	SampleRate uint32
+}
+
+// CallStart returns the originating call's start time: CallStartedAt when a
+// segment roll set it, else StartedAt (a single-file recording).
+func (c CallComplete) CallStart() time.Time {
+	if !c.CallStartedAt.IsZero() {
+		return c.CallStartedAt
+	}
+	return c.StartedAt
 }
 
 // Duration returns how long the call ran.

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -746,6 +747,9 @@ func (r *Recorder) sessionForWrite(serial string, callID uint64) *recordingSessi
 			if ns == nil {
 				return nil
 			}
+			// Carry the over index the park stamped, so this file's
+			// CallComplete says which segment of the call it is.
+			ns.segment = s.segment
 			r.sessions[serial] = ns
 			s = ns
 		}
@@ -1242,7 +1246,7 @@ func (r *Recorder) handleSegment(seg trunking.CallSegment) {
 	// Park a dormant session: keeps the call's identity so the next write
 	// opens the next segment file, without creating an empty trailing
 	// file if no further audio arrives before the call ends.
-	r.sessions[seg.DeviceSerial] = &recordingSession{cs: s.cs, callID: s.callID}
+	r.sessions[seg.DeviceSerial] = &recordingSession{cs: s.cs, callID: s.callID, segment: s.segment + 1}
 	r.mu.Unlock()
 	if cc != nil {
 		r.normalizeIfEnabled(cc.AudioPath)
@@ -1388,7 +1392,11 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 		EndedAt:      endedAt,
 		Reason:       reason,
 		AudioPath:    s.wavPath,
-		SampleRate:   s.sampleRate,
+		// The call's own start + this file's index, so the call log can attach
+		// every segment of a multi-over call to the one row (see CallComplete).
+		CallStartedAt: s.cs.StartedAt,
+		Segment:       s.segment,
+		SampleRate:    s.sampleRate,
 	}
 	var meta *callMeta
 	if r.writeCallJSON {
@@ -1849,6 +1857,18 @@ func fadeTail(from int16, n int) []int16 {
 }
 
 // sanitize strips characters that are awkward in file paths across OSes.
+//
+// It keeps letters and digits from EVERY script (Unicode categories L, M, N),
+// not just ASCII — an operator naming talkgroups/radios in Cyrillic, Greek,
+// CJK, … used to get a directory of underscores ("Депо им.Русакова" →
+// "_______.________", the reported bug) because the old mapper only passed
+// [A-Za-z0-9]. Every modern filesystem GopherTrunk runs on (APFS, ext4, NTFS)
+// is UTF-8/UTF-16 clean, so the alias survives verbatim; only separators,
+// whitespace, control characters and shell/OS metacharacters become '_'.
+// Dots stay (talkgroup names like "Site 1.2" are common) but a segment that
+// would be "." or ".." is neutralised so a token value can never traverse.
+// Invalid UTF-8 bytes map to '_' as well (strings.Map hands them over as
+// U+FFFD, which is a symbol, not a letter).
 func sanitize(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -1856,19 +1876,19 @@ func sanitize(s string) string {
 	}
 	mapper := func(r rune) rune {
 		switch {
-		case r >= 'a' && r <= 'z':
-			return r
-		case r >= 'A' && r <= 'Z':
-			return r
-		case r >= '0' && r <= '9':
-			return r
 		case r == '-' || r == '_' || r == '.':
+			return r
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r):
 			return r
 		default:
 			return '_'
 		}
 	}
-	return strings.Map(mapper, s)
+	out := strings.Map(mapper, s)
+	if out == "." || out == ".." {
+		return strings.Repeat("_", len(out))
+	}
+	return out
 }
 
 type recordingSession struct {
@@ -1915,6 +1935,11 @@ type recordingSession struct {
 	// each (which flooded at debug level on a garbled call).
 	vocoderDrops int
 	startedAt    time.Time
+	// segment is this file's 0-based index within the call: 0 for the first
+	// (or only) recording, incremented on each per-transmission segment roll
+	// (handleSegment parks the dormant successor with segment+1). Carried on
+	// the CallComplete so the call log keeps the overs in order.
+	segment int
 	// callID is the Grant.CallID of the call this session records. Frames
 	// arriving via WriteRawFrameForCall with a different non-zero callID are
 	// dropped (see sessionForWrite) so a reused tap serial can't bleed the

--- a/internal/voice/recorder_segment_test.go
+++ b/internal/voice/recorder_segment_test.go
@@ -148,3 +148,84 @@ func waitSession(t *testing.T, r *Recorder, serial string, want bool) {
 	}
 	t.Fatalf("timed out waiting for HasSession(%q) == %v", serial, want)
 }
+
+// TestRecorderSegmentCompleteCarriesCallStart pins the field the call log
+// keys on: every per-over KindCallComplete must carry the CALL's start
+// (CallStartedAt == CallStart.StartedAt) and its segment index, even though
+// its own StartedAt is the over's start. Without it the second over's
+// recording could not be attached to the call row (the "30 s call, 4 s
+// recording" report).
+func TestRecorderSegmentCompleteCarriesCallStart(t *testing.T) {
+	r, bus, _ := mkRecorder(t, false)
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "S", Protocol: "fm", GroupID: 5, SourceID: 9,
+			FrequencyHz: 451_000_000,
+		},
+		DeviceSerial: "V1",
+		StartedAt:    time.Date(2026, 9, 10, 0, 15, 18, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitSession(t, r, "V1", true)
+	if err := r.WritePCM("V1", make([]int16, 800)); err != nil {
+		t.Fatal(err)
+	}
+	bus.Publish(events.Event{Kind: events.KindCallSegment, Payload: trunking.CallSegment{
+		DeviceSerial: "V1", At: cs.StartedAt.Add(6 * time.Second),
+	}})
+	time.Sleep(50 * time.Millisecond)
+	if err := r.WritePCM("V1", make([]int16, 800)); err != nil {
+		t.Fatal(err)
+	}
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: "V1", StartedAt: cs.StartedAt,
+		EndedAt: cs.StartedAt.Add(30 * time.Second), Reason: trunking.EndReasonNormal,
+	}})
+	waitSession(t, r, "V1", false)
+
+	var completes []trunking.CallComplete
+	deadline := time.After(500 * time.Millisecond)
+loop:
+	for {
+		select {
+		case ev := <-sub.C:
+			if cc, ok := ev.Payload.(trunking.CallComplete); ok && ev.Kind == events.KindCallComplete {
+				completes = append(completes, cc)
+				if len(completes) == 2 {
+					break loop
+				}
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+	if len(completes) != 2 {
+		t.Fatalf("got %d CallComplete events, want 2", len(completes))
+	}
+	for i, cc := range completes {
+		if !cc.CallStartedAt.Equal(cs.StartedAt) {
+			t.Errorf("segment %d: CallStartedAt = %v, want the call's start %v", i, cc.CallStartedAt, cs.StartedAt)
+		}
+		if cc.Segment != i {
+			t.Errorf("segment %d: Segment = %d", i, cc.Segment)
+		}
+		if cc.AudioPath == "" {
+			t.Errorf("segment %d: empty AudioPath", i)
+		}
+	}
+	if completes[0].AudioPath == completes[1].AudioPath {
+		t.Errorf("both segments announce the same file %q", completes[0].AudioPath)
+	}
+	if !completes[1].StartedAt.After(completes[0].StartedAt) {
+		t.Errorf("segment 1 StartedAt %v should be after segment 0's %v", completes[1].StartedAt, completes[0].StartedAt)
+	}
+}

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -581,6 +581,22 @@ func TestSanitize(t *testing.T) {
 		"  spaces  ":        "spaces",
 		"path/../traversal": "path_.._traversal",
 		"":                  "",
+		// Non-ASCII letters survive (the operator's Cyrillic alias used to
+		// come out as "_______.________"); only the space becomes '_'.
+		"Депо им.Русакова": "Депо_им.Русакова",
+		"Дежурный депо":    "Дежурный_депо",
+		"Ärzte-Notruf 3":   "Ärzte-Notruf_3",
+		"東京消防庁":            "東京消防庁",
+		// Combining marks (a decomposed é) stay attached to their base.
+		"caf\u0065\u0301": "caf\u0065\u0301",
+		// OS/shell metacharacters and controls still map to '_'.
+		"a:b*c?d\"e<f>g|h": "a_b_c_d_e_f_g_h",
+		"tab\there":        "tab_here",
+		// A bare "." / ".." segment can never traverse.
+		".":  "_",
+		"..": "__",
+		// Invalid UTF-8 is neutralised, not passed through.
+		"bad\xffbyte": "bad_byte",
 	}
 	for in, want := range cases {
 		if got := sanitize(in); got != want {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -211,12 +211,20 @@ export const api = {
   },
   history: (
     c: ClientConfig,
-    opts: { limit?: number; system?: string; group_id?: number } = {},
+    opts: {
+      limit?: number;
+      system?: string;
+      group_id?: number;
+      // Filter to calls FROM one radio (call_log.source_id) — the per-RID
+      // view of the call log, so recordings can be found by who was talking.
+      source_id?: number;
+    } = {},
   ) => {
     const q = new URLSearchParams();
     if (opts.limit != null) q.set("limit", String(opts.limit));
     if (opts.system) q.set("system", opts.system);
     if (opts.group_id != null) q.set("group_id", String(opts.group_id));
+    if (opts.source_id != null) q.set("source_id", String(opts.source_id));
     const qs = q.toString();
     return request<{ calls: CallRow[] }>(
       c,

--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -82,9 +82,13 @@ describe("DataTable", () => {
     // First page shows 1..10, not 11.
     expect(screen.getByText("item-10")).toBeInTheDocument();
     expect(screen.queryByText("item-11")).toBeNull();
-    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+    expect(screen.getAllByText("1 / 3")).toHaveLength(2);
 
-    await user.click(screen.getByRole("button", { name: /Next/i }));
+    // Prev/Next are rendered above AND below the table (the bottom pair sits
+    // under the floating audio player); either steps the page.
+    const nexts = screen.getAllByRole("button", { name: /Next/i });
+    expect(nexts).toHaveLength(2);
+    await user.click(nexts[0]);
     expect(screen.getByText("item-11")).toBeInTheDocument();
     expect(screen.queryByText("item-10")).toBeNull();
   });

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -141,10 +141,50 @@ export function DataTable<T>({
 
   const hasToolbar = searchable || !!toolbar || showColumnMenu;
   const totalCols = visibleColumns.length + (rowActions ? 1 : 0);
+  const paginated = !!pageSize && sorted.length > pageSize;
+
+  // The Prev / Next pair. Rendered ABOVE the table (in the toolbar row, or
+  // on its own when there is no toolbar) as well as below it: the bottom
+  // pager sits exactly where the floating audio mini-player docks
+  // (bottom-right), so on a 50-row page the operator could not reach "Next"
+  // without stopping the player. The main content also keeps bottom padding
+  // for the player (AppShell), but a second pager that is always in reach is
+  // what the reported bug asked for.
+  const pager = (position: "top" | "bottom") =>
+    paginated ? (
+      <div
+        className="flex items-center gap-2 text-xs text-muted"
+        data-testid={`pager-${position}`}
+      >
+        <span className="tabular-nums">
+          {page * pageSize! + 1}–{Math.min((page + 1) * pageSize!, sorted.length)}{" "}
+          of {sorted.length}
+        </span>
+        <button
+          type="button"
+          className="btn-ghost !min-h-0 !py-1 text-xs"
+          onClick={() => setPage((p) => Math.max(0, p - 1))}
+          disabled={page === 0}
+        >
+          ‹ Prev
+        </button>
+        <span className="tabular-nums">
+          {page + 1} / {pageCount}
+        </span>
+        <button
+          type="button"
+          className="btn-ghost !min-h-0 !py-1 text-xs"
+          onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+          disabled={page >= pageCount - 1}
+        >
+          Next ›
+        </button>
+      </div>
+    ) : null;
 
   return (
     <div className="space-y-2">
-      {hasToolbar && (
+      {hasToolbar ? (
         <div className="flex items-center gap-2 flex-wrap">
           {searchable && (
             <Input
@@ -157,12 +197,13 @@ export function DataTable<T>({
             />
           )}
           {toolbar}
-          <div className="ml-auto flex items-center gap-2">
+          <div className="ml-auto flex items-center gap-3 flex-wrap">
             {searchable && query && (
               <span className="text-xs text-muted">
                 {sorted.length} of {rows.length}
               </span>
             )}
+            {pager("top")}
             {showColumnMenu && (
               <ColumnMenu
                 columns={columns}
@@ -172,6 +213,8 @@ export function DataTable<T>({
             )}
           </div>
         </div>
+      ) : (
+        paginated && <div className="flex justify-end">{pager("top")}</div>
       )}
 
       <div className="panel overflow-hidden">
@@ -254,33 +297,7 @@ export function DataTable<T>({
         )}
       </div>
 
-      {pageSize && sorted.length > pageSize && (
-        <div className="flex items-center justify-between gap-2 text-xs text-muted">
-          <span>
-            {page * pageSize + 1}–{Math.min((page + 1) * pageSize, sorted.length)}{" "}
-            of {sorted.length}
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              className="btn-ghost !min-h-0 !py-1 text-xs"
-              onClick={() => setPage((p) => Math.max(0, p - 1))}
-              disabled={page === 0}
-            >
-              ‹ Prev
-            </button>
-            <span>
-              {page + 1} / {pageCount}
-            </span>
-            <button
-              className="btn-ghost !min-h-0 !py-1 text-xs"
-              onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
-              disabled={page >= pageCount - 1}
-            >
-              Next ›
-            </button>
-          </div>
-        </div>
-      )}
+      {paginated && <div className="flex justify-end">{pager("bottom")}</div>}
     </div>
   );
 }

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -71,7 +71,10 @@ export function AppShell({ children }: Props) {
           onOpenMore={() => setDrawerOpen(true)}
           onOpenPalette={() => setPaletteOpen(true)}
         />
-        <main id="main" className="flex-1 p-3 sm:p-4 pb-24 sm:pb-4">
+        {/* Bottom padding at EVERY width: the floating audio mini-player docks
+            bottom-right and covered the last table row / pager on desktop
+            (sm:pb-4 left it only 1rem). Mobile keeps room for BottomNav too. */}
+        <main id="main" className="flex-1 p-3 sm:p-4 pb-24 sm:pb-24">
           {children}
         </main>
       </div>

--- a/web/src/lib/formatTime.test.ts
+++ b/web/src/lib/formatTime.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { formatClock } from "./formatTime";
+import { formatClock, formatLocalDateTime } from "./formatTime";
 
 // Pin a non-UTC timezone so the "local, not GMT" behaviour is observable and
 // deterministic regardless of where the suite runs.
@@ -25,5 +25,28 @@ describe("formatClock", () => {
     // Non-date input: Date() is NaN, so it returns raw.slice(11,19) — here the
     // 8 chars starting at index 11 ("XXXXXXXXXXX" is 11 chars) = "12:34:56".
     expect(formatClock("XXXXXXXXXXX12:34:56")).toBe("12:34:56");
+  });
+});
+
+describe("formatLocalDateTime", () => {
+  it("renders date + time in local time, not UTC", () => {
+    // 2026-09-10T00:15:18Z is 20:15:18 the previous evening in New York.
+    // The old `.replace("T", " ")` slice would have shown "2026-09-10 00:15:18"
+    // — the operator's "history is 3 hours behind the activity feed" report.
+    expect(formatLocalDateTime("2026-09-10T00:15:18Z")).toBe(
+      "2026-09-09 20:15:18",
+    );
+  });
+
+  it("drops fractional seconds and honours an explicit offset", () => {
+    expect(formatLocalDateTime("2026-09-10T03:15:18.654+03:00")).toBe(
+      "2026-09-09 20:15:18",
+    );
+  });
+
+  it("falls back to the raw value on an unparseable timestamp", () => {
+    // (V8's Date parser is permissive — even "xTy.1" yields a year — so the
+    // fixture is plain words, which every engine rejects.)
+    expect(formatLocalDateTime("not a date")).toBe("not a date");
   });
 });

--- a/web/src/lib/formatTime.ts
+++ b/web/src/lib/formatTime.ts
@@ -20,3 +20,29 @@ export function formatClock(ts: string): string {
     hour12: false,
   });
 }
+
+// formatLocalDateTime renders an RFC3339 / ISO timestamp as a compact
+// "YYYY-MM-DD HH:MM:SS" string in the BROWSER'S LOCAL timezone.
+//
+// Several panels (History, Events, Dashboard digest, Active, Tones, the
+// scanner log) used to do `ts.replace("T", " ").replace(/\..*$/, "")` on the
+// daemon's UTC string — a pure string slice that always shows GMT. An
+// operator in UTC+3 therefore saw the History panel three hours behind the
+// live activity feed (which formats locally) and read it as "history stops
+// updating": the 00:15 row WAS the 03:15 call. Keep the same fixed-width
+// numeric shape (sortable, monospace-friendly) but in local time, so every
+// panel agrees with the activity feed and the daemon log.
+//
+// On an unparseable timestamp it falls back to the old raw slice so a
+// malformed daemon value is still visible rather than blank.
+export function formatLocalDateTime(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) {
+    return ts.replace("T", " ").replace(/\..*$/, "");
+  }
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  );
+}

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from "../components/ui/PageHeader";
 import type { ActiveCallDTO } from "../api/types";
 import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
 import { useDataPoll } from "../hooks/useDataPoll";
+import { formatLocalDateTime } from "../lib/formatTime";
 import {
   useLingeringActiveCalls,
   callDuration,
@@ -301,7 +302,7 @@ export function Active() {
             <DetailField
               label="Started"
               mono
-              value={selected.started_at.replace("T", " ").replace(/\..*$/, "")}
+              value={formatLocalDateTime(selected.started_at)}
             />
             <DetailField
               label="Duration"

--- a/web/src/panels/Dashboard.tsx
+++ b/web/src/panels/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
 import { selectClientConfig, useShared } from "../store/shared";
 import { groupEvents } from "../lib/groupEvents";
 import type { EventDTO } from "../api/types";
+import { formatLocalDateTime } from "../lib/formatTime";
 
 // DIGEST_EXCLUDE names the high-frequency status/diagnostic event kinds that
 // don't belong in the human "what happened" digest: a P25 control channel
@@ -242,7 +243,7 @@ export function Dashboard() {
               .map((g, i) => (
                 <li key={`${g.lastTimestamp}-${i}`} className="flex gap-3">
                   <span className="text-muted shrink-0">
-                    {g.lastTimestamp.replace("T", " ").replace(/\..*$/, "")}
+                    {formatLocalDateTime(g.lastTimestamp)}
                   </span>
                   <span className="text-accent shrink-0 w-28 truncate">
                     {g.event.kind}

--- a/web/src/panels/Events.tsx
+++ b/web/src/panels/Events.tsx
@@ -5,6 +5,7 @@ import { Badge } from "../components/ui/Badge";
 import type { EventDTO } from "../api/types";
 import { useShared } from "../store/shared";
 import { contentKey, groupEvents, type GroupedEvent } from "../lib/groupEvents";
+import { formatLocalDateTime } from "../lib/formatTime";
 
 // Events renders the live ring buffer the WebSocket stream populates
 // into the shared store. No polling — the stream pushes everything;
@@ -55,7 +56,7 @@ export function Events() {
         header: "Time",
         render: (g) => (
           <span className="font-mono text-xs text-muted whitespace-nowrap">
-            {g.event.timestamp.replace("T", " ").replace(/\..*$/, "")}
+            {formatLocalDateTime(g.event.timestamp)}
             {g.count > 1 ? (
               <span
                 className="ml-1 px-1 rounded bg-surface text-fg/70 text-[10px]"

--- a/web/src/panels/History.test.tsx
+++ b/web/src/panels/History.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 vi.mock("../api/client", () => ({
@@ -58,6 +58,9 @@ describe("History panel", () => {
     vi.clearAllMocks();
     resetStore();
   });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   // Regression: the client used to read the wrong envelope key, so every
   // History query rendered "No calls in the daemon's call log for this
@@ -81,6 +84,69 @@ describe("History panel", () => {
       system: "250_013",
       group_id: 1020545,
     });
+  });
+
+  it("seeds the filter from ?source_id= (the per-radio view)", async () => {
+    vi.mocked(api.history).mockResolvedValue([]);
+    renderPanel("/history?source_id=1005492");
+    await waitFor(() => {
+      expect(api.history).toHaveBeenCalled();
+    });
+    expect(vi.mocked(api.history).mock.calls[0][1]).toMatchObject({
+      source_id: 1005492,
+    });
+  });
+
+  // Regression: the Started column was a raw slice of the daemon's UTC
+  // string, so an operator in UTC+3 saw History three hours behind the
+  // activity feed and read it as "history stops updating".
+  it("renders Started in the browser's local time, not UTC", async () => {
+    vi.stubEnv("TZ", "Europe/Moscow"); // UTC+3
+    try {
+      vi.mocked(api.history).mockResolvedValue([
+        { ...row, started_at: "2026-09-10T00:15:18Z" },
+      ]);
+      renderPanel();
+      await waitFor(() => {
+        expect(screen.getByText("2026-09-10 03:15:18")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("2026-09-10 00:15:18")).toBeNull();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  // Regression: History fetched once per filter change and never again, so
+  // new calls appeared only on a page reload. A call.end in the live event
+  // feed now triggers a (debounced) refetch.
+  it("refetches after a call.end arrives in the event feed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      vi.mocked(api.history).mockResolvedValue([row]);
+      renderPanel();
+      await waitFor(() => {
+        expect(api.history).toHaveBeenCalledTimes(1);
+      });
+      act(() => {
+        useShared.getState().appendEvents([
+          {
+            kind: "call.end",
+            timestamp: "2026-09-10T00:15:49Z",
+            payload: { group_id: 1020545 },
+          },
+        ]);
+      });
+      // Not immediately — the refetch waits for the recorder's call.complete.
+      expect(api.history).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      await waitFor(() => {
+        expect(api.history).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shows the empty state when the filter matches nothing", async () => {

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api } from "../api/client";
 import { writes } from "../api/write";
@@ -11,55 +11,97 @@ import { CallHealth } from "../components/SignalHealth";
 import { PageHeader } from "../components/ui/PageHeader";
 import type { CallRow } from "../api/types";
 import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
+import { formatLocalDateTime } from "../lib/formatTime";
 import {
   selectCanMutate,
   selectClientConfig,
   useShared,
 } from "../store/shared";
 
+// HISTORY_POLL_MS is the fallback refresh cadence while the tab is visible.
+// The primary trigger is the live event feed (a call.end below); the poll
+// covers a dropped SSE/WS connection so the table can never quietly freeze.
+const HISTORY_POLL_MS = 30_000;
+// HISTORY_REFRESH_DELAY_MS is how long after a call.end the refetch waits, so
+// the recorder's call.complete (has_recording) has landed on the row first.
+const HISTORY_REFRESH_DELAY_MS = 1_500;
+
+type HistoryFilter = {
+  limit?: number;
+  system?: string;
+  group_id?: number;
+  source_id?: number;
+};
+
+// selectLastCallEnd picks the timestamp of the newest call.end in the live
+// feed — a primitive, so the zustand subscription only re-renders on a new
+// call ending, not on every event.
+function selectLastCallEnd(s: { events: { kind: string; timestamp: string }[] }) {
+  for (let i = s.events.length - 1; i >= 0; i--) {
+    if (s.events[i].kind === "call.end") return s.events[i].timestamp;
+  }
+  return null;
+}
+
 // History reads /api/v1/calls/history with the same filter shape the
-// daemon accepts: limit, system, group_id. The response envelope is
+// daemon accepts: limit, system, group_id, source_id. The response envelope is
 // {"calls":[...]} — reading any other key yields a silently empty table.
+//
+// The table is LIVE: it refetches shortly after every call.end in the event
+// feed and on a slow visible-tab poll. It used to fetch exactly once per
+// filter change, so the operator had to reload the page to see new calls
+// (the "history updates too slow / stops reflecting latest calls" report —
+// though most of that report was the UTC rendering, see formatLocalDateTime).
 export function History() {
   const cfg = useShared(selectClientConfig);
   const canMutate = useShared(selectCanMutate);
   const setGlobalError = useShared((s) => s.setError);
   const notify = useShared((s) => s.notify);
+  const lastCallEnd = useShared(selectLastCallEnd);
+  // Bumped to refetch with the same filter (live refresh / poll).
+  const [refreshTick, setRefreshTick] = useState(0);
 
   const [rows, setRows] = useState<CallRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmSweep, setConfirmSweep] = useState(false);
 
-  // Cross-links from Talkgroups / Systems seed the filter via query params
-  // (?system=, ?group_id=) so "view this TG's / system's calls" lands here
-  // pre-filtered — the cross-selection trunking operators expect.
+  // Cross-links from Talkgroups / Systems / Radio IDs seed the filter via
+  // query params (?system=, ?group_id=, ?source_id=) so "view this TG's /
+  // system's / radio's calls" lands here pre-filtered — the cross-selection
+  // trunking operators expect.
   const [searchParams] = useSearchParams();
   const initSystem = searchParams.get("system") ?? "";
   const initGroup = searchParams.get("group_id") ?? "";
+  const initSource = searchParams.get("source_id") ?? "";
 
   // Form fields kept separate from the "submitted" filter object so
   // typing into the inputs doesn't trigger a fetch on every keystroke.
   const [limitInput, setLimitInput] = useState("200");
   const [systemInput, setSystemInput] = useState(initSystem);
   const [groupInput, setGroupInput] = useState(initGroup);
-  const [filter, setFilter] = useState<{
-    limit?: number;
-    system?: string;
-    group_id?: number;
-  }>(() => {
-    const f: { limit?: number; system?: string; group_id?: number } = { limit: 200 };
+  const [sourceInput, setSourceInput] = useState(initSource);
+  const [filter, setFilter] = useState<HistoryFilter>(() => {
+    const f: HistoryFilter = { limit: 200 };
     if (initSystem) f.system = initSystem;
     const g = parseInt(initGroup, 10);
     if (Number.isFinite(g)) f.group_id = g;
+    const src = parseInt(initSource, 10);
+    if (Number.isFinite(src)) f.source_id = src;
     return f;
   });
 
   const [selected, setSelected] = useState<CallRow | null>(null);
 
+  // A refetch with the SAME filter (live refresh / poll) is silent: the
+  // rows stay on screen and the header's "loading…" doesn't flash every
+  // 30 s. Only a filter change shows the loading state.
+  const fetchedFilter = useRef<HistoryFilter | null>(null);
   useEffect(() => {
     let cancel = false;
-    setLoading(true);
+    const silent = fetchedFilter.current === filter;
+    fetchedFilter.current = filter;
+    if (!silent) setLoading(true);
     setError(null);
     api
       .history(cfg, filter)
@@ -77,16 +119,44 @@ export function History() {
     return () => {
       cancel = true;
     };
-  }, [cfg, filter]);
+  }, [cfg, filter, refreshTick]);
+
+  // Live refresh: a call.end in the event feed means a new row (or a row that
+  // just gained its duration / recording). Debounced past the recorder's
+  // call.complete so has_recording is right on the first paint. The feed
+  // usually already holds a call.end when the panel mounts — that one is not
+  // news, skip it.
+  const seenCallEnd = useRef(lastCallEnd);
+  useEffect(() => {
+    if (lastCallEnd === null || lastCallEnd === seenCallEnd.current) return;
+    seenCallEnd.current = lastCallEnd;
+    const t = window.setTimeout(
+      () => setRefreshTick((n) => n + 1),
+      HISTORY_REFRESH_DELAY_MS,
+    );
+    return () => window.clearTimeout(t);
+  }, [lastCallEnd]);
+
+  // Fallback poll while the tab is visible (covers a dropped event stream).
+  useEffect(() => {
+    const t = window.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        setRefreshTick((n) => n + 1);
+      }
+    }, HISTORY_POLL_MS);
+    return () => window.clearInterval(t);
+  }, []);
 
   function applyFilter(e: React.FormEvent) {
     e.preventDefault();
-    const next: typeof filter = {};
+    const next: HistoryFilter = {};
     const lim = parseInt(limitInput, 10);
     if (Number.isFinite(lim) && lim > 0) next.limit = lim;
     if (systemInput.trim()) next.system = systemInput.trim();
     const gid = parseInt(groupInput, 10);
     if (Number.isFinite(gid)) next.group_id = gid;
+    const src = parseInt(sourceInput, 10);
+    if (Number.isFinite(src)) next.source_id = src;
     setFilter(next);
   }
 
@@ -94,6 +164,7 @@ export function History() {
     setLimitInput("200");
     setSystemInput("");
     setGroupInput("");
+    setSourceInput("");
     setFilter({ limit: 200 });
   }
 
@@ -104,7 +175,7 @@ export function History() {
         header: "Started",
         render: (r) => (
           <span className="font-mono text-xs text-muted whitespace-nowrap">
-            {r.started_at.replace("T", " ").replace(/\..*$/, "")}
+            {formatLocalDateTime(r.started_at)}
           </span>
         ),
         sort: (a, b) => a.started_at.localeCompare(b.started_at),
@@ -254,7 +325,7 @@ export function History() {
 
       <form
         onSubmit={applyFilter}
-        className="panel p-3 grid grid-cols-2 sm:grid-cols-4 gap-2 items-end"
+        className="panel p-3 grid grid-cols-2 sm:grid-cols-5 gap-2 items-end"
       >
         <label className="text-xs space-y-1">
           <span className="text-muted uppercase tracking-wider">Limit</span>
@@ -286,6 +357,17 @@ export function History() {
             placeholder="e.g. 1001"
             value={groupInput}
             onChange={(e) => setGroupInput(e.target.value)}
+          />
+        </label>
+        <label className="text-xs space-y-1">
+          <span className="text-muted uppercase tracking-wider">Source RID</span>
+          <input
+            type="number"
+            min={0}
+            className="input w-full"
+            placeholder="radio id"
+            value={sourceInput}
+            onChange={(e) => setSourceInput(e.target.value)}
           />
         </label>
         <div className="flex gap-2 col-span-2 sm:col-span-1">
@@ -369,14 +451,14 @@ export function History() {
             <DetailField
               label="Started"
               mono
-              value={selected.started_at.replace("T", " ").replace(/\..*$/, "")}
+              value={formatLocalDateTime(selected.started_at)}
             />
             <DetailField
               label="Ended"
               mono
               value={
                 selected.ended_at
-                  ? selected.ended_at.replace("T", " ").replace(/\..*$/, "")
+                  ? formatLocalDateTime(selected.ended_at)
                   : null
               }
             />

--- a/web/src/panels/Pagers.tsx
+++ b/web/src/panels/Pagers.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { selectClientConfig, useShared } from "../store/shared";
+import { formatClock } from "../lib/formatTime";
 
 // Pagers panel — list of recent POCSAG and FLEX pages decoded by the
 // daemon. Each row carries its protocol, RIC, function code, encoding,
@@ -159,10 +160,6 @@ function ProtocolBadge({ protocol }: { protocol: string }) {
 }
 
 function formatTime(ts: string): string {
-  try {
-    const d = new Date(ts);
-    return d.toISOString().slice(11, 19);
-  } catch {
-    return ts.slice(11, 19);
-  }
+  // Local wall-clock, like every other live panel (toISOString is always UTC).
+  return formatClock(ts);
 }

--- a/web/src/panels/RadioIDs.test.tsx
+++ b/web/src/panels/RadioIDs.test.tsx
@@ -219,6 +219,72 @@ describe("RadioIDs panel", () => {
     });
   });
 
+  // Recordings used to be playable only from the talkgroup-filtered History
+  // table; each recent call with a recording now carries its own play button
+  // that expands the RecordingPlayer inline, plus a link to the per-radio
+  // call log.
+  it("plays a recent call's recording from the radio's modal", async () => {
+    vi.mocked(api.rids).mockResolvedValue([
+      { id: 4242, alias: "ALPHA", configured: true, call_count: 2 },
+    ]);
+    vi.mocked(api.ridHistory).mockResolvedValue([
+      {
+        id: 1,
+        system: "Metro",
+        protocol: "p25",
+        group_id: 99,
+        frequency_hz: 851_000_000,
+        started_at: "2026-05-26T12:00:00Z",
+        has_recording: true,
+      },
+      {
+        id: 2,
+        system: "Metro",
+        protocol: "p25",
+        group_id: 99,
+        frequency_hz: 851_000_000,
+        started_at: "2026-05-26T12:01:00Z",
+      },
+    ]);
+    // RecordingPlayer fetches the audio; leave it pending so the test only
+    // asserts the player mounted.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => new Promise(() => {}));
+    try {
+      renderPanel();
+      await waitFor(() => {
+        expect(screen.getByText("ALPHA")).toBeInTheDocument();
+      });
+      await userEvent.click(screen.getByText("ALPHA"));
+
+      const play = await screen.findByRole("button", {
+        name: /Play recording of call 1/,
+      });
+      // Only the call that has a recording gets a button.
+      expect(
+        screen.queryByRole("button", { name: /Play recording of call 2/ }),
+      ).toBeNull();
+      expect(
+        screen.getByRole("link", { name: /All calls from this radio/ }),
+      ).toHaveAttribute("href", "/history?source_id=4242");
+
+      await userEvent.click(play);
+      expect(screen.getByText(/Loading recording/)).toBeInTheDocument();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/calls/1/audio"),
+        expect.anything(),
+      );
+      // Toggles off again.
+      await userEvent.click(
+        screen.getByRole("button", { name: /Hide recording of call 1/ }),
+      );
+      expect(screen.queryByText(/Loading recording/)).toBeNull();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   // Regression: a /rids/:id deep link (e.g. a source-radio click in CC
   // Activity or call history) must open that radio's detail modal. The route
   // used to be unregistered, so such links fell through to the dashboard.

--- a/web/src/panels/RadioIDs.tsx
+++ b/web/src/panels/RadioIDs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
@@ -10,7 +10,9 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { Section } from "../components/ui/Section";
 import { Select } from "../components/ui/Select";
 import { PositionMap, type MapPoint } from "../components/PositionMap";
+import { RecordingPlayer } from "../components/RecordingPlayer";
 import type { CallRow, LocationFix, RIDDTO } from "../api/types";
+import { formatLocalDateTime } from "../lib/formatTime";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -39,6 +41,8 @@ export function RadioIDs() {
   const [selected, setSelected] = useState<RIDDTO | null>(null);
   const [history, setHistory] = useState<CallRow[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
+  // The recent call whose recording is expanded inline (one at a time).
+  const [playingCallId, setPlayingCallId] = useState<number | null>(null);
   const [busy, setBusy] = useState(false);
   // Selected system filter ("" = all systems). Populates the ?system= query so
   // a large multi-system RID roster stays legible.
@@ -179,6 +183,7 @@ export function RadioIDs() {
 
   // Fetch per-RID call history when the detail modal opens.
   useEffect(() => {
+    setPlayingCallId(null);
     if (!selected) {
       setHistory([]);
       return;
@@ -436,18 +441,29 @@ export function RadioIDs() {
             />
             <DetailField
               label="First seen"
-              value={selected.first_seen ?? "—"}
+              mono
+              value={selected.first_seen ? formatLocalDateTime(selected.first_seen) : "—"}
             />
             <DetailField
               label="Last seen"
-              value={selected.last_seen ?? "—"}
+              mono
+              value={selected.last_seen ? formatLocalDateTime(selected.last_seen) : "—"}
             />
           </div>
 
           <div className="pt-3 border-t border-panel">
-            <p className="text-xs uppercase tracking-wider text-muted mb-2">
-              Recent calls
-            </p>
+            <div className="flex items-baseline justify-between gap-3 mb-2">
+              <p className="text-xs uppercase tracking-wider text-muted">
+                Recent calls
+              </p>
+              <Link
+                to={`/history?source_id=${selected.id}`}
+                className="text-xs text-accent hover:underline"
+                title="Open the call log filtered to calls from this radio"
+              >
+                All calls from this radio →
+              </Link>
+            </div>
             {historyLoading ? (
               <p className="text-xs text-muted">Loading…</p>
             ) : history.length === 0 ? (
@@ -455,17 +471,42 @@ export function RadioIDs() {
                 No calls in the persisted call log for this RID.
               </p>
             ) : (
-              <ul className="space-y-1 max-h-56 overflow-y-auto text-xs">
+              <ul className="space-y-1 max-h-72 overflow-y-auto text-xs">
                 {history.map((c) => (
-                  <li
-                    key={c.id}
-                    className="flex justify-between gap-3 font-mono"
-                  >
-                    <span>
-                      {c.system} · TG {c.group_id}
-                      {c.talkgroup_alpha ? ` · ${c.talkgroup_alpha}` : ""}
-                    </span>
-                    <span className="text-muted">{formatTime(c.started_at)}</span>
+                  <li key={c.id} className="font-mono">
+                    <div className="flex justify-between items-center gap-3">
+                      <span>
+                        {c.system} · TG {c.group_id}
+                        {c.talkgroup_alpha ? ` · ${c.talkgroup_alpha}` : ""}
+                      </span>
+                      <span className="flex items-center gap-2 shrink-0">
+                        <span className="text-muted">{formatTime(c.started_at)}</span>
+                        {/* Per-call playback: recordings used to be reachable
+                            only through the talkgroup-filtered History table. */}
+                        {c.has_recording && (
+                          <button
+                            type="button"
+                            className="btn-ghost !min-h-0 !py-0 !px-1.5 text-xs"
+                            aria-label={
+                              playingCallId === c.id
+                                ? `Hide recording of call ${c.id}`
+                                : `Play recording of call ${c.id}`
+                            }
+                            aria-expanded={playingCallId === c.id}
+                            onClick={() =>
+                              setPlayingCallId((cur) => (cur === c.id ? null : c.id))
+                            }
+                          >
+                            {playingCallId === c.id ? "■" : "▶"}
+                          </button>
+                        )}
+                      </span>
+                    </div>
+                    {playingCallId === c.id && (
+                      <div className="mt-1 mb-2">
+                        <RecordingPlayer cfg={cfg} callId={c.id} />
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -557,10 +598,6 @@ export function RadioIDs() {
 }
 
 function formatTime(rfc3339: string): string {
-  // Render compact local time; fall back to the raw string if
-  // parsing fails so a malformed daemon timestamp is still visible.
-  const t = Date.parse(rfc3339);
-  if (Number.isNaN(t)) return rfc3339;
-  const d = new Date(t);
-  return d.toLocaleString();
+  // Compact local date + time, the same shape as the History table.
+  return formatLocalDateTime(rfc3339);
 }

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -18,6 +18,7 @@ import type {
   SystemHuntStatusDTO,
 } from "../api/types";
 import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
+import { formatLocalDateTime } from "../lib/formatTime";
 
 const POLL_INTERVAL_MS = 3_000;
 
@@ -558,7 +559,7 @@ function StatePill({ state }: { state: string }) {
 }
 
 function timeOnly(ts: string): string {
-  return ts.replace("T", " ").replace(/\..*$/, "");
+  return formatLocalDateTime(ts);
 }
 
 function formatHz(hz: number): string {

--- a/web/src/panels/Tones.tsx
+++ b/web/src/panels/Tones.tsx
@@ -5,6 +5,7 @@ import { ConfirmModal } from "../components/ConfirmModal";
 import { PageHeader } from "../components/ui/PageHeader";
 import type { EventDTO, ToneAlertDTO } from "../api/types";
 import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
+import { formatLocalDateTime } from "../lib/formatTime";
 
 interface ToneRow {
   alert: ToneAlertDTO;
@@ -40,7 +41,7 @@ export function Tones() {
         header: "Matched",
         render: (r) => (
           <span className="font-mono text-xs text-muted whitespace-nowrap">
-            {r.alert.matched_at.replace("T", " ").replace(/\..*$/, "")}
+            {formatLocalDateTime(r.alert.matched_at)}
           </span>
         ),
         sort: (a, b) => a.alert.matched_at.localeCompare(b.alert.matched_at),
@@ -185,7 +186,7 @@ function ToneDetail({ row, onClose }: { row: ToneRow; onClose: () => void }) {
           <div className="flex-1">
             <h3 className="text-lg font-semibold">{row.alert.profile}</h3>
             <p className="text-xs text-muted">
-              {row.alert.matched_at.replace("T", " ").replace(/\..*$/, "")}
+              {formatLocalDateTime(row.alert.matched_at)}
             </p>
           </div>
           <button


### PR DESCRIPTION
Five reports, one root cause each:

- Multi-over calls played only their first over ("duration 30 s, recording
  4 s"). Per-transmission segment rolls publish one CallComplete PER
  SEGMENT stamped with the over's own StartedAt, which matched no call
  row, so the call log kept the first file and orphaned the rest.
  CallComplete now carries CallStartedAt + Segment, every file lands in a
  new call_recordings table (swept with its row), and
  GET /calls/{id}/audio concatenates the segments into one WAV with the
  inter-over silence restored (capped 1.5 s), degrading to the first file
  when a segment can't be decoded. Pre-table rows keep playing from
  recording_path.
- Cyrillic talkgroup/radio names became "_______" recording folders: the
  recorder's sanitize passed only [A-Za-z0-9._-]. It now keeps Unicode
  letters/digits/marks; separators, controls and OS/shell metacharacters
  still map to '_', and a bare "."/".." segment can never traverse.
- History (and Events, Dashboard digest, Active, Tones, scanner log,
  Pagers) rendered the daemon's UTC string as-is, so a UTC+3 operator saw
  History 3 h behind the activity feed and read it as "history stops
  updating". All now go through formatLocalDateTime/formatClock; Radio
  IDs' first/last seen too. History also refetches after each call.end
  and polls every 30 s while visible.
- The floating audio player covered DataTable's pager: Prev/Next now
  render above the table too, and the main content keeps bottom clearance
  at every width.
- Recordings were only reachable by talkgroup: each recent call in a
  radio's modal with a recording gets an inline play button, plus an
  "All calls from this radio" link into History, which gains a source_id
  filter backed by a new ?source_id= parameter on /calls/history.

Failing-first regressions: TestCallLogAttachesEverySegmentRecording,
TestCallAudioEndpointPlaysEverySegment,
TestRecorderSegmentCompleteCarriesCallStart, the new TestSanitize cases,
TestCallHistoryEndpointFiltersBySourceID, and the History / RadioIDs /
DataTable / formatTime vitest cases.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GCzBJnESrBfuP3SJxSMnTr