### PR TITLE
ambe2: decode 2450 silence frames like the references (#644); tetra dmo: voice chain adopts the pipeline's colour (#1003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,31 @@ for tagged releases.
   never require acceptance.
 
 ### Fixed
+- **DMR (AMBE+2 3600x2450) silence frames no longer gate the audio and reset the
+  gain predictor** (#644). A frame-by-frame diff of the in-tree decoder against
+  szechyjs/mbelib and mbelib-neo (the dsd-neo vocoder) on the #644 sample showed
+  the 2450 unpack is bit-identical on every voice frame, but AMBE+2 *silence*
+  frames (b0 124/125 — 47% of that sample, in runs of up to 1.3 s) were
+  short-circuited to digital silence with the cross-frame state reset, whereas
+  both references decode them as an ordinary all-unvoiced frame (w0 = 2π/32,
+  L = 14) carrying the frame's own gain delta and spectral envelope. The first
+  voice frame after every pause therefore decoded with gamma = ΔΓ + 0 instead of
+  ΔΓ + 0.5·γ_prev — up to 4 log2 units (≈24 dB) low against both references —
+  and the pauses were hard-gated between utterances. Silence frames now decode
+  as the references do (the background the radio encoded plays at its
+  transmitted level, the predictor carries through); pinned by literal reference
+  vectors in `params2450_silence_test.go`.
+- **TETRA DMO voice chain adopts the control pipeline's recovered colour instead
+  of falling back to colour 0** (#1003, the 20 Aug on-air run). The chain gave up
+  at colour 0 when its own recovery did not land, before ever adopting the
+  pipeline's colour, and a hint that once failed local re-verification was never
+  retried — so a whole PTT decoded as BFI and ended on hangtime. The pipeline's
+  colour (confidence-gated on the same carrier) now wins wherever the colour-0
+  guess would otherwise be used, and the two DMO receivers share one
+  configuration (`tetrarx.DMOOptions`: equalizer on, DC block off — the voice
+  chain alone ran the DC blocker, the prime suspect for why it could not verify
+  the colour the pipeline recovered). `tetra_mcc` / `tetra_mnc` now appear in
+  `config.example.yaml` (a `tetra-dmo` system example). Still on-air-gated.
 - **Voice-calibration docs described a DSD-FME invocation that cannot work**:
   `dsd-fme -r <call>.raw -o reference.wav` (`-r` reads DSD-FME's cookie-headed
   `.imb`/`.amb` container written by `recordings.mbe_files`, not the flat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1222,3 +1222,34 @@ confirmation before any close-as-completed.
   (`captureName`) — `%.3f` renamed a 442.3875 MHz slice "442.387MHz"; every other frequency
   name in the tree was already `%.4f`, and `toFixed(3)` on a centre frequency in a SPA is a
   bug (sample rates / spans / kHz spacings at 3 decimals are fine).
+- **AMBE+2 3600x2450 (DMR) is bit-identical to mbelib on every VOICE frame — the #644
+  "computer voice" was the SILENCE-frame handling, measured against two references.**
+  A frame-by-frame diff (szechyjs/mbelib 1.3.0 + arancormonk/mbelib-neo, both cloneable
+  from the dev environment; build with `gcc -c` + `ar`, dump `cur_mp` per frame) of the
+  committed `internal/voice/ambe2/testdata/dmr-voice.raw` (the reporter's 378-frame TS2
+  clip) shows `unpackParams2450`'s Tl/Vl/L/w0 match mbelib to 1e-5 on all 201 voice frames
+  and the amplitude prediction within ~1 dB per band — so the earlier "the 2450 high-band
+  deficit is in unpackParams2450" note is REFUTED; do not chase the 2450 tables. What
+  differed: 177 frames are AMBE+2 *silence* frames (b0 124/125, runs of 44/63 = ~1.3 s)
+  that both references decode as an all-unvoiced fixed-model frame (w0 = 2π/32, L = 14,
+  the frame's own ΔΓ/PRBA/HOC) and synthesise, while GT rendered digital silence and
+  reset the predictor — so every post-pause onset frame had gamma = ΔΓ + 0 vs
+  ΔΓ + 0.5·γ_prev (frame 95: 4.37 vs 8.40; frame 308: 5.78 vs 10.03 — ≈24 dB), and the
+  pauses were hard-gated. Fixed to the reference behaviour; `params2450_silence_test.go`
+  pins literal Tl (frame 0) and the gamma sequence at every onset (both refs agree to the
+  printed precision). Two things the diff did NOT settle: the two references disagree on
+  the silence model itself (mbelib-neo/JMBE uses L=15 and a different w0; mbelib and
+  DSD-FME's lwvmobile fork use 2π/32 / L=14 — GT follows the DSD-FME lineage the reporter
+  compares against), and the whole-file band fractions depend on that model, so compare
+  voice frames only (`voicemask`) when measuring spectra. On this sample GT is NOT high-band
+  deficient vs mbelib-neo on voice frames (3–4 kHz 0.057 vs 0.123 fraction, GT brighter).
+- **TETRA DMO voice chain (#1003, 20 Aug run) now adopts the pipeline's colour over the
+  colour-0 fallback, and both DMO receivers share `tetrarx.DMOOptions`.** The chain's
+  give-up path fell back to `baseMNI` before adopting the pipeline's 39, and a hint that
+  failed local re-verification once was never retried; `adoptLiveColourUnverified` now
+  applies the pipeline's (confidence-gated) colour wherever the guess would be used
+  (give-up cap, post-give-up hint, flush) — pinned failing-first by
+  `TestDMOVoiceDecoderPrefersPipelineColourOverFallback`. The voice chain's `EnableDCBlock`
+  is now OFF like the pipeline's (the prime suspect for the divergent bursts); still
+  on-air-gated. `tetra_mcc`/`tetra_mnc` were missing from config.example.yaml (the 4 Sep
+  rule) — now in a `tetra-dmo` example.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1196,6 +1196,18 @@ trunking:
   #     #                               # traffic soft path (opt-in until
   #     #                               # the GT_TETRA_LMS capture A/B)
   #
+  #   - name: "DMO-438.9"
+  #     protocol: tetra-dmo             # TETRA Direct Mode (radio-to-radio);
+  #     control_channels: [438_900_000] # the DMO carrier to camp on
+  #     tetra_mcc: 250                  # the radios' network MNI (CPS codeplug):
+  #     tetra_mnc: 1                    #   TCH/S is scrambled with the FULL
+  #                                     #   ExtendedColourCode(MCC, MNC, colour),
+  #                                     #   so a non-zero MNI must be configured
+  #                                     #   or colour recovery never reaches the
+  #                                     #   seed; 0 / 0 (default) = MNI-0 DMO
+  #     # tetra_colour_code: 39         # pin the DM colour (normally auto-
+  #                                     #   recovered from the traffic)
+  #
   #   - name: "Legacy-EDACS"
   #     protocol: edacs
   #     control_channels: [856_012_500]

--- a/internal/radio/tetra/receiver/dmo_options.go
+++ b/internal/radio/tetra/receiver/dmo_options.go
@@ -1,0 +1,34 @@
+package receiver
+
+// DMOOptions returns the receiver configuration every TETRA DMO (Direct Mode)
+// consumer shares. The control pipeline (ccdecoder's tetra-dmo pipeline) and the
+// voice composer's DMO chain run the SAME π/4-DQPSK receiver on the SAME carrier
+// tap, and they have to slice the same bursts: the pipeline recovers the DM
+// traffic colour code from its stream and hands it to the voice chain, which
+// verifies it against ITS stream before adopting it. On the 20 Aug #1003 on-air
+// run the two receivers were configured differently — the voice chain
+// additionally ran the DC-removal high-pass — and they disagreed: the pipeline
+// decoded ~200 CRC-valid TCH/S at colour 39 in one PTT while the voice chain could
+// not verify that colour on its own bursts and decoded nothing. Sharing the knobs
+// makes that drift structurally impossible.
+//
+// Callers attach their own sinks (DibitSink / SoftSink / SymbolSink) and may
+// override ClockMode from the system config; nothing else should differ.
+//
+//   - EnableEqualizer: the blind SnapshotCMA is REQUIRED for DMO, not optional —
+//     on the reporter's 438.9 MHz capture it lifts CRC-valid SCH/S from ~6 to ~64
+//     by inverting the ISI that smears the constellation (the same lever the TMO
+//     CC path and the offline TestTETRADMOReplay run by default).
+//   - EnableDCBlock stays OFF, as on the control pipeline that decodes on air.
+//     The DC blocker is the TMO voice-only stage (receiver.go); DMO's pipeline has
+//     never run it, and it is the prime suspect for the 20 Aug divergence.
+func DMOOptions(sampleRateHz float64) Options {
+	return Options{
+		SampleRateHz:        sampleRateHz,
+		ClockMode:           ClockGardner,
+		GardnerGain:         0.005,
+		EnableAFC:           true,
+		EnableChannelFilter: true,
+		EnableEqualizer:     true,
+	}
+}

--- a/internal/radio/tetra/receiver/dmo_options_test.go
+++ b/internal/radio/tetra/receiver/dmo_options_test.go
@@ -1,0 +1,28 @@
+package receiver
+
+import "testing"
+
+// TestDMOOptionsMatchTheOnAirPipeline pins the shared DMO receiver knobs to the
+// configuration the control pipeline decoded with on the 20 Aug #1003 capture,
+// so neither DMO consumer can drift back to a private receiver setup.
+func TestDMOOptionsMatchTheOnAirPipeline(t *testing.T) {
+	o := DMOOptions(144_000)
+	if o.SampleRateHz != 144_000 {
+		t.Errorf("SampleRateHz = %v, want 144000", o.SampleRateHz)
+	}
+	if !o.EnableEqualizer {
+		t.Errorf("EnableEqualizer = false; the blind CMA is required for DMO")
+	}
+	if o.EnableDCBlock {
+		t.Errorf("EnableDCBlock = true; the DMO pipeline that decodes on air runs it off")
+	}
+	if !o.EnableAFC || !o.EnableChannelFilter {
+		t.Errorf("AFC=%v channel filter=%v, want both on", o.EnableAFC, o.EnableChannelFilter)
+	}
+	if o.ClockMode != ClockGardner || o.GardnerGain != 0.005 {
+		t.Errorf("clock %v gain %v, want Gardner / 0.005", o.ClockMode, o.GardnerGain)
+	}
+	if o.DibitSink != nil || o.SoftSink != nil || o.SymbolSink != nil {
+		t.Errorf("DMOOptions must not attach sinks; callers own them")
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines_dmo.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo.go
@@ -115,29 +115,26 @@ func newTETRADMOPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	}
 	p.ext = tetra.NewDMStreamExtractor(p.onBurst)
 	p.grid = tetra.NewDMSlotGrid()
-	p.rx = tetrarx.New(tetrarx.Options{
-		SampleRateHz: opts.SampleRateHz,
-		DibitSink: func(dibits []uint8, baseIdx int) {
-			opts.tapDibits(dibits, baseIdx)
-			p.ext.Process(dibits, p.pendingSoft, baseIdx)
-			p.pendingSoft = nil
-		},
-		// The SoftSink fires just before the matching DibitSink with the same base
-		// (issue #553), so stash the differentials and hand them to the extractor
-		// alongside the dibits, keeping the two strictly parallel.
-		SoftSink: func(diffs []complex64, baseIdx int) {
-			p.pendingSoft = diffs
-		},
-		ClockMode:           tetraClockMode,
-		GardnerGain:         0.005,
-		EnableAFC:           true,
-		EnableChannelFilter: true,
-		// The blind SnapshotCMA equalizer is REQUIRED for DMO, not optional: on the
-		// reporter's 438.9 MHz capture it lifts CRC-valid SCH/S from ~6 to ~64 by
-		// inverting the ISI that smears the π/4-DQPSK constellation (same lever the
-		// TMO CC path and the offline TestTETRADMOReplay run by default).
-		EnableEqualizer: true,
-	})
+	// The receiver knobs (equalizer on, DC block off, AFC, channel filter) are
+	// shared with the composer's DMO voice chain through tetrarx.DMOOptions so
+	// both consumers slice the same bursts — the voice chain verifies THIS
+	// pipeline's recovered colour against its own stream (see DMOOptions' doc for
+	// the 20 Aug divergence). Only the sinks and the configured clock mode are
+	// set here.
+	rxOpts := tetrarx.DMOOptions(opts.SampleRateHz)
+	rxOpts.DibitSink = func(dibits []uint8, baseIdx int) {
+		opts.tapDibits(dibits, baseIdx)
+		p.ext.Process(dibits, p.pendingSoft, baseIdx)
+		p.pendingSoft = nil
+	}
+	// The SoftSink fires just before the matching DibitSink with the same base
+	// (issue #553), so stash the differentials and hand them to the extractor
+	// alongside the dibits, keeping the two strictly parallel.
+	rxOpts.SoftSink = func(diffs []complex64, baseIdx int) {
+		p.pendingSoft = diffs
+	}
+	rxOpts.ClockMode = tetraClockMode
+	p.rx = tetrarx.New(rxOpts)
 	log.Info("ccdecoder: tetra DMO pipeline configured",
 		"system", opts.SystemName, "freq_hz", opts.FrequencyHz,
 		"colour_override", opts.System.TETRAColourCode)

--- a/internal/voice/ambe2/params.go
+++ b/internal/voice/ambe2/params.go
@@ -62,6 +62,14 @@ type Params struct {
 	DeltaGamma float64
 	Unvc       float64
 	Tone       bool
+	// SilenceFrame marks an AMBE+2 3600x2450 "silence" frame (b0 124 or
+	// 125). It is NOT a Silent frame to the decoder: mbelib and
+	// mbelib-neo/JMBE both decode it as an ordinary all-unvoiced frame
+	// with a fixed spectral model (w0 = 2π/32, L = 14) and the frame's
+	// own gain / PRBA / HOC bits, so the gain predictor and the log2Ml
+	// history carry across a pause and the background the radio encoded
+	// is synthesised at its transmitted level. See unpackParams2450.
+	SilenceFrame bool
 
 	B0, B1, B2, B3, B4, B5, B6, B7, B8 int
 }

--- a/internal/voice/ambe2/params2450.go
+++ b/internal/voice/ambe2/params2450.go
@@ -16,9 +16,11 @@ import (
 // Algorithmic reference: szechyjs/mbelib's mbe_decodeAmbe2450Parms in
 // ambe3600x2450.c (ISC-licensed; codebook attribution in
 // tables2450.go). The 2450 frame distinguishes erasure (b0 120-123),
-// silence (124-125) and tone (126-127) frames by b0 range; all three
-// are rendered as silence here — tone synthesis is a follow-up,
-// matching the 2400 path's tone-as-silence treatment.
+// silence (124-125) and tone (126-127) frames by b0 range: erasure and
+// tone are rendered as silence here (tone synthesis is a follow-up,
+// matching the 2400 path's tone-as-silence treatment); a silence frame
+// is decoded as the all-unvoiced fixed-model frame both references
+// make of it (see below).
 func unpackParams2450(info []byte) (Params, error) {
 	if len(info) != InfoBits {
 		return Params{}, fmt.Errorf("%w, got %d", ErrInfoLength, len(info))
@@ -32,9 +34,27 @@ func unpackParams2450(info []byte) (Params, error) {
 		int(info[38])<<1 |
 		int(info[39])
 
-	// b0 in 120..127 marks an erasure / silence / tone frame; render
-	// all three as silence.
-	if b0 >= 120 {
+	// b0 in 120..127 is not a voice pitch. 120..123 mark an erasure and
+	// 126..127 a tone frame; both are rendered as silence (tone synthesis
+	// is a follow-up, matching the 2400 path's tone-as-silence treatment).
+	//
+	// 124..125 are AMBE+2 SILENCE frames, and those are NOT silence to the
+	// decoder. mbelib's mbe_decodeAmbe2450Parms (the DSD-FME lineage) and
+	// mbelib-neo/JMBE both decode them as an ordinary all-unvoiced frame
+	// with a fixed model — w0 = 2π/32, L = 14 — and the frame's own gain /
+	// PRBA / HOC bits, then synthesise them like any other frame: the gain
+	// predictor (gamma = ΔΓ + 0.5·γ_prev) and the log2Ml history carry
+	// through the pause, and the background the radio encoded (a vehicle
+	// cab, a street) plays at its transmitted level. GopherTrunk used to
+	// short-circuit them to digital silence AND reset the predictor, so the
+	// first frame after every pause decoded with gamma = ΔΓ + 0 instead of
+	// ΔΓ + 0.5·γ_prev. Measured on the #644 sample (47% silence frames)
+	// against both references: identical Tl on every voice frame, but
+	// 4 log2 units (≈24 dB) low at each utterance onset, with the pauses
+	// hard-gated in between — the "unnatural / computer voice" report.
+	// Pinned by TestDecodeDMRSampleGammaTracksReference.
+	silenceFrame := b0 == 124 || b0 == 125
+	if b0 >= 120 && !silenceFrame {
 		p := Params{B0: b0}
 		p.Params.Silent = true
 		if b0 >= 126 {
@@ -43,32 +63,44 @@ func unpackParams2450(info []byte) (Params, error) {
 		return p, nil
 	}
 
-	f0 := dmrW0table[b0]
+	var f0 float64
+	var L int
+	if silenceFrame {
+		// mbelib: cur_mp->w0 = 2π/32, f0 = 1/32, L = 14, Vl[1..L] = 0.
+		f0 = 1.0 / 32
+		L = 14
+	} else {
+		f0 = dmrW0table[b0]
+		L = int(dmrLtable[b0])
+	}
 	w0 := f0 * 2 * math.Pi
 	unvc := 0.2046 / math.Sqrt(w0)
-	L := int(dmrLtable[b0])
 	if L < 9 || L > 56 {
 		return Params{}, fmt.Errorf("ambe2: 2450 derived L=%d out of [9, 56]", L)
 	}
 
 	p := Params{
-		Params: mbe.Params{Header: mbe.Header{W0: w0, L: L}},
-		Unvc:   unvc,
-		B0:     b0,
+		Params:       mbe.Params{Header: mbe.Header{W0: w0, L: L}},
+		Unvc:         unvc,
+		B0:           b0,
+		SilenceFrame: silenceFrame,
 	}
 
-	// V/UV: b1 (5 bits) selects a voicing-pattern row.
+	// V/UV: b1 (5 bits) selects a voicing-pattern row. A silence frame is
+	// all-unvoiced by definition (Vl stays 0; mbelib skips the lookup).
 	b1 := int(info[4])<<4 | int(info[5])<<3 | int(info[6])<<2 |
 		int(info[7])<<1 | int(info[35])
 	p.B1 = b1
-	for l := 1; l <= L; l++ {
-		jl := int(float64(l) * 16.0 * f0)
-		if jl < 0 {
-			jl = 0
-		} else if jl > 7 {
-			jl = 7
+	if !silenceFrame {
+		for l := 1; l <= L; l++ {
+			jl := int(float64(l) * 16.0 * f0)
+			if jl < 0 {
+				jl = 0
+			} else if jl > 7 {
+				jl = 7
+			}
+			p.Vl[l] = dmrVuv[b1][jl]
 		}
-		p.Vl[l] = dmrVuv[b1][jl]
 	}
 
 	// Gain delta — absolute gamma is folded in by the synthesizer.

--- a/internal/voice/ambe2/params2450_silence_test.go
+++ b/internal/voice/ambe2/params2450_silence_test.go
@@ -1,0 +1,139 @@
+package ambe2
+
+import (
+	"encoding/hex"
+	"math"
+	"os"
+	"testing"
+)
+
+// Literal frames from the committed #644 fixture (testdata/dmr-voice.raw,
+// 7 bytes per frame, MSB-first) and reference values from an independent
+// decoder: szechyjs/mbelib 1.3.0 mbe_decodeAmbe2450Parms (ambe3600x2450.c)
+// run over the same bytes; mbelib-neo (the dsd-neo vocoder, JMBE-derived)
+// reproduces every gamma value below to the printed precision. Literal
+// vectors cross-checked against an independent decoder are the only thing
+// that catches constant/table drift — a round-trip test cannot.
+const (
+	dmrSampleFrame0  = "b0b9243e0bc180" // voice frame, b0=91, L=37
+	dmrSampleFrame19 = "f84902a06c3d80" // first AMBE+2 silence frame, b0=124
+)
+
+// mbelibFrame0Tl is Tl[1..37] for dmrSampleFrame0 straight out of
+// mbe_decodeAmbe2450Parms (before the log2Ml prediction), the stateless
+// part of the unpack: b0..b8 → tables → PRBA/HOC inverse DCTs.
+var mbelibFrame0Tl = []float64{
+	-0.28504, 0.04614, -0.06424, 0.02870, 0.85792, 1.17561, 0.30392, -0.66631,
+	-0.15903, -0.09478, -0.04798, 0.06767, 0.25219, 0.35697, 0.44166, 0.57037,
+	1.32356, 0.83144, 0.19813, -0.21465, -0.23297, 0.13734, 0.64194, 0.81750,
+	0.45392, -0.03082, -0.05036, -0.34765, -0.56400, -0.54765, -0.53555, -0.63647,
+	-0.62833, -0.48978, -0.67395, -1.44068, -2.23123,
+}
+
+func mustFrame(t *testing.T, h string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(h)
+	if err != nil || len(b) != FrameBytes {
+		t.Fatalf("bad literal frame %q: %v", h, err)
+	}
+	return b
+}
+
+// TestUnpack2450TlMatchesMbelibFrame0 pins the stateless spectral-residual
+// reconstruction of the 3600x2450 unpack against the mbelib reference on a
+// real over-the-air frame: same tables, same DCTs, to 1e-5.
+func TestUnpack2450TlMatchesMbelibFrame0(t *testing.T) {
+	p, err := unpackParams2450(unpackInfoBits(mustFrame(t, dmrSampleFrame0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.B0 != 91 || p.L != len(mbelibFrame0Tl) || p.SilenceFrame {
+		t.Fatalf("b0=%d L=%d silence=%v, want b0=91 L=%d voice", p.B0, p.L, p.SilenceFrame, len(mbelibFrame0Tl))
+	}
+	for l, want := range mbelibFrame0Tl {
+		if got := p.Tl[l+1]; math.Abs(got-want) > 2e-5 {
+			t.Errorf("Tl[%d] = %.5f, mbelib %.5f", l+1, got, want)
+		}
+	}
+}
+
+// TestUnpack2450SilenceFrameIsUnvoicedNoiseFrame pins how an AMBE+2 silence
+// frame (b0 124/125) unpacks: as mbelib's fixed all-unvoiced model
+// (w0 = 2π/32, L = 14) carrying the frame's own gain delta and spectral
+// residuals — not as a Silent short-circuit. Fails against the old unpack,
+// which returned Params{Silent: true} with no gain and no envelope.
+func TestUnpack2450SilenceFrameIsUnvoicedNoiseFrame(t *testing.T) {
+	info := unpackInfoBits(mustFrame(t, dmrSampleFrame19))
+	p, err := unpackParams2450(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.B0 != 124 || !p.SilenceFrame {
+		t.Fatalf("b0=%d silence=%v, want a b0=124 silence frame", p.B0, p.SilenceFrame)
+	}
+	if p.Silent || p.Tone {
+		t.Fatalf("silence frame flagged Silent=%v Tone=%v; the references decode it as a voice-path frame", p.Silent, p.Tone)
+	}
+	if p.L != 14 || math.Abs(p.W0-2*math.Pi/32) > 1e-12 {
+		t.Errorf("model L=%d w0=%.6f, want L=14 w0=2π/32=%.6f (mbelib silence model)", p.L, p.W0, 2*math.Pi/32)
+	}
+	for l := 1; l <= p.L; l++ {
+		if p.Vl[l] != 0 {
+			t.Errorf("Vl[%d]=%d, want 0 (all-unvoiced)", l, p.Vl[l])
+		}
+	}
+	// The gain delta must come from the frame's b2 bits, exactly as for a
+	// voice frame.
+	b2 := int(info[8])<<4 | int(info[9])<<3 | int(info[10])<<2 | int(info[11])<<1 | int(info[36])
+	if p.B2 != b2 || p.DeltaGamma != dmrDg[b2] {
+		t.Errorf("DeltaGamma=%.4f (b2=%d), want dmrDg[%d]=%.4f", p.DeltaGamma, p.B2, b2, dmrDg[b2])
+	}
+	var nonZero int
+	for l := 1; l <= p.L; l++ {
+		if p.Tl[l] != 0 {
+			nonZero++
+		}
+	}
+	if nonZero == 0 {
+		t.Errorf("no spectral residuals decoded for the silence frame")
+	}
+}
+
+// TestDecodeDMRSampleGammaTracksReference is the cross-frame regression for
+// the #644 onset defect. The fixture is 47% silence frames in runs of up to
+// 63 (~1.3 s). Both reference decoders carry the gain predictor through
+// them (gamma = ΔΓ + 0.5·γ_prev on every frame, silence included); the old
+// decoder reset gamma to 0 on each silence frame, so the first voice frame
+// after every pause landed up to 4 log2 units (≈24 dB) below the
+// references (frame 95: 4.37 vs 8.40; frame 308: 5.78 vs 10.03). The
+// expected values are cur_mp->gamma from mbelib after decoding the named
+// frame; mbelib-neo agrees on every one.
+func TestDecodeDMRSampleGammaTracksReference(t *testing.T) {
+	raw, err := os.ReadFile("testdata/dmr-voice.raw")
+	if err != nil {
+		t.Skipf("no #644 sample at testdata/dmr-voice.raw: %v", err)
+	}
+	want := map[int]float64{
+		0:   4.22829,  // first voice frame (no history)
+		19:  3.78742,  // first silence frame: its own gamma
+		63:  -2.37824, // onset after a 44-frame silence run
+		95:  8.40044,  // onset after a 20-frame run (old decoder: 4.37)
+		103: 7.36772,
+		162: -2.62281,
+		169: 2.68536,
+		279: -2.64333,
+		308: 10.03160, // onset after a 63-frame run (old decoder: 5.78)
+	}
+	d := NewDMR()
+	for i := 0; i+FrameBytes <= len(raw); i += FrameBytes {
+		frame := i / FrameBytes
+		if _, err := d.Decode(raw[i : i+FrameBytes]); err != nil {
+			t.Fatalf("decode frame %d: %v", frame, err)
+		}
+		if w, ok := want[frame]; ok {
+			if math.Abs(d.prevGamma-w) > 2e-3 {
+				t.Errorf("frame %d: gamma %.5f, reference %.5f", frame, d.prevGamma, w)
+			}
+		}
+	}
+}

--- a/internal/voice/composer/tetra_dmo_voice.go
+++ b/internal/voice/composer/tetra_dmo_voice.go
@@ -61,21 +61,18 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 	}
 	ext := tetra.NewDMStreamExtractor(dec.onBurst)
 
+	// The receiver knobs are shared with the control pipeline through
+	// tetrarx.DMOOptions (equalizer on, DC block OFF — the 20 Aug #1003 run showed
+	// this chain, with the DC blocker on, could not verify the colour the pipeline
+	// recovered on the same carrier). Only the sinks are attached here.
 	var pendingSoft []complex64
-	rx := tetrarx.New(tetrarx.Options{
-		SampleRateHz: symbolHz,
-		DibitSink: func(d []uint8, base int) {
-			ext.Process(d, pendingSoft, base)
-			pendingSoft = nil
-		},
-		SoftSink:            func(diffs []complex64, base int) { pendingSoft = diffs },
-		ClockMode:           tetrarx.ClockGardner,
-		GardnerGain:         0.005,
-		EnableAFC:           true,
-		EnableChannelFilter: true,
-		EnableEqualizer:     true, // invert the ISI that garbles DMO TCH/S (required for DMO)
-		EnableDCBlock:       true, // strip the front-end DC spur on the voice tap
-	})
+	rxOpts := tetrarx.DMOOptions(symbolHz)
+	rxOpts.DibitSink = func(d []uint8, base int) {
+		ext.Process(d, pendingSoft, base)
+		pendingSoft = nil
+	}
+	rxOpts.SoftSink = func(diffs []complex64, base int) { pendingSoft = diffs }
+	rx := tetrarx.New(rxOpts)
 
 	c.log.Info("composer: tetra DMO voice follow started — DNB TCH/S decode + ACELP vocoder",
 		"serial", serial, "colour_hint", colourHint, "rate_hz", symbolHz)
@@ -86,6 +83,7 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 			"serial", serial, "dnb_bursts", dec.dnb.Load(),
 			"speech_frames", dec.speech.Load(), "bfi_count", dec.bfi.Load(),
 			"colour", dec.colour, "colour_recovered", dec.colourRecovered,
+			"colour_from_pipeline", dec.colourFromPipeline,
 			"colour_attempts", dec.colourTries)
 	}()
 
@@ -122,8 +120,11 @@ const (
 	// colour-code recovery (matches the pipeline's dmoColourBatch cadence).
 	dmoVoiceColourBatch = 20
 	// dmoVoiceColourMax caps the buffer: past this, if no colour has cleared the
-	// confidence gate, decode the buffer at colour 0 (a clear radio-to-radio call) and
-	// stop buffering — an encrypted/unrecoverable call then simply yields no speech.
+	// confidence gate, stop buffering and decode at the best colour available —
+	// the control pipeline's recovered colour if it has one (adopted even when
+	// this chain cannot re-verify it locally, see adoptLiveColourUnverified),
+	// else colour 0 on the known MNI (a clear radio-to-radio call). An
+	// encrypted/unrecoverable call then simply yields no speech.
 	dmoVoiceColourMax = 120
 	// dmoVoiceColourMaxAttempts caps how many recovery passes to run, mirroring the
 	// control pipeline's dmoColourMaxAttempts.
@@ -170,7 +171,14 @@ type dmoVoiceDecoder struct {
 	// colour 0", which colourKnown alone conflates — the end-of-call log used to
 	// claim colour_known=true colour=0 on a call where nothing was ever recovered.
 	colourRecovered bool
-	buffer          []tetra.DMBurst // ALL DNBs awaiting colour recovery (retroactive decode)
+	// colourFromPipeline is set when the control pipeline's colour was adopted
+	// WITHOUT this chain verifying it on its own bursts (the give-up / flush
+	// paths, or a hint landing after give-up). The pipeline's answer is
+	// confidence-gated on the same carrier, so it beats the colour-0 fallback
+	// it replaces; on the 20 Aug #1003 run the chain fell back to 0 before
+	// ever adopting the pipeline's 39 and decoded 242 DNBs as BFI.
+	colourFromPipeline bool
+	buffer             []tetra.DMBurst // ALL DNBs awaiting colour recovery (retroactive decode)
 	// scored holds only the slot-grid-QUALIFIED DNBs (freshest
 	// dmoVoiceColourBatch), the set colour recovery and hint verification score
 	// against. The DNB correlator false-alarms ~18/s, so an un-gated scoring
@@ -271,6 +279,31 @@ func (d *dmoVoiceDecoder) tryAdoptLiveColour() bool {
 	return true
 }
 
+// adoptLiveColourUnverified adopts the control pipeline's recovered colour
+// WITHOUT verifying it against this chain's own bursts. It is only used where the
+// alternative is the colour-0 fallback — the give-up cap, flush, or a hint that
+// lands after give-up — never while local recovery still has a chance, so a stale
+// hint can only ever replace a guess, not a locally recovered colour. The
+// pipeline's colour is confidence-gated (RecoverDMColourCode's dominance gate) on
+// the same carrier; the fallback is not evidence at all. This is what the 20 Aug
+// #1003 on-air run lacked: the chain gave up at colour 0 before adopting the
+// pipeline's 39, and tryAdoptLiveColour's re-verification then failed forever on a
+// receiver whose bursts differed from the pipeline's. Returns true when the colour
+// changed.
+func (d *dmoVoiceDecoder) adoptLiveColourUnverified() bool {
+	if d.liveColour == nil || d.colourRecovered {
+		return false
+	}
+	c, known := d.liveColour()
+	if !known || (d.colourKnown && c == d.colour) {
+		return false
+	}
+	d.colour, d.colourKnown, d.colourFromPipeline = c, true, true
+	d.c.log.Info("composer: tetra DMO colour adopted from control pipeline (not verified on this chain's bursts)",
+		"serial", d.serial, "colour", c)
+	return true
+}
+
 // onBurst handles one streamed DMO burst. DSBs carry no speech (signalling only), so
 // only DNBs are decoded. Until the colour code is known, DNBs are buffered; once
 // recovered/adopted (or the cap forces a colour-0 fallback) the buffer is decoded in
@@ -289,7 +322,11 @@ func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
 			if qualified {
 				d.pushScored(b)
 			}
-			d.tryAdoptLiveColour()
+			// A verified adoption is preferred; failing that, the pipeline's
+			// colour still beats the fallback this chain is decoding at.
+			if !d.tryAdoptLiveColour() {
+				d.adoptLiveColourUnverified()
+			}
 		}
 		d.emit(b)
 		return
@@ -311,10 +348,13 @@ func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
 	case canBrute && d.tryRecoverColour():
 		// Recovered locally; fall through and flush.
 	case len(d.buffer) >= dmoVoiceColourMax || d.colourTries >= dmoVoiceColourMaxAttempts:
-		// Give up recovering; assume clear colour 0 on top of the known MNI
+		// Give up recovering locally. Prefer the control pipeline's colour even
+		// unverified; otherwise assume clear colour 0 on top of the known MNI
 		// (baseMNI | 0 — plain 0 when MNI is 0). A genuinely encrypted call then
 		// yields no CRC-valid speech (bfi), which the hangtime ends normally.
-		d.colour, d.colourKnown = d.baseMNI, true
+		if !d.adoptLiveColourUnverified() {
+			d.colour, d.colourKnown = d.baseMNI, true
+		}
 	default:
 		return // keep buffering
 	}
@@ -374,9 +414,10 @@ func (d *dmoVoiceDecoder) flush() {
 		if !d.tryAdoptLiveColour() {
 			d.tryRecoverColour()
 		}
-		if !d.colourRecovered {
-			// Nothing cleared the gate — fall back to clear colour 0 on top of the
-			// known MNI (baseMNI | 0) so a short clear call still decodes.
+		if !d.colourRecovered && !d.adoptLiveColourUnverified() {
+			// Nothing cleared the gate and the pipeline has no answer — fall back
+			// to clear colour 0 on top of the known MNI (baseMNI | 0) so a short
+			// clear call still decodes.
 			d.colour = d.baseMNI
 		}
 		d.colourKnown = true

--- a/internal/voice/composer/tetra_dmo_voice_test.go
+++ b/internal/voice/composer/tetra_dmo_voice_test.go
@@ -457,3 +457,67 @@ func TestDMOVoiceDecoderKeepsBufferedSpeechAcrossAttempts(t *testing.T) {
 		}
 	}
 }
+
+// TestDMOVoiceDecoderPrefersPipelineColourOverFallback reproduces the 20 Aug
+// #1003 on-air run. The grant fired with colour_hint=0; the chain buffered past
+// dmoVoiceColourMax without its own recovery landing and the give-up path fell
+// back to colour 0 BEFORE it ever adopted the pipeline's colour (39 on that
+// run). tryAdoptLiveColour then never cleared, because its local re-verification
+// kept failing on this chain's own bursts (a receiver configured differently
+// from the pipeline's) and a hint that failed once was never retried — so all
+// 242 DNBs decoded as BFI and the call died on hangtime. The pipeline's colour is
+// confidence-gated on the same carrier; the fallback is a guess, so the
+// pipeline's answer must win wherever the fallback would otherwise be used.
+//
+// Here the chain's bursts are undecodable at ANY colour while the hint is up
+// (local recovery and hint verification both fail, as on air) and a few
+// decodable colour-39 bursts arrive afterwards. Old code: colour 0, nothing
+// emitted. Fixed: colour 39 adopted at give-up (or the moment the hint lands
+// after give-up) and every good burst's speech emitted.
+func TestDMOVoiceDecoderPrefersPipelineColourOverFallback(t *testing.T) {
+	const colour = 39
+	for _, tc := range []struct {
+		name         string
+		hintAfterDNB int // hint becomes known once this many DNBs were seen
+	}{
+		{"hint known from the start", 0},
+		{"hint lands after the give-up cap", dmoVoiceColourMax + 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			noise := buildDMOUndecodableDNBs(t, dmoVoiceColourMax+10)
+			good, want := buildDMODNBBursts(t, colour, 6)
+
+			sink := &fakeDMOSink{}
+			c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+			seen := 0
+			dec := &dmoVoiceDecoder{
+				c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
+				grid: tetra.NewDMSlotGrid(),
+				liveColour: func() (uint32, bool) {
+					if seen >= tc.hintAfterDNB {
+						return colour, true
+					}
+					return 0, false
+				},
+			}
+			for _, b := range noise {
+				seen++
+				dec.onBurst(b)
+			}
+			for _, b := range good {
+				seen++
+				dec.onBurst(b)
+			}
+			dec.flush()
+
+			if !dec.colourKnown || dec.colour != colour {
+				t.Fatalf("decoding at colour=%d known=%v, want the pipeline's %d over the colour-0 fallback",
+					dec.colour, dec.colourKnown, colour)
+			}
+			if len(sink.frames) != 2*len(want) {
+				t.Fatalf("emitted %d speech frames, want %d (good bursts decoded BFI at the fallback colour?)",
+					len(sink.frames), 2*len(want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two reference-pinned fixes from the daily issue review, one per commit, plus the notes.

**#644 (DMR "computer voice").** The staged "frame-by-frame diff against a wired mbelib 2450 reference" is done: szechyjs/mbelib 1.3.0 and arancormonk/mbelib-neo (the dsd-neo vocoder) were built and run over the committed 378-frame `dmr-voice.raw` sample, dumping `cur_mp` per frame. Result: `unpackParams2450` is **bit-identical** on every voice frame (Tl to 1e-5, same Vl/L/w0) and the amplitude prediction is within ~1 dB per band — the earlier "the 2450 high-band deficit is in unpackParams2450" note is refuted. What differed: 177 of the 378 frames are AMBE+2 **silence** frames (b0 124/125, runs of up to 1.3 s) that both references decode as an ordinary all-unvoiced fixed-model frame (w0 = 2π/32, L = 14) with the frame's own gain delta and envelope, while GopherTrunk short-circuited them to digital silence and reset the predictor. So the first voice frame after every pause decoded with gamma = ΔΓ + 0 instead of ΔΓ + 0.5·γ_prev — frame 95: 4.37 vs 8.40, frame 308: 5.78 vs 10.03, i.e. ≈24 dB low at each utterance onset — and the pauses were hard-gated.

**#1003 (TETRA DMO, the 20 Aug on-air run).** The voice chain gave up at colour 0 when its own recovery did not land, before ever adopting the colour the control pipeline had recovered on the same carrier, and a hint that once failed local re-verification was never retried — a whole PTT decoded as BFI and ended on hangtime. The pipeline's colour is confidence-gated; the fallback is a guess. It now wins wherever the guess would otherwise be used. The two DMO receivers also share one configuration (`tetrarx.DMOOptions`, equalizer on / DC block off): the voice chain alone ran the DC blocker, the prime suspect for why its bursts could not verify the colour the pipeline decoded ~200 CRC-valid TCH/S with.

## Changes

- `internal/voice/ambe2/params2450.go`, `params.go` — b0 124/125 unpack as mbelib's silence model (all-unvoiced, w0 = 2π/32, L = 14, gain/PRBA/HOC decoded) and run the normal decode path; new `Params.SilenceFrame`. Erasure (120–123) and tone (126–127) unchanged.
- `internal/voice/ambe2/params2450_silence_test.go` — literal reference vectors: frame-0 Tl from mbelib, the silence-frame model, and the gamma sequence at every silence-run onset (both references agree).
- `internal/radio/tetra/receiver/dmo_options.go` (+ test) — the shared DMO receiver knobs; `pipelines_dmo.go` and `tetra_dmo_voice.go` build from it.
- `internal/voice/composer/tetra_dmo_voice.go` — `adoptLiveColourUnverified` at the give-up cap, on a hint landing after give-up, and at flush; `colour_from_pipeline` in the end-of-call log.
- `config.example.yaml` — `tetra_mcc` / `tetra_mnc` were missing (the "every config key" rule); a `tetra-dmo` system example now carries them.
- `CHANGELOG.md`, `CLAUDE.md` — write-ups.

## Test plan

- [x] `make vet test` is green locally (full `-race ./...`, exit 0)
- [ ] `make integration` — not run; no daemon/DSP/replay path changed beyond the receiver option plumbing (the DMO integration test lives under the tag and the ccdecoder/composer unit suites cover the pipeline/voice-chain construction)
- [x] Added tests, all **failing-first** (verified by stashing the fix):
  - `TestUnpack2450SilenceFrameIsUnvoicedNoiseFrame`, `TestDecodeDMRSampleGammaTracksReference` (old unpack: gamma 4.37 / 5.78 at the onsets vs 8.40 / 10.03), `TestUnpack2450TlMatchesMbelibFrame0`
  - `TestDMOVoiceDecoderPrefersPipelineColourOverFallback` (old chain: colour 0, nothing emitted)
  - `TestDMOOptionsMatchTheOnAirPipeline`
- [ ] Smoke-tested against real hardware — **no**. #644: measured against two reference decoders on the reporter's own frames, but not yet A/B'd by ear by the reporter. #1003: on-air-gated per #764/#771; the 20 Aug capture is the operator's.

## Breaking changes

None. DMR audio changes audibly by design: AMBE+2 silence frames now play the background the radio encoded (as DSD-FME / dsd-neo / SDRtrunk do) instead of digital silence, and post-pause onsets are no longer attenuated. No config keys change; `tetra_mcc`/`tetra_mnc` already existed and are only now documented.

## Docs / CHANGELOG

- [x] `## [Unreleased]` → Fixed bullets in `CHANGELOG.md`
- [x] `config.example.yaml` gained the `tetra-dmo` example; `CLAUDE.md` investigation notes

## Linked issues

Refs #644, Refs #1003 (both stay open pending reporter verification; `Refs`, not `Closes`). #1001 gets a status comment only — the on-air LMS lever it was waiting on (`tetra_traffic_lms`) already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3BvrYdtCakj94u4h4EdBR

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3BvrYdtCakj94u4h4EdBR)_