### PR TITLE
tetra: precomputed RM(30,14) codebook and a branch-free FIR window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1155,6 +1155,65 @@ confirmation before any close-as-completed.
   that one IS in `unpackParams2450`, and needs the mbelib-neo 2450 frame diff. Measure with
   band fractions / centroid / LSD, never by ear alone; the "gt-shipped" WAVs had
   enhance+normalize+warm on top and hid all of this.
+- **"Host overruns at a tiny 200 kS/s" on the dual-TETRA wideband rig (10 Sep) was CPU, and the
+  CPU was `DecodeAACH` re-ENCODING all 16 384 RM(30,14) codewords per call.** `DecodeRM3014Tetra`
+  / `DecodeRM3014TetraSoft` were ML searches that called `EncodeRM3014Tetra` (allocating) for every
+  codeword on every call: ~15 ms and ~16 k allocations per AACH decode, run once per downlink slot
+  (~70/s per carrier) on the wideband pump AND once per traffic burst in the voice demux. Two TETRA
+  DDC channels at 200 kS/s measured 0.44x real time on one 2.1 GHz core with 65% in that search
+  (`TestEngineDualTETRA200kThroughput`, `GT_WB_BENCH_SECONDS=30 GT_WB_BENCH_PROFILE=...`), and it
+  was the ~19 GC/s on a 9 MB heap in the operator's heartbeat lines. Fix: a once-built codebook
+  (`rm3014Table`, uint32-packed) with popcount / three 10-bit partial-sum tables — 17 µs / 36 µs,
+  allocation-free, bit-identical (`rm_30_14_tetra_codebook_test.go` keeps the brute force as the
+  reference). Second cost was `filter.FIR.Process` (~50% after that): its ring buffer branched per
+  tap; it now runs a mirrored 2N history window with the SAME float32 summation order
+  (`TestFIRMirroredWindowIsBitExact`), ~1.8x faster. Pump: 0.44x → 0.12x real time. Lesson: an
+  "overruns at low rate" report on a path that logs no `decode can't keep up` WARN still means
+  profile the pump — `host_drops` is the consumer, and the consumer here was a block decoder,
+  not the DSP.
+- **IPSC "still losing calls" (10 Sep, 1200 s Signal Lab flac at 442.3875 MHz) was the polyphase
+  channelizer's BIN EDGE, root-caused on the capture and fixed by 2x oversampling the
+  channelizer.** The live wideband tap (6.25 MS/s, `tuner_strategy: polyphase` → 32 bins of
+  195.3125 kHz; Fire2 at +687.5 kHz = 3.52 bins ⇒ 0.48 from bin 4) logged `sync_hits=0` for
+  minutes at a time while the same capture decodes 25 001 idle beacons / 14 grants through a DDC
+  (the repeater sits at −53 dBFS over a −83 dBFS floor ≈ 30 dB SNR, keyed solid through both
+  missed windows — the offline `TestDMRIPSCReplay` grants at 12:17:27 and 12:20:34 local, the
+  live log has nothing on Fire2 between 12:11 and 12:22). `TestDMRIPSCWidebandReplay`
+  (`GT_DMR_IQ=<flac> GT_DMR_WB=1`, interpolates the slice to the field bin geometry and A/Bs
+  `ChannelizerBank` vs `DDCBank` with one tap each on the SAME stream) reproduced it exactly:
+  polyphase 1991 beacons / 2 grants vs DDC 6103 / 7 over 300 s, deaf in the same tens-of-seconds
+  stretches. Mechanism: the critically-sampled bin's prototype is −6 dB AT the edge and the
+  half of a 12.5 kHz channel that crosses ±binRate/2 folds back — measured −18.6/−9.3/−6.2/−5.2 dB
+  across one channel's 0.45..0.51-bin span (`TestChannelizerBankBinEdgeChannelIsFlat`, fails on the
+  old bank). `channelizer.Oversampled` (Harris M/2 polyphase: M/2 inputs per step, IDFT, and the
+  per-bin `e^{-j2πk·t_s/M}` rotation a critically-sampled bank never needs) emits each bin at
+  2·Fs/M with cutoff 0.75·Fs/M, so the whole bin is flat; `ChannelizerBank` uses it unconditionally
+  (fine-tune NCO/resampler now run from 2·binRate — dense-71 bench 1.5→2.8 ms/chunk, DDC 11.8 ms).
+  Post-fix the polyphase arm matches the DDC arm window-for-window on the capture. The old
+  "dense plan crowds taps onto bin edges — reduced SNR" WARN is gone (DEBUG layout line only).
+  A clean synthetic C4FM carrier at residual 0.48 still GRANTED through the old bank (200 header
+  repeats need only a few good bursts), so a synthetic grant test could not fail first — the
+  tone-flatness pin + the capture harness are the regression; don't reintroduce a grant-based one.
+- **P25 IMBE vs trunk-recorder/OP25 on the same 7-reply conversation (10 Sep, tg 805): measured,
+  NOT changed.** Merging GT's per-transmission WAVs back-to-back (TR's `freqList.pos` is cumulative
+  length, no gaps) and aligning per segment: (1) GT's recordings are SHORTER — 27.18 s vs 30.42 s;
+  the loss is whole LDUs at the HEAD (0.36 s = 2 LDUs on two replies, 1 LDU on one, 0 on three) —
+  receiver acquisition, not the talkgroup gate (`boundaryTracker` already starts `lastMatch=true`);
+  OP25 catches the first LDU more often. Needs a voice IQ capture to tune (`ddaWarmupSymbols`=512
+  ≈107 ms plus filter/AGC settle). (2) Spectrum: the SHIPPED WAVs (enhance chain on) sit at
+  LSD 4.4 dB from OP25 (−5 dB at 100–300 Hz from the HPF/tilt, +3.6/+8 dB at 2–3/3–4 kHz); the
+  raw recorder-default decode of the same `.raw` frames is 3.6 dB, and sweeping
+  `recordings.unvoiced_gain` (`TestIMBEUnvoicedGainSweep`, `GT_IMBE_RAW_DIR`/`GT_IMBE_GAINS`) is
+  monotonic: 5.49 (the dsd-neo/mbelib calibration) → 3.57 dB, 2 → 2.96, 1 → 2.69, 0.5 → 2.53.
+  So the two references DISAGREE on unvoiced level by several dB (mbelib's 3-cosine unvoiced is
+  ≈5.5x a voiced harmonic; the spec's equal-power rule is gain 1, which is where OP25 sits) — and
+  the residual +5..+7 dB GT excess at 3–4 kHz (rel. 1 kHz) does NOT move with the gain, so it is
+  in the high-harmonic spectral-amplitude reconstruction/§6.2 path, same family as the open AMBE
+  2450 note above; per-harmonic diff against OP25's `imbe_vocoder` is the next instrument. Don't
+  flip the default on one conversation; an operator chasing OP25's balance can set
+  `unvoiced_gain: 1` and lower `enhance.hpf_hz`/`tilt_hz`. GT's per-call JSON shipped
+  `srcList: []` on this rig while TR lists the two radios (80902/80816); not investigated this
+  round.
 - **Capture ceilings**: siglab capture-from-tuner 120→1200 s (`maxCaptureSeconds`, byte
   budget 4 GiB estimated at the UNCOMPRESSED decoder width even for flac),
   `diversity_capture_seconds` 120→1200 (`maxDiversityCaptureSeconds`); the REST hunt capture

--- a/cmd/gophertrunk/dmr_ipsc_wideband_replay_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_wideband_replay_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestDMRIPSCWidebandReplay re-creates the WIDEBAND geometry a narrowband IPSC
+// capture was received through and A/Bs the two tuner banks on it: the
+// capture (a Signal Lab 25 kS/s wav/flac slice, GT_DMR_IQ) is interpolated to
+// a wideband rate of GT_DMR_WB_BINS channelizer bins of GT_DMR_WB_BIN_HZ each,
+// mixed to GT_DMR_WB_OFFSET_HZ from centre, and fed to a ChannelizerBank (the
+// daemon's tuner_strategy: polyphase) and a DDCBank with one tap each at that
+// offset, each driving its own DMR receiver + Tier II state machine. Per-window
+// idle-beacon and FEC counts show whether the polyphase tap goes deaf where
+// the DDC does not.
+//
+// Defaults reproduce the 10 Sep field report: a 6.25 MS/s X310 plan gets 32
+// bins of 195.3125 kHz, and the repeater at +687.5 kHz lands 0.48 of a bin
+// from bin 4's centre — only the bin width and residual matter to the tap, so
+// 8 bins of the same width keep the replay affordable (and the tap in band).
+// GT_DMR_WB_START / GT_DMR_WB_END (seconds) select an excerpt.
+func TestDMRIPSCWidebandReplay(t *testing.T) {
+	path := os.Getenv("GT_DMR_IQ")
+	if path == "" || os.Getenv("GT_DMR_WB") == "" {
+		t.Skip("set GT_DMR_IQ (container capture) and GT_DMR_WB=1")
+	}
+	iq, rate, err := siglab.DecodeContainerFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inRate := float64(rate)
+	bins := envInt("GT_DMR_WB_BINS", 8)
+	binHz := envFloat("GT_DMR_WB_BIN_HZ", 6_250_000.0/32)
+	offsetHz := envFloat("GT_DMR_WB_OFFSET_HZ", 687_500)
+	startS := envFloat("GT_DMR_WB_START", 0)
+	endS := envFloat("GT_DMR_WB_END", float64(len(iq))/inRate)
+	iq = iq[int(startS*inRate):int(math.Min(endS*inRate, float64(len(iq))))]
+	wbRate := binHz * float64(bins)
+	l, m := rationalRatioTest(wbRate, inRate)
+	up := dsp.NewResampler(l, m, 24, 9.0)
+	t.Logf("capture %.0f Hz %.1fs → wideband %.1f Hz (L=%d M=%d), %d bins of %.1f Hz, tap at %+.0f Hz = bin %.2f",
+		inRate, float64(len(iq))/inRate, wbRate, l, m, bins, binHz, offsetHz, offsetHz/binHz)
+
+	type arm struct {
+		name  string
+		bank  tuner.Bank
+		rx    *dmrrx.Receiver
+		cc    *tier2.ConventionalChannel
+		bus   *events.Bus
+		grant []string
+		lastB uint64
+		lastF uint64
+		rows  []string
+	}
+	mk := func(name string, bank tuner.Bank) *arm {
+		a := &arm{name: name, bank: bank, bus: events.NewBus(256)}
+		a.cc = tier2.New(tier2.Options{Bus: a.bus, SystemName: name, FrequencyHz: 0})
+		a.rx = dmrrx.New(dmrrx.Options{SampleRateHz: bank.OutputRateHz(), DeviationHz: 1944.0, ClockGain: 0.015,
+			DibitSink: dmr.DibitSink(func(d []uint8, b int) { a.cc.Process(d, b) })})
+		if err := bank.AddTap(offsetHz, func(out []complex64) { a.rx.Process(out) }); err != nil {
+			t.Fatal(err)
+		}
+		sub := a.bus.Subscribe()
+		go func() {
+			for ev := range sub.C {
+				if ev.Kind == events.KindGrant {
+					if g, ok := ev.Payload.(trunking.Grant); ok {
+						a.grant = append(a.grant, fmt.Sprintf("tg=%d src=%d", g.GroupID, g.SourceID))
+					}
+				}
+			}
+		}()
+		return a
+	}
+	arms := []*arm{
+		mk("polyphase", tuner.NewChannelizerBank(wbRate, 48_000, 0.05, bins, 16, 9.0)),
+		mk("ddc", tuner.NewDDCBank(wbRate, 48_000, 0.05)),
+	}
+	const chunk = 25_000
+	window := int(10 * inRate)
+	var wide []complex64
+	var nco complex128 = 1
+	step := complex(math.Cos(2*math.Pi*offsetHz/wbRate), math.Sin(2*math.Pi*offsetHz/wbRate))
+	for i := 0; i < len(iq); i += chunk {
+		e := i + chunk
+		if e > len(iq) {
+			e = len(iq)
+		}
+		wide = up.Process(wide[:0], iq[i:e])
+		for j := range wide {
+			wide[j] = complex(float32(real(nco))*real(wide[j])-float32(imag(nco))*imag(wide[j]),
+				float32(real(nco))*imag(wide[j])+float32(imag(nco))*real(wide[j]))
+			nco *= step
+		}
+		if i%(chunk*40) == 0 {
+			nco /= complex(math.Hypot(real(nco), imag(nco)), 0)
+		}
+		for _, a := range arms {
+			a.bank.Process(wide)
+		}
+		if (e/window) != (i/window) || e == len(iq) {
+			sec := startS + float64(e)/inRate
+			for _, a := range arms {
+				c := a.cc.Counters()
+				a.rows = append(a.rows, fmt.Sprintf("%6.0fs beacons %4d fec %3d", sec, c.Beacons-a.lastB, c.FECPass-a.lastF))
+				a.lastB, a.lastF = c.Beacons, c.FECPass
+			}
+		}
+	}
+	for _, a := range arms {
+		c := a.cc.Counters()
+		t.Logf("%-9s out_rate=%.1f beacons=%d fec_pass=%d fec_fail=%d late_entries=%d rekeys=%d grants=%d", a.name, a.bank.OutputRateHz(), c.Beacons, c.FECPass, c.FECFail, c.LateEntries, c.Rekeys, len(a.grant))
+	}
+	for i := range arms[0].rows {
+		t.Logf("  %s | %s", arms[0].rows[i], arms[1].rows[i])
+	}
+	for _, a := range arms {
+		a.bus.Close()
+	}
+}
+
+func envInt(k string, d int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return d
+}
+
+func envFloat(k string, d float64) float64 {
+	if v := os.Getenv(k); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return d
+}
+
+// rationalRatioTest reduces out/in to a small L/M for the interpolator.
+func rationalRatioTest(out, in float64) (int, int) {
+	for m := 1; m <= 64; m++ {
+		l := out * float64(m) / in
+		if math.Abs(l-math.Round(l)) < 1e-6 {
+			return int(math.Round(l)), m
+		}
+	}
+	return int(math.Round(out / in)), 1
+}

--- a/cmd/gophertrunk/imbe_gain_sweep_test.go
+++ b/cmd/gophertrunk/imbe_gain_sweep_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// TestIMBEUnvoicedGainSweep is a calibration instrument, skipped unless
+// GT_IMBE_RAW_DIR is set: it decodes every .raw IMBE sidecar in that directory
+// once per unvoiced band gain in GT_IMBE_GAINS (comma list, e.g. "1,2,5.49")
+// into GT_IMBE_OUT/<name>.g<gain>.wav with the recorder's synthesis defaults
+// (§6.2 enhancement on), so the same frames can be scored per gain against an
+// external reference decode of the same transmission (OP25 / trunk-recorder,
+// dsd-neo) by long-term spectral distance. Used for the 10 Sep P25 A/B
+// (see CLAUDE.md "P25 IMBE vs trunk-recorder").
+func TestIMBEUnvoicedGainSweep(t *testing.T) {
+	dir := os.Getenv("GT_IMBE_RAW_DIR")
+	if dir == "" {
+		t.Skip("set GT_IMBE_RAW_DIR")
+	}
+	out := os.Getenv("GT_IMBE_OUT")
+	gains := strings.Split(os.Getenv("GT_IMBE_GAINS"), ",")
+	raws, _ := filepath.Glob(filepath.Join(dir, "*.raw"))
+	for _, gs := range gains {
+		g, err := strconv.ParseFloat(gs, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, raw := range raws {
+			v, err := voice.DefaultRegistry.New("imbe")
+			if err != nil {
+				t.Fatal(err)
+			}
+			v.(voice.SpecAmplitudeConfigurable).SetSpecAmplitudeEnhance(true)
+			v.(voice.UnvoicedGainConfigurable).SetUnvoicedGain(g)
+			in, err := os.Open(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			base := strings.TrimSuffix(filepath.Base(raw), ".raw")
+			of, err := os.Create(filepath.Join(out, base+".g"+gs+".wav"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := voice.DecodeStreamWithVocoder(in, v, of); err != nil {
+				t.Fatal(err)
+			}
+			of.Close()
+			in.Close()
+			v.Close()
+		}
+	}
+}

--- a/docs/_posts/2026-08-12-the-hunt-09-wideband-multisite-p25.md
+++ b/docs/_posts/2026-08-12-the-hunt-09-wideband-multisite-p25.md
@@ -192,13 +192,15 @@ control channels, no bin-alignment constraints. But it scales linearly: 70 taps
 means 70 reduced-rate resamplers, and the host stops keeping up. A
 `ChannelizerBank` instead runs **one** shared polyphase filter/FFT across the
 whole band and reads each tap out of a bin — a dense 71-repeater DMR plan benches
-**~6× cheaper** on the channelizer than on a per-tap DDC. The cost is that a bin
-has a fixed width, so a carrier that lands near a bin edge decodes at reduced
-SNR. The engine keeps the bin width roughly constant (`channelizerBinsFor` aims
-for ~150 kHz per bin, so a 10 MS/s band gets ~64 bins instead of 16), and when a
-dense plan crowds taps onto bin edges it **warns** rather than silently
-degrading — the channelizer is still the only bank that stays real-time at that
-tap count, so the trade-off is made visible, not avoided.
+**~4× cheaper** on the channelizer than on a per-tap DDC. The bins have a fixed
+width (`channelizerBinsFor` aims for ~150 kHz per bin, so a 10 MS/s band gets
+~64 bins instead of 16), and since a 12.5 kHz plan never aligns to that grid
+some carriers inevitably land near a bin edge. The channelizer is therefore
+**2× oversampled**: each bin is emitted at twice its spacing with the whole bin
+inside the prototype's flat passband, so an edge tap decodes exactly like a
+centred one. (The first, critically-sampled version rolled the edge off by
+−6 dB and folded the part of a channel that crossed it — a repeater 0.48 bins
+off-centre went deaf for minutes on a 30 dB SNR signal.)
 
 ### How that principle shaped the Go code
 

--- a/docs/reference/channelizer.md
+++ b/docs/reference/channelizer.md
@@ -78,7 +78,11 @@ which is what makes wideband, many-channel monitoring practical on an ordinary C
   efficient, but adjacent-channel energy can alias unless the prototype is designed carefully.
 - **Oversampled / M:N channelizer.** Decimates by less than the channel count, leaving guard
   room so channels don't overlap at the edges — needed when the wanted signals don't sit
-  exactly on the channel grid.
+  exactly on the channel grid. GopherTrunk's `ChannelizerBank` is 2× oversampled for exactly
+  this reason: a repeater that lands 0.48 of a bin off-centre (a 12.5 kHz plan never aligns
+  to ~150–200 kHz bins) was tilted and folded by the critically-sampled bin and decoded only
+  intermittently; with the whole bin inside the prototype's flat passband it decodes like a
+  centred one.
 - **Non-uniform / per-tap DDC.** When only a few channels are wanted, or they sit at arbitrary
   offsets, individual [DDCs](/reference/digital-down-converter/) can be cheaper than a full
   bank — a channelizer wins when many uniformly-spaced channels are needed at once.

--- a/internal/dsp/channelizer/oversampled.go
+++ b/internal/dsp/channelizer/oversampled.go
@@ -1,0 +1,158 @@
+package channelizer
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// Oversampled is a 2x-oversampled M-channel polyphase channelizer: the bins
+// are spaced Fs/M apart exactly like Polyphase, but each bin is emitted at
+// 2·Fs/M and its prototype lowpass keeps the WHOLE bin — edges included — in
+// its flat passband.
+//
+// Why it exists: the critically-sampled Polyphase emits each bin at Fs/M with
+// a prototype whose −6 dB point sits ON the bin edge, so a carrier a fraction
+// of a bin off-centre is both tilted by the roll-off and, past ±Fs/(2M),
+// folded back onto itself. A DMR repeater 0.48 bins off-centre on a 6.25 MS/s
+// / 32-bin plan (the 10 Sep IPSC report: sync_hits=0 for minutes on a 30 dB
+// SNR carrier the DDC decoded continuously) is the failure mode. With 2x
+// oversampling the bin's Nyquist edge moves to ±Fs/M and the prototype's
+// cutoff to 0.75·Fs/M: everything within ±0.5 bin of the centre passes flat,
+// the transition band is content the tap's own resampler rejects, and only
+// the ≥ 0.93·Fs/M stopband can alias, onto |f| ≥ 0.93 bins — never onto a
+// tap's channel.
+//
+// Structure (Harris, "Multirate Signal Processing", M/2 polyphase): every
+// D = M/2 input samples one output sample per bin is computed as
+//
+//	y_k[s] = e^{-j2πk·t_s/M} · Σ_r e^{+j2πkr/M} · u_r,   u_r = Σ_p h[r+pM]·x[t_s−r−pM]
+//
+// i.e. the polyphase partial sums over the last N input samples, an M-point
+// inverse DFT, and the per-bin rotation that the output-time advance of M/2
+// (not M) samples per step leaves behind. That rotation is what a critically-
+// sampled channelizer never needs — and what an oversampled one silently gets
+// wrong without.
+type Oversampled struct {
+	m     int
+	n     int         // prototype length padded to a multiple of m
+	proto []float32   // padded prototype
+	hist  []complex64 // 2n mirrored history: hist[pos:pos+n] is the last n samples oldest-first
+	pos   int
+	since int // input samples since the last output step
+	tmod  int // (index of the newest input sample) mod m
+	plan  fft.Plan
+	u     []complex128
+	y     []complex128
+	rot   []complex64 // rot[q] = e^{-j2πq/M}
+}
+
+// NewOversampled builds a 2x-oversampled M-channel channelizer (M even, ≥ 2)
+// with a Kaiser-window prototype of tapsPerBranch·M taps, cutoff 0.75·Fs/M
+// and the given shape parameter.
+func NewOversampled(channels, tapsPerBranch int, kaiserBeta float64) *Oversampled {
+	if channels < 2 || channels%2 != 0 {
+		panic("channelizer: oversampled channelizer needs an even channel count >= 2")
+	}
+	N := channels * tapsPerBranch
+	if N%2 == 0 {
+		N++
+	}
+	proto := filter.LowpassKaiser(N, 0.75/float64(channels), kaiserBeta)
+	return NewOversampledWithPrototype(channels, proto)
+}
+
+// NewOversampledWithPrototype lets callers supply the prototype filter.
+func NewOversampledWithPrototype(channels int, proto []float32) *Oversampled {
+	if channels < 2 || channels%2 != 0 {
+		panic("channelizer: oversampled channelizer needs an even channel count >= 2")
+	}
+	n := ((len(proto) + channels - 1) / channels) * channels
+	padded := make([]float32, n)
+	copy(padded, proto)
+	rot := make([]complex64, channels)
+	for q := range rot {
+		th := -2 * math.Pi * float64(q) / float64(channels)
+		rot[q] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+	}
+	return &Oversampled{
+		m:     channels,
+		n:     n,
+		proto: padded,
+		hist:  make([]complex64, 2*n),
+		tmod:  channels - 1, // so the first input sample is t = 0
+		plan:  fft.New(channels),
+		u:     make([]complex128, channels),
+		rot:   rot,
+	}
+}
+
+// Channels returns the number of bins M.
+func (p *Oversampled) Channels() int { return p.m }
+
+// OversamplingFactor is the ratio of a bin's output rate to the bin spacing.
+func (p *Oversampled) OversamplingFactor() int { return 2 }
+
+// Process consumes len(src) IQ samples and emits one output sample per bin
+// for every M/2 input samples; dst[ch][k] is bin ch's k-th output. dst is
+// reused when it has the right shape.
+func (p *Oversampled) Process(dst [][]complex64, src []complex64) [][]complex64 {
+	if dst == nil || len(dst) != p.m {
+		dst = make([][]complex64, p.m)
+	}
+	for c := 0; c < p.m; c++ {
+		dst[c] = dst[c][:0]
+	}
+	m, n, step := p.m, p.n, p.m/2
+	for _, x := range src {
+		p.hist[p.pos] = x
+		p.hist[p.pos+n] = x
+		p.pos++
+		if p.pos == n {
+			p.pos = 0
+		}
+		p.tmod++
+		if p.tmod == m {
+			p.tmod = 0
+		}
+		p.since++
+		if p.since < step {
+			continue
+		}
+		p.since = 0
+		// w is the last n samples oldest-first: x[t_s − i] = w[n−1−i].
+		w := p.hist[p.pos : p.pos+n]
+		for r := 0; r < m; r++ {
+			var accI, accQ float32
+			// h[r+pM] pairs with w[n−1−r−pM]; walk both from the newest tap.
+			for i := r; i < n; i += m {
+				s := w[n-1-i]
+				h := p.proto[i]
+				accI += h * real(s)
+				accQ += h * imag(s)
+			}
+			p.u[r] = complex(float64(accI), float64(accQ))
+		}
+		p.y = p.plan.Inverse(p.y, p.u)
+		// The plan's inverse is 1/M-normalised; the channelizer wants the
+		// plain sum so a unit tone at a bin centre leaves at unit amplitude
+		// (DC-normalised prototype), matching Polyphase.
+		scale := float32(m)
+		for k := 0; k < m; k++ {
+			v := p.y[k]
+			r := p.rot[(k*p.tmod)%m]
+			re, im := float32(real(v))*scale, float32(imag(v))*scale
+			dst[k] = append(dst[k], complex(re*real(r)-im*imag(r), re*imag(r)+im*real(r)))
+		}
+	}
+	return dst
+}
+
+// Reset clears the history so a restarted stream does not see stale samples.
+func (p *Oversampled) Reset() {
+	for i := range p.hist {
+		p.hist[i] = 0
+	}
+	p.pos, p.since, p.tmod = 0, 0, p.m-1
+}

--- a/internal/dsp/channelizer/oversampled_test.go
+++ b/internal/dsp/channelizer/oversampled_test.go
@@ -1,0 +1,121 @@
+package channelizer
+
+import (
+	"math"
+	"math/cmplx"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// TestOversampledMatchesDirectFilterbank pins the polyphase structure against
+// the textbook definition it implements: bin k at output step s is the input
+// demodulated by e^{-j2πk t/M} and filtered by the prototype, sampled every
+// M/2 input samples.
+func TestOversampledMatchesDirectFilterbank(t *testing.T) {
+	const M = 8
+	proto := filter.LowpassKaiser(M*6+1, 0.75/M, 7)
+	ch := NewOversampledWithPrototype(M, proto)
+	rng := rand.New(rand.NewSource(1))
+	const N = 512
+	in := make([]complex64, N)
+	for i := range in {
+		in[i] = complex(float32(rng.NormFloat64()), float32(rng.NormFloat64()))
+	}
+	// Feed in uneven chunks to prove Process is chunk-invariant.
+	var out [][]complex64
+	for i := 0; i < N; {
+		e := i + rng.Intn(40) + 1
+		if e > N {
+			e = N
+		}
+		part := ch.Process(nil, in[i:e])
+		if out == nil {
+			out = make([][]complex64, M)
+		}
+		for k := range part {
+			out[k] = append(out[k], part[k]...)
+		}
+		i = e
+	}
+	step := M / 2
+	for k := 0; k < M; k++ {
+		if got, want := len(out[k]), N/step; got != want {
+			t.Fatalf("bin %d: %d outputs, want %d", k, got, want)
+		}
+		for s := 0; s < N/step; s++ {
+			ts := (s+1)*step - 1
+			var want complex128
+			for n := 0; n < len(proto); n++ {
+				idx := ts - n
+				if idx < 0 {
+					break
+				}
+				x := complex128(in[idx])
+				want += complex(float64(proto[n]), 0) * x * cmplx.Exp(complex(0, -2*math.Pi*float64(k)*float64(idx)/M))
+			}
+			got := complex128(out[k][s])
+			if cmplx.Abs(got-want) > 1e-3*(1+cmplx.Abs(want)) {
+				t.Fatalf("bin %d step %d: got %v want %v", k, s, got, want)
+			}
+		}
+	}
+}
+
+// TestOversampledBinEdgeToneIsFlat is the property the critically-sampled
+// channelizer lacks: a tone anywhere within ±0.5 bin of a bin centre leaves
+// that bin at (almost) unit amplitude and at exactly its residual frequency —
+// the bin edge is inside the flat passband, not on the −6 dB roll-off and
+// not folded.
+func TestOversampledBinEdgeToneIsFlat(t *testing.T) {
+	const M = 16
+	const Fs = 16.0 * 48_000
+	const binRate = Fs / M
+	ch := NewOversampled(M, 16, 9.0)
+	for _, residual := range []float64{0, 0.25, 0.48, -0.48, 0.5} {
+		const k0 = 5
+		f := (k0 + residual) * binRate
+		const N = 1 << 14
+		in := make([]complex64, N)
+		for i := range in {
+			th := 2 * math.Pi * f * float64(i) / Fs
+			in[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		}
+		out := ch.Process(nil, in)
+		bin := out[k0][len(out[k0])/2:] // skip the filter transient
+		outRate := 2 * binRate
+		// Locate the tone in the bin output by DFT peak.
+		L := len(bin)
+		bestP, bestF := 0.0, 0.0
+		for q := -L / 2; q < L/2; q++ {
+			var acc complex128
+			for i, s := range bin {
+				acc += complex128(s) * cmplx.Exp(complex(0, -2*math.Pi*float64(q)*float64(i)/float64(L)))
+			}
+			if p := cmplx.Abs(acc); p > bestP {
+				bestP, bestF = p, float64(q)*outRate/float64(L)
+			}
+		}
+		amp := bestP / float64(L)
+		if math.Abs(bestF-residual*binRate) > outRate/float64(L)*1.5 {
+			t.Errorf("residual %.2f: tone left bin %d at %.0f Hz, want %.0f Hz", residual, k0, bestF, residual*binRate)
+		}
+		if db := 20 * math.Log10(amp); db < -1.0 || db > 0.5 {
+			t.Errorf("residual %.2f: bin %d amplitude %.2f dB, want within [-1, +0.5] dB (flat passband)", residual, k0, db)
+		}
+		ch.Reset()
+	}
+}
+
+// TestOversampledOutputRate pins 2 output samples per bin per M input samples.
+func TestOversampledOutputRate(t *testing.T) {
+	const M = 4
+	ch := NewOversampled(M, 8, 8.6)
+	out := ch.Process(nil, make([]complex64, 1024))
+	for c := 0; c < M; c++ {
+		if got, want := len(out[c]), 1024*2/M; got != want {
+			t.Errorf("bin %d: len = %d, want %d", c, got, want)
+		}
+	}
+}

--- a/internal/dsp/filter/fir.go
+++ b/internal/dsp/filter/fir.go
@@ -13,7 +13,17 @@ import (
 // It maintains an internal sample history so consecutive Process calls
 // produce a continuous output stream.
 type FIR struct {
-	taps    []float32
+	taps []float32
+	// rtaps is taps reversed (rtaps[j] = taps[N-1-j]) so the dot product runs
+	// over a contiguous, chronologically ordered history window.
+	rtaps []float32
+	// hist is a 2N mirrored history: every sample is written at histPos and
+	// histPos+N, so hist[histPos:histPos+N] is always the last N samples in
+	// arrival order with no wrap. That turns the per-tap modulo/branch of a
+	// plain ring buffer into a straight two-slice dot product — the filter
+	// is the largest single cost of a narrowband receiver (≈50% of a TETRA
+	// wideband tap's CPU once the AACH decoder stopped re-encoding its
+	// codebook), so the inner loop matters.
 	hist    []complex64
 	histPos int
 }
@@ -24,7 +34,11 @@ func NewFIR(taps []float32) *FIR {
 	}
 	cp := make([]float32, len(taps))
 	copy(cp, taps)
-	return &FIR{taps: cp, hist: make([]complex64, len(taps))}
+	rt := make([]float32, len(taps))
+	for j := range rt {
+		rt[j] = taps[len(taps)-1-j]
+	}
+	return &FIR{taps: cp, rtaps: rt, hist: make([]complex64, 2*len(taps))}
 }
 
 // Reset clears the internal history.
@@ -44,27 +58,26 @@ func (f *FIR) Process(dst, src []complex64) []complex64 {
 		dst = dst[:len(src)]
 	}
 	N := len(f.taps)
+	rt := f.rtaps[:N]
 	for i, x := range src {
 		f.hist[f.histPos] = x
+		f.hist[f.histPos+N] = x
 		f.histPos++
 		if f.histPos == N {
 			f.histPos = 0
 		}
-		// Convolve: output is sum_{k} h[k] * hist[(histPos - 1 - k) mod N].
+		// w holds the last N samples oldest-first; output is
+		// sum_k h[k] * w[N-1-k] = sum_j rtaps[j] * w[j]. Accumulate newest
+		// tap first (j descending) so the float32 summation order matches
+		// the original ring-buffer loop exactly.
+		w := f.hist[f.histPos : f.histPos+N]
+		w = w[:len(rt)]
 		var accI, accQ float32
-		idx := f.histPos - 1
-		if idx < 0 {
-			idx = N - 1
-		}
-		for k := 0; k < N; k++ {
-			s := f.hist[idx]
-			h := f.taps[k]
+		for j := len(rt) - 1; j >= 0; j-- {
+			s := w[j]
+			h := rt[j]
 			accI += h * real(s)
 			accQ += h * imag(s)
-			idx--
-			if idx < 0 {
-				idx = N - 1
-			}
 		}
 		dst[i] = complex(accI, accQ)
 	}

--- a/internal/dsp/filter/fir_window_test.go
+++ b/internal/dsp/filter/fir_window_test.go
@@ -1,0 +1,98 @@
+package filter
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// ringFIR is the original modulo-indexed ring-buffer implementation, kept as
+// the bit-exact reference for the mirrored-window Process.
+type ringFIR struct {
+	taps    []float32
+	hist    []complex64
+	histPos int
+}
+
+func (f *ringFIR) process(src []complex64) []complex64 {
+	dst := make([]complex64, len(src))
+	N := len(f.taps)
+	for i, x := range src {
+		f.hist[f.histPos] = x
+		f.histPos++
+		if f.histPos == N {
+			f.histPos = 0
+		}
+		var accI, accQ float32
+		idx := f.histPos - 1
+		if idx < 0 {
+			idx = N - 1
+		}
+		for k := 0; k < N; k++ {
+			s := f.hist[idx]
+			h := f.taps[k]
+			accI += h * real(s)
+			accQ += h * imag(s)
+			idx--
+			if idx < 0 {
+				idx = N - 1
+			}
+		}
+		dst[i] = complex(accI, accQ)
+	}
+	return dst
+}
+
+// TestFIRMirroredWindowIsBitExact pins the mirrored-history Process against
+// the original ring-buffer loop: same taps, same chunking, identical float32
+// output (the summation order is preserved on purpose so every golden that
+// runs through a FIR stays valid).
+func TestFIRMirroredWindowIsBitExact(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	for _, n := range []int{1, 2, 7, 33, 128, 257} {
+		taps := make([]float32, n)
+		for i := range taps {
+			taps[i] = float32(rng.NormFloat64())
+		}
+		fast := NewFIR(taps)
+		ref := &ringFIR{taps: taps, hist: make([]complex64, n)}
+		var dst []complex64
+		for chunk := 0; chunk < 20; chunk++ {
+			src := make([]complex64, rng.Intn(300)+1)
+			for i := range src {
+				src[i] = complex(float32(rng.NormFloat64()), float32(rng.NormFloat64()))
+			}
+			dst = fast.Process(dst, src)
+			want := ref.process(src)
+			for i := range want {
+				if dst[i] != want[i] {
+					t.Fatalf("taps=%d chunk=%d sample=%d: got %v want %v", n, chunk, i, dst[i], want[i])
+				}
+			}
+		}
+		fast.Reset()
+		ref = &ringFIR{taps: taps, hist: make([]complex64, n)}
+		src := make([]complex64, 50)
+		src[0] = 1
+		dst = fast.Process(dst, src)
+		want := ref.process(src)
+		for i := range want {
+			if dst[i] != want[i] {
+				t.Fatalf("after Reset taps=%d sample=%d: got %v want %v", n, i, dst[i], want[i])
+			}
+		}
+	}
+}
+
+func BenchmarkFIR129(b *testing.B) {
+	taps := make([]float32, 129)
+	for i := range taps {
+		taps[i] = float32(i%7) * 0.01
+	}
+	f := NewFIR(taps)
+	src := make([]complex64, 4096)
+	var dst []complex64
+	b.SetBytes(int64(len(src) * 8))
+	for i := 0; i < b.N; i++ {
+		dst = f.Process(dst, src)
+	}
+}

--- a/internal/dsp/tuner/channelizerbank.go
+++ b/internal/dsp/tuner/channelizerbank.go
@@ -21,22 +21,29 @@ import (
 // More than one tap may share a channelizer bin: each tap reads the same
 // bin output and runs its own fine-tune DDC (NCO mixer keyed off its own
 // residual offset + resampler), so the taps are independent downstream and
-// their narrow per-protocol receivers reject the in-band neighbours. The
-// caveat is purely a quality one: a critically-sampled bin rolls off toward
-// its edges, so a tap whose residual sits near ±binRate/2 is attenuated.
-// Callers that need every channel at full SNR should keep residuals well
-// inside the bin (raise the bin count) or use DDCBank, which has no bin
-// geometry at all. See widebandt2's strategy picker.
+// their narrow per-protocol receivers reject the in-band neighbours.
+//
+// The channelizer is 2x oversampled (channelizer.Oversampled): each bin is
+// emitted at 2·InputRateHz/M with the whole ±binRate/2 span inside the
+// prototype's flat passband, so a tap sitting on a bin edge decodes exactly
+// like one at a bin centre. The critically-sampled predecessor rolled off to
+// −6 dB at the edge and folded the part of a channel that crossed it — a DMR
+// repeater 0.48 bins off-centre (10 Sep IPSC report) went deaf for minutes at
+// 30 dB SNR while a DDC on the same stream decoded every transmission. The
+// fine-tune resampler now decimates from 2·binRate, which doubles the per-tap
+// cost; the shared channelizer still leaves a dense plan several times
+// cheaper than per-tap DDCs.
 type ChannelizerBank struct {
 	inRateHz    float64
 	outRateHz   float64
 	actualOutHz float64
 	guardFrac   float64
 
-	channels  int
-	binRateHz float64
+	channels     int
+	binRateHz    float64 // bin SPACING, InputRateHz/M
+	binOutRateHz float64 // each bin's emitted rate, 2·binRateHz (oversampled)
 
-	ch   *channelizer.Polyphase
+	ch   *channelizer.Oversampled
 	bins [][]complex64 // reused channelizer output buffer
 
 	taps []*channelizerTap
@@ -62,23 +69,26 @@ type channelizerTap struct {
 }
 
 // NewChannelizerBank constructs a ChannelizerBank with the requested
-// number of channelizer bins (must be ≥ 2). tapsPerBranch and kaiserBeta
+// number of channelizer bins (must be an even number ≥ 2 — the oversampled
+// structure advances M/2 samples per output). tapsPerBranch and kaiserBeta
 // govern the channelizer's prototype filter; sensible defaults are 16
 // and 9.0 respectively, matching the channelizer package's own tests.
 func NewChannelizerBank(inRateHz, outRateHz, guardFrac float64, channels, tapsPerBranch int, kaiserBeta float64) *ChannelizerBank {
-	if channels < 2 {
-		panic("tuner: ChannelizerBank requires channels >= 2")
+	if channels < 2 || channels%2 != 0 {
+		panic("tuner: ChannelizerBank requires an even channel count >= 2")
 	}
 	binRateHz := inRateHz / float64(channels)
-	l, m := rationalRatio(outRateHz, binRateHz)
+	binOutRateHz := 2 * binRateHz
+	l, m := rationalRatio(outRateHz, binOutRateHz)
 	return &ChannelizerBank{
-		inRateHz:    inRateHz,
-		outRateHz:   outRateHz,
-		actualOutHz: binRateHz * float64(l) / float64(m),
-		guardFrac:   guardFrac,
-		channels:    channels,
-		binRateHz:   binRateHz,
-		ch:          channelizer.New(channels, tapsPerBranch, kaiserBeta),
+		inRateHz:     inRateHz,
+		outRateHz:    outRateHz,
+		actualOutHz:  binOutRateHz * float64(l) / float64(m),
+		guardFrac:    guardFrac,
+		channels:     channels,
+		binRateHz:    binRateHz,
+		binOutRateHz: binOutRateHz,
+		ch:           channelizer.NewOversampled(channels, tapsPerBranch, kaiserBeta),
 	}
 }
 
@@ -95,7 +105,7 @@ func (b *ChannelizerBank) AddTap(offsetHz float64, sink SinkFunc) error {
 	binCenter := b.binCenterHz(binIdx)
 	residual := offsetHz - binCenter
 
-	l, m := rationalRatio(b.outRateHz, b.binRateHz)
+	l, m := rationalRatio(b.outRateHz, b.binOutRateHz)
 	tapsPerBranch := (ddcStopbandTaps*m + l - 1) / l
 	if tapsPerBranch < ddcMinTapsPerBranch {
 		tapsPerBranch = ddcMinTapsPerBranch
@@ -104,7 +114,7 @@ func (b *ChannelizerBank) AddTap(offsetHz float64, sink SinkFunc) error {
 		offsetHz:   offsetHz,
 		binIdx:     binIdx,
 		residualHz: residual,
-		nco:        newNCO(residual, b.binRateHz),
+		nco:        newNCO(residual, b.binOutRateHz),
 		resampler:  dsp.NewResampler(l, m, tapsPerBranch, ddcKaiserBeta),
 		sink:       sink,
 	}
@@ -114,9 +124,8 @@ func (b *ChannelizerBank) AddTap(offsetHz float64, sink SinkFunc) error {
 
 // MaxResidualFrac returns the largest |residual|/binRate over all taps added
 // so far — a 0..0.5 measure of how close the worst-placed tap sits to its
-// bin edge, where the critically-sampled prototype rolls off. Callers use it
-// to decide whether the polyphase layout is clean enough or whether a
-// per-tap DDC (no bin geometry) would decode the set better.
+// bin edge. With the oversampled channelizer the whole bin is in the flat
+// passband, so this is a layout diagnostic, not a decode-quality cliff.
 func (b *ChannelizerBank) MaxResidualFrac() float64 {
 	worst := 0.0
 	for _, t := range b.taps {
@@ -212,19 +221,16 @@ func (b *ChannelizerBank) Process(src []complex64) {
 func (b *ChannelizerBank) InputRateHz() float64 { return b.inRateHz }
 
 // OutputRateHz returns the per-tap narrow-band sample rate the bank actually
-// emits. The fine-tune resampler decimates the bin rate (InputRateHz/channels)
-// to the construction target, but when that exact ratio exceeds the resampler
+// emits. The fine-tune resampler decimates the bin's emitted rate
+// (2·InputRateHz/channels) to the construction target, but when that exact ratio exceeds the resampler
 // caps the achieved rate differs by a fraction of a percent (issue #550);
 // consumers should build their symbol clocks from this value.
 func (b *ChannelizerBank) OutputRateHz() float64 { return b.actualOutHz }
 
-// Reset clears the channelizer and every tap's fine-tune state. The
-// channelizer.Polyphase has no Reset method of its own; we drive a
-// flush of zero-input samples through it to clear the polyphase history
-// so a restart doesn't replay stale samples.
+// Reset clears the channelizer and every tap's fine-tune state so a restart
+// doesn't replay stale samples.
 func (b *ChannelizerBank) Reset() {
-	flush := make([]complex64, b.channels*16)
-	b.ch.Process(b.bins, flush)
+	b.ch.Reset()
 	for _, t := range b.taps {
 		t.nco.reset()
 		t.resampler.Reset()

--- a/internal/dsp/tuner/channelizerbank_test.go
+++ b/internal/dsp/tuner/channelizerbank_test.go
@@ -3,6 +3,7 @@ package tuner
 import (
 	"errors"
 	"math"
+	"math/cmplx"
 	"testing"
 )
 
@@ -271,5 +272,60 @@ func TestBinForOffsetWrapsNegativeFrequencies(t *testing.T) {
 	}
 	if got := b.binCenterHz(15); math.Abs(got+150_000) > 1 {
 		t.Errorf("binCenterHz(15) = %.1f, want -150000", got)
+	}
+}
+
+// TestChannelizerBankBinEdgeChannelIsFlat is the regression for the 10 Sep
+// IPSC "still losing calls" report: a repeater 0.48 bins off a channelizer
+// bin centre decoded only intermittently on the live wideband tap while a
+// DDC on the same IQ decoded every transmission (TestDMRIPSCWidebandReplay on
+// the operator's capture: 1991 vs 6103 idle beacons, 2 vs 7 grants over the
+// same 300 s). A 12.5 kHz channel centred there spans both sides of the bin's
+// edge: the critically-sampled bin rolled its centre off by −6 dB and FOLDED
+// the part beyond the edge back across baseband, where the tap's fine-tune
+// resampler then rejected it. Every tone across such a channel must now leave
+// the tap flat (within 1 dB) and at its true offset from the tap centre.
+func TestChannelizerBankBinEdgeChannelIsFlat(t *testing.T) {
+	const (
+		M       = 8
+		inRate  = 8 * 195_312.5 // the 6.25 MS/s / 32-bin plan's bin width
+		outRate = 48_000.0
+		binRate = inRate / M
+	)
+	tapResidual := 0.48 // bins from bin 3's centre, the field geometry
+	tapHz := (3 + tapResidual) * binRate
+	for _, toneResidual := range []float64{0.45, 0.48, 0.50, 0.51} { // a 12.5 kHz channel at 0.48 spans 0.448..0.512 bins
+		b := NewChannelizerBank(inRate, outRate, 0.05, M, 16, 9.0)
+		var got []complex64
+		if err := b.AddTap(tapHz, func(out []complex64) { got = append(got, out...) }); err != nil {
+			t.Fatal(err)
+		}
+		toneHz := (3 + toneResidual) * binRate
+		const N = 1 << 17
+		in := make([]complex64, N)
+		for i := range in {
+			th := 2 * math.Pi * toneHz * float64(i) / inRate
+			in[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		}
+		b.Process(in)
+		seg := got[len(got)/2:]
+		L := len(seg)
+		bestP, bestF := 0.0, 0.0
+		for q := -L / 2; q < L/2; q++ {
+			var acc complex128
+			for i, s := range seg {
+				acc += complex128(s) * cmplx.Exp(complex(0, -2*math.Pi*float64(q)*float64(i)/float64(L)))
+			}
+			if p := cmplx.Abs(acc); p > bestP {
+				bestP, bestF = p, float64(q)*b.OutputRateHz()/float64(L)
+			}
+		}
+		wantF := toneHz - tapHz
+		if math.Abs(bestF-wantF) > 2*b.OutputRateHz()/float64(L) {
+			t.Errorf("tone at residual %.2f: left the tap at %.0f Hz, want %.0f Hz (folded across the bin edge)", toneResidual, bestF, wantF)
+		}
+		if db := 20 * math.Log10(bestP/float64(L)); db < -1 || db > 0.5 {
+			t.Errorf("tone at residual %.2f: %.2f dB, want within [-1, +0.5] dB (bin-edge roll-off)", toneResidual, db)
+		}
 	}
 }

--- a/internal/dsp/tuner/tuner.go
+++ b/internal/dsp/tuner/tuner.go
@@ -12,11 +12,12 @@
 //     there is no constraint on the tap offsets - they can sit anywhere
 //     inside the dongle's usable IQ band. Best for a small number of taps.
 //
-//   - ChannelizerBank: a single M-channel critically-sampled polyphase
+//   - ChannelizerBank: a single M-channel 2x-oversampled polyphase
 //     channelizer (internal/dsp/channelizer) splits the input into evenly-
 //     spaced bins; a small fine-tune DDC on the bin nearest each tap
 //     offset cleans up the residual. The wide-band filter cost is shared
-//     across all taps, which wins at higher tap counts.
+//     across all taps, which wins at higher tap counts, and the
+//     oversampling keeps a tap on a bin edge as clean as one at a centre.
 //
 // Both implementations decimate to the same narrow-band rate - typically
 // 48 kHz, matching what the existing 4800-baud C4FM receivers

--- a/internal/radio/framing/rm_30_14_tetra.go
+++ b/internal/radio/framing/rm_30_14_tetra.go
@@ -1,6 +1,10 @@
 package framing
 
-import "math"
+import (
+	"math"
+	"math/bits"
+	"sync"
+)
 
 // Shortened (30,14) Reed-Muller block code per ETSI EN 300 392-2
 // §8.2.3.2. Used by the TETRA AACH (Access Assignment Channel) to
@@ -78,6 +82,70 @@ func EncodeRM3014Tetra(info []byte) []byte {
 	return out
 }
 
+// rm3014Codebook is every valid (30,14) codeword packed MSB-first into a
+// uint32 (codeword bit i at bit position 29-i), indexed by its 14 information
+// bits (the systematic prefix, so index v ⇔ info bits = v MSB-first). Built once
+// on first use: the AACH decoders below are maximum-likelihood searches over all
+// 2^14 codewords, and re-ENCODING every codeword per call (the previous
+// implementation: 16 384 EncodeRM3014Tetra calls, each allocating) made one
+// hard AACH decode cost ~16 k allocations and several hundred microseconds.
+// On a locked TETRA control channel that decode runs once per downlink slot
+// (~70/s per carrier) plus once per traffic burst in the voice demux, so it was
+// ~65% of the wideband pump's CPU on the 10 Sep dual-TETRA X310 rig and the
+// dominant source of its GC churn (~19 collections/s on a 9 MB heap) — i.e. the
+// "host overruns at a tiny 200 kS/s" report. A table lookup + popcount search
+// is ~50× cheaper and allocation-free on the search path.
+var (
+	rm3014Once     sync.Once
+	rm3014Codebook [1 << 14]uint32
+	// rm3014RowMask[r] is parity row r of rm3014ParityMatrix packed as a
+	// 16-bit mask (column c at bit 15-c), so a codeword's parity is the XOR
+	// of the row masks of its set information bits.
+	rm3014RowMask [14]uint32
+)
+
+func rm3014Table() *[1 << 14]uint32 {
+	rm3014Once.Do(func() {
+		for r := 0; r < 14; r++ {
+			var m uint32
+			for c := 0; c < 16; c++ {
+				if rm3014ParityMatrix[r][c] != 0 {
+					m |= 1 << uint(15-c)
+				}
+			}
+			rm3014RowMask[r] = m
+		}
+		for v := 0; v < 1<<14; v++ {
+			var parity uint32
+			for r := 0; r < 14; r++ {
+				if v&(1<<uint(13-r)) != 0 {
+					parity ^= rm3014RowMask[r]
+				}
+			}
+			rm3014Codebook[v] = uint32(v)<<16 | parity
+		}
+	})
+	return &rm3014Codebook
+}
+
+// rm3014Pack packs 30 hard bits MSB-first into the codebook's uint32 layout.
+func rm3014Pack(bits []byte) uint32 {
+	var w uint32
+	for i := 0; i < 30; i++ {
+		w = w<<1 | uint32(bits[i]&1)
+	}
+	return w
+}
+
+// rm3014Info unpacks the 14 information bits of codebook index v MSB-first.
+func rm3014Info(v int) []byte {
+	out := make([]byte, 14)
+	for i := 0; i < 14; i++ {
+		out[i] = byte((v >> uint(13-i)) & 1)
+	}
+	return out
+}
+
 // DecodeRM3014Tetra decodes 30 received bits via minimum-Hamming-
 // distance search across all 2^14 = 16 384 valid codewords. Returns
 // (info, errs) where info is the 14-bit information vector closest
@@ -88,36 +156,26 @@ func EncodeRM3014Tetra(info []byte) []byte {
 // noisier captures the (30,14) RM code has minimum distance ≥ 4
 // (giving guaranteed single-bit correction across the 30-bit
 // codeword) and detect-up-to-3 capability — beyond that the
-// closest-codeword decoder may mis-correct.
+// closest-codeword decoder may mis-correct. Ties resolve to the
+// lowest information vector, as the original per-codeword re-encode
+// search did.
 func DecodeRM3014Tetra(received []byte) ([]byte, int) {
 	if len(received) != 30 {
 		return nil, -1
 	}
-	bestDist := 31
-	var bestInfo [14]byte
-	for v := 0; v < (1 << 14); v++ {
-		var info [14]byte
-		for i := 0; i < 14; i++ {
-			info[i] = byte((v >> uint(13-i)) & 1)
-		}
-		cw := EncodeRM3014Tetra(info[:])
-		dist := 0
-		for i := 0; i < 30; i++ {
-			if cw[i] != received[i]&1 {
-				dist++
-			}
-		}
-		if dist < bestDist {
-			bestDist = dist
-			bestInfo = info
-			if dist == 0 {
+	table := rm3014Table()
+	r := rm3014Pack(received)
+	bestDist, bestV := 31, 0
+	for v, cw := range table {
+		d := bits.OnesCount32(cw ^ r)
+		if d < bestDist {
+			bestDist, bestV = d, v
+			if d == 0 {
 				break
 			}
 		}
 	}
-	out := make([]byte, 14)
-	copy(out, bestInfo[:])
-	return out, bestDist
+	return rm3014Info(bestV), bestDist
 }
 
 // DecodeRM3014TetraSoft decodes 30 soft type-4 LLRs via soft-decision
@@ -130,64 +188,66 @@ func DecodeRM3014Tetra(received []byte) ([]byte, int) {
 // gain), so more concurrent-call bursts carry a routable marker instead of being
 // dropped.
 //
-// Returns (info, dist, margin): info is the 14-bit information vector of the
-// most-likely codeword; dist is that codeword's Hamming distance to the
-// hard-sliced LLRs (the same metric the hard decoder returns, so a caller can gate
-// a low-confidence soft pick exactly as before); margin is the normalised gap
-// between the best and second-best codeword correlations in [0,1] (0 ⇒ a tie,
-// higher ⇒ more confident), a soft-domain confidence signal. dist is -1 for a
-// malformed input length.
+// Returns the 14 information bits of the ML codeword, its Hamming distance to the
+// hard-sliced input (so callers can keep the DecodeRM3014Tetra confidence gate),
+// and margin = (best − second-best correlation) / (2·Σ|llr|) ∈ [0, 1] — 0 when
+// two codewords fit equally well, 1 when the input is a clean codeword.
+//
+// The correlation Σ llr_i·(1−2c_i) = T − 2·Σ_{c_i=1} llr_i is evaluated per
+// codeword from three 10-bit partial-sum tables (one per third of the 30-bit
+// word) rather than a 30-term dot product, so the 16 384-codeword search is
+// ~50 k adds instead of ~500 k and allocation-free.
 func DecodeRM3014TetraSoft(llr []float32) (info []byte, dist int, margin float64) {
 	if len(llr) != 30 {
 		return nil, -1, 0
 	}
+	table := rm3014Table()
+	// tab[k][x]: Σ llr over the set bits of the 10-bit group x, where group 0
+	// is codeword bits 0..9 (uint32 bits 29..20), group 1 bits 10..19, group 2
+	// bits 20..29.
+	var tab [3][1024]float64
+	var total float64
+	for i := 0; i < 30; i++ {
+		total += float64(llr[i])
+	}
+	for k := 0; k < 3; k++ {
+		for x := 1; x < 1024; x++ {
+			low := x & -x
+			b := bits.TrailingZeros32(uint32(low)) // bit index within the group, LSB = last bit of the group
+			i := k*10 + (9 - b)
+			tab[k][x] = tab[k][x&(x-1)] + float64(llr[i])
+		}
+	}
 	best, second := math.Inf(-1), math.Inf(-1)
-	var bestInfo [14]byte
-	for v := 0; v < (1 << 14); v++ {
-		var cand [14]byte
-		for i := 0; i < 14; i++ {
-			cand[i] = byte((v >> uint(13-i)) & 1)
-		}
-		cw := EncodeRM3014Tetra(cand[:])
-		// Correlation metric: +llr where the codeword bit is 0 (LLR says bit 0),
-		// -llr where it is 1. The ML codeword maximises it.
-		var m float64
-		for i := 0; i < 30; i++ {
-			if cw[i] == 0 {
-				m += float64(llr[i])
-			} else {
-				m -= float64(llr[i])
-			}
-		}
+	bestV := 0
+	for v, cw := range table {
+		s := tab[0][cw>>20] + tab[1][(cw>>10)&1023] + tab[2][cw&1023]
+		m := total - 2*s
 		switch {
 		case m > best:
 			second = best
 			best = m
-			bestInfo = cand
+			bestV = v
 		case m > second:
 			second = m
 		}
 	}
-	cw := EncodeRM3014Tetra(bestInfo[:])
+	cw := table[bestV]
 	var energy float64
 	for i := 0; i < 30; i++ {
-		hb := byte(0)
+		hb := uint32(0)
 		if llr[i] < 0 {
 			hb = 1
-		}
-		if cw[i] != hb {
-			dist++
-		}
-		if llr[i] < 0 {
 			energy -= float64(llr[i])
 		} else {
 			energy += float64(llr[i])
+		}
+		if (cw>>uint(29-i))&1 != hb {
+			dist++
 		}
 	}
 	if energy > 0 {
 		margin = (best - second) / (2 * energy) // best-second ∈ [0, 2·energy]
 	}
-	out := make([]byte, 14)
-	copy(out, bestInfo[:])
-	return out, dist, margin
+	return rm3014Info(bestV), dist, margin
 }

--- a/internal/radio/framing/rm_30_14_tetra_codebook_test.go
+++ b/internal/radio/framing/rm_30_14_tetra_codebook_test.go
@@ -1,0 +1,162 @@
+package framing
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// bruteForceRM3014 is the original per-codeword re-encode search, kept as
+// the reference the codebook decoders must match bit-for-bit.
+func bruteForceRM3014(received []byte) ([]byte, int) {
+	bestDist := 31
+	var bestInfo [14]byte
+	for v := 0; v < (1 << 14); v++ {
+		var info [14]byte
+		for i := 0; i < 14; i++ {
+			info[i] = byte((v >> uint(13-i)) & 1)
+		}
+		cw := EncodeRM3014Tetra(info[:])
+		dist := 0
+		for i := 0; i < 30; i++ {
+			if cw[i] != received[i]&1 {
+				dist++
+			}
+		}
+		if dist < bestDist {
+			bestDist = dist
+			bestInfo = info
+			if dist == 0 {
+				break
+			}
+		}
+	}
+	return bestInfo[:], bestDist
+}
+
+func bruteForceRM3014Soft(llr []float32) ([]byte, int, float64) {
+	best, second := math.Inf(-1), math.Inf(-1)
+	var bestInfo [14]byte
+	for v := 0; v < (1 << 14); v++ {
+		var cand [14]byte
+		for i := 0; i < 14; i++ {
+			cand[i] = byte((v >> uint(13-i)) & 1)
+		}
+		cw := EncodeRM3014Tetra(cand[:])
+		var m float64
+		for i := 0; i < 30; i++ {
+			if cw[i] == 0 {
+				m += float64(llr[i])
+			} else {
+				m -= float64(llr[i])
+			}
+		}
+		switch {
+		case m > best:
+			second = best
+			best = m
+			bestInfo = cand
+		case m > second:
+			second = m
+		}
+	}
+	cw := EncodeRM3014Tetra(bestInfo[:])
+	dist := 0
+	var energy float64
+	for i := 0; i < 30; i++ {
+		hb := byte(0)
+		if llr[i] < 0 {
+			hb = 1
+		}
+		if cw[i] != hb {
+			dist++
+		}
+		energy += math.Abs(float64(llr[i]))
+	}
+	margin := 0.0
+	if energy > 0 {
+		margin = (best - second) / (2 * energy)
+	}
+	return bestInfo[:], dist, margin
+}
+
+// TestRM3014CodebookMatchesBruteForce pins the table-driven decoders against
+// the original re-encode-every-codeword search on random words at every
+// error weight, including uncorrectable ones where tie-breaking matters.
+func TestRM3014CodebookMatchesBruteForce(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	for n := 0; n < 400; n++ {
+		info := make([]byte, 14)
+		for i := range info {
+			info[i] = byte(rng.Intn(2))
+		}
+		cw := EncodeRM3014Tetra(info)
+		rx := append([]byte(nil), cw...)
+		for k := rng.Intn(9); k > 0; k-- {
+			rx[rng.Intn(30)] ^= 1
+		}
+		if n%5 == 0 { // fully random words too
+			for i := range rx {
+				rx[i] = byte(rng.Intn(2))
+			}
+		}
+		wantInfo, wantDist := bruteForceRM3014(rx)
+		gotInfo, gotDist := DecodeRM3014Tetra(rx)
+		if gotDist != wantDist || string(gotInfo) != string(wantInfo) {
+			t.Fatalf("hard #%d: got %v/%d want %v/%d", n, gotInfo, gotDist, wantInfo, wantDist)
+		}
+		llr := make([]float32, 30)
+		for i := range llr {
+			llr[i] = float32(1-2*int(rx[i])) + float32(rng.NormFloat64()*0.8)
+		}
+		wi, wd, wm := bruteForceRM3014Soft(llr)
+		gi, gd, gm := DecodeRM3014TetraSoft(llr)
+		if string(gi) != string(wi) || gd != wd || math.Abs(gm-wm) > 1e-9 {
+			t.Fatalf("soft #%d: got %v/%d/%.9f want %v/%d/%.9f", n, gi, gd, gm, wi, wd, wm)
+		}
+	}
+}
+
+// TestRM3014DecodeAllocations pins the allocation-free search path: the
+// pre-codebook implementation allocated ~16 k slices per decode, which was
+// the wideband TETRA pump's dominant GC load.
+func TestRM3014DecodeAllocations(t *testing.T) {
+	rx := make([]byte, 30)
+	rx[3] = 1
+	if a := testing.AllocsPerRun(20, func() { DecodeRM3014Tetra(rx) }); a > 1 {
+		t.Fatalf("DecodeRM3014Tetra allocs/run = %v, want ≤ 1", a)
+	}
+	llr := make([]float32, 30)
+	for i := range llr {
+		llr[i] = 1
+	}
+	if a := testing.AllocsPerRun(20, func() { DecodeRM3014TetraSoft(llr) }); a > 1 {
+		t.Fatalf("DecodeRM3014TetraSoft allocs/run = %v, want ≤ 1", a)
+	}
+}
+
+func BenchmarkDecodeRM3014Tetra(b *testing.B) {
+	rx := make([]byte, 30)
+	rx[7], rx[20] = 1, 1
+	for i := 0; i < b.N; i++ {
+		DecodeRM3014Tetra(rx)
+	}
+}
+
+func BenchmarkDecodeRM3014TetraSoft(b *testing.B) {
+	llr := make([]float32, 30)
+	for i := range llr {
+		llr[i] = float32(1 - 2*(i%3&1))
+	}
+	for i := 0; i < b.N; i++ {
+		DecodeRM3014TetraSoft(llr)
+	}
+}
+
+func BenchmarkDecodeRM3014TetraBruteForce(b *testing.B) {
+	rx := make([]byte, 30)
+	rx[7], rx[20] = 1, 1
+	for i := 0; i < b.N; i++ {
+		bruteForceRM3014(rx)
+	}
+}

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -145,16 +145,14 @@ func channelizerBinsFor(sampleRateHz uint32) int {
 const channelizerTapsPerBranch = 16
 const channelizerKaiserBeta = 9.0
 
-// channelizerCleanResidualFrac is the |residual|/binRate above which a tap sits
-// far enough toward its channelizer bin edge to lose noticeable SNR. A
-// critically-sampled bin is flat to ~0.45·binRate then rolls off to −6 dB at
-// the edge (0.5). New warns when a polyphase plan crowds taps past this — a
-// dense, irregular plan (e.g. 70 DMR repeaters on a 12.5 kHz grid that never
-// aligns to the bin centres) inevitably does. The channelizer is still used
-// because it is the only bank that stays real-time at this tap count (a per-tap
-// DDC benches ~6x heavier — see BenchmarkDense71* in internal/dsp/tuner); the
-// warning just makes the trade-off visible.
-const channelizerCleanResidualFrac = 0.40
+// channelizerEdgeResidualFrac is the |residual|/binRate above which a tap
+// sits on a channelizer bin edge. The channelizer is 2x oversampled, so a
+// bin-edge tap decodes exactly like a centred one (the critically-sampled
+// predecessor rolled off to −6 dB there and folded the channel across the
+// edge — the 10 Sep IPSC "losing calls" report, pinned by
+// TestDMRIPSCWidebandReplay on the operator's capture); New now only logs the
+// layout at DEBUG so a dense plan's geometry stays visible in a log.
+const channelizerEdgeResidualFrac = 0.40
 
 // ChannelConfig binds one repeater frequency to the trunking system
 // it belongs to. The Engine creates one DMR state machine per entry,
@@ -643,17 +641,10 @@ func New(opts Options) (*Engine, error) {
 		engine.channels = append(engine.channels, ec)
 	}
 
-	// Dense, irregular plans crowd some taps onto channelizer bin edges, where
-	// the critically-sampled bin rolls off and those channels decode at reduced
-	// SNR. The channelizer is still the right bank (a per-tap DDC at this tap
-	// count is ~6x heavier and would not stay real-time), so this is a
-	// heads-up, not a switch: a channel that won't lock may simply be sitting on
-	// a bin edge — give it its own dongle, or thin the plan, if it matters.
 	if cb, ok := bank.(*tuner.ChannelizerBank); ok {
-		if frac := cb.MaxResidualFrac(); frac > channelizerCleanResidualFrac {
-			log.Warn("widebandt2: dense plan crowds some taps onto channelizer bin edges — those channels decode at reduced SNR (inherent to packing this many carriers on one wideband tuner)",
-				"serial", opts.Serial, "worst_residual_frac", fmt.Sprintf("%.2f", frac),
-				"clean_threshold", channelizerCleanResidualFrac)
+		if frac := cb.MaxResidualFrac(); frac > channelizerEdgeResidualFrac {
+			log.Debug("widebandt2: plan places taps near channelizer bin edges (oversampled channelizer: no SNR penalty)",
+				"serial", opts.Serial, "worst_residual_frac", fmt.Sprintf("%.2f", frac))
 		}
 		// Fan the per-tap fine-tune loop out across CPU cores. A dense plan's
 		// 71 NCO+resampler+receiver chains are the bulk of the per-chunk cost
@@ -1470,12 +1461,12 @@ func (ec *engineChannel) powerLabel() string {
 // DDCBank (linear, no bin-alignment constraint); a larger fleet favours the
 // shared polyphase channelizer, whose amortised wide-band filter is the only
 // thing that stays real-time at high tap counts. A dense 71-DMR plan benches
-// ~6x cheaper on the channelizer than on a per-tap DDC (one shared FFT vs 71
-// reduced-rate resamplers — BenchmarkDense71* in internal/dsp/tuner), so auto
-// keeps high counts on the channelizer even
-// when the plan crowds taps onto bin edges — New warns about the resulting
-// edge roll-off rather than trading real-time headroom for it. Explicit
-// "ddc"/"polyphase" are honoured verbatim.
+// ~4x cheaper on the (2x oversampled) channelizer than on a per-tap DDC (one
+// shared FFT vs 71 reduced-rate resamplers — BenchmarkDense71* in
+// internal/dsp/tuner), so auto keeps high counts on the channelizer; since the
+// oversampling a tap on a bin edge decodes like one at a centre, so the plan's
+// geometry no longer argues for the DDC. Explicit "ddc"/"polyphase" are
+// honoured verbatim.
 func pickStrategy(requested string, channelCount int) (kind, tag string) {
 	switch requested {
 	case "ddc":

--- a/internal/scanner/widebandt2/engine_bench_tetra_test.go
+++ b/internal/scanner/widebandt2/engine_bench_tetra_test.go
@@ -1,0 +1,84 @@
+package widebandt2
+
+import (
+	"context"
+	"log/slog"
+	"math/rand"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestEngineDualTETRA200kThroughput is a CPU-budget instrument, skipped unless
+// GT_WB_BENCH_SECONDS is set: it pumps that many seconds of 200 kS/s noise
+// through the wideband engine with two TETRA DDC channels (the 10 Sep
+// dual-TETRA X310 config that reported host overruns) and logs the ratio of
+// processing time to stream time on the single pump goroutine. GT_WB_BENCH_PROFILE
+// writes a CPU profile. Before the RM(30,14) codebook + FIR window fixes this
+// measured 0.44x real time on a 2.1 GHz Xeon core (65% of it re-encoding the
+// AACH codebook per slot); after, 0.12x.
+func TestEngineDualTETRA200kThroughput(t *testing.T) {
+	secs := 20
+	if v := os.Getenv("GT_WB_BENCH_SECONDS"); v == "" {
+		t.Skip("set GT_WB_BENCH_SECONDS")
+	} else {
+		secs = atoiOr(v, 20)
+	}
+	const rate = 200_000
+	const chunk = 998
+	rng := rand.New(rand.NewSource(1))
+	n := secs * rate / chunk
+	chunks := make([][]complex64, n)
+	for i := range chunks {
+		c := make([]complex64, chunk)
+		for j := range c {
+			c[j] = complex(float32(rng.NormFloat64()*0.01), float32(rng.NormFloat64()*0.01))
+		}
+		chunks[i] = c
+	}
+	dev := newMockDevice(chunks)
+	bus := events.NewBus(64)
+	defer bus.Close()
+	center := uint32(467_912_500)
+	e, err := New(Options{
+		Log:          slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: rate,
+		CenterFreqHz: center,
+		Channels: []ChannelConfig{
+			{FrequencyHz: 467_912_500, SystemName: "a"},
+			{FrequencyHz: 467_875_000, SystemName: "b"},
+		},
+		Systems: []trunking.System{tetraSystem("a", 467_912_500), tetraSystem("b", 467_875_000)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p := os.Getenv("GT_WB_BENCH_PROFILE"); p != "" {
+		f, _ := os.Create(p)
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	start := time.Now()
+	_ = e.Run(ctx) // the mock closes the stream when its chunks run out
+	el := time.Since(start)
+	t.Logf("processed %d s of 200 kS/s dual-TETRA IQ in %v (%.2fx real time)", secs, el, el.Seconds()/float64(secs))
+}
+
+func atoiOr(s string, d int) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return d
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}


### PR DESCRIPTION
The dual-TETRA wideband rig (two 144 kHz DDC channels off a 200 kS/s X310
stream) reported soapyremote host overruns "even at a tiny bandwidth". The
wideband pump measured 0.44x real time on one core with 65% of it inside
DecodeAACH: DecodeRM3014Tetra / DecodeRM3014TetraSoft were maximum-likelihood
searches that re-ran EncodeRM3014Tetra (allocating) for every one of the
16 384 codewords on every call — ~15 ms and ~16 k allocations per AACH decode,
once per downlink slot per carrier plus once per traffic burst in the voice
demux, and the source of the ~19 GC/s in the operator's heartbeat lines.

Build the codebook once (uint32-packed, indexed by the systematic info bits)
and search it with popcount (hard) or three 10-bit partial-sum tables (soft):
17 µs / 36 µs, allocation-free on the search path, bit-identical to the
brute force, which the new test keeps as the reference.

filter.FIR was the next cost: its ring buffer branched per tap. Keep a
mirrored 2N history so the window is contiguous and accumulate in the same
float32 order, pinned bit-exact against the old loop.

Two TETRA channels at 200 kS/s now process at 0.12x real time (was 0.44x).
TestEngineDualTETRA200kThroughput (GT_WB_BENCH_SECONDS) is the instrument.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CWgNx2LsGqfcEz3gadJb1M