### PR TITLE
tetra dmo: learn the TCH/S scramble seed exactly, per transmission (#1003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,42 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- **TETRA DMO voice: the "bogus colour code on every call" is gone — the
+  TCH/S scramble seed is learned exactly, per transmission (#1003).** The
+  12 Sep three-PTT capture, solved burst by burst with a new exact GF(2)
+  scramble-seed solver (`tetra.SolveTCHScrambleSeed`: the TCH/S coding and the
+  scrambler are both linear, so one error-free DNB pins all 30 seed bits with
+  128 redundant checks), shows a DIFFERENT 30-bit seed on each PTT — the
+  transmitting radio's source address (the DSB SCH/H field right before the
+  MNI, which reads MCC 250 / MNC 1 exactly as the operator's codeplug) under a
+  fixed 6-bit prefix. No "colour code" a 64-way brute force could reach; the
+  colours it reported (36, 31, 39, 3) were partial-keystream artifacts. The
+  pipeline and the voice chain now share `tetra.DMSeedTracker`: the DSB
+  announces the seed as a hint, the first clean DNB solves it exactly (a
+  reliability-ranked sparse-check solve covers errored bursts), and every
+  re-key re-learns it. On the capture: 159 CRC-valid TCH/S across all three
+  PTTs and 9.5 s of speech, versus 58 bursts of one PTT before. `tetra_mcc` /
+  `tetra_mnc` are no longer needed for DMO. On-air verification of the
+  daemon path (a recording with intelligible audio) is the remaining gate.
+- **Conventional DMR wideband tap: a deaf tap now heals itself.** The 12 Sep
+  IPSC log showed the 442.3875 MHz tap going deaf for ~3-minute stretches,
+  six times in 30 minutes, at its normal -51 dBFS while the other tap and
+  every offline replay of the same IQ (DDC, channelizer, live-sized chunks)
+  decoded everything — state inside the live receiver chain, root cause
+  still open. The engine now resets a Tier II receiver (and its stream
+  state, `tier2.ResyncReset`) after three windows with no sync at the
+  channel's own decoding level, logging the receiver internals; the
+  activity line carries `dibits` and `deaf_heals`. `dmrrx.Receiver.Reset`
+  now also resets the timing loop and demod history.
+
 ### Added
+- **DMO seed instruments**: `TestTETRADMOSeedScan` (`GT_TETRA_DMO_SEEDS=1`)
+  prints every burst's solved seed next to each DSB's SCH/S and raw SCH/H
+  bits; `TestTETRADMOReplay` reports the per-transmission seed runs and reads
+  wav/flac captures; `TestDMRIPSCBurstDump` (`GT_DMR_DUMP=<file>`) dumps a
+  conventional-DMR capture burst by burst (slot types, colour codes, embedded
+  LC), and `TestDMRIPSCWidebandReplay` takes `GT_DMR_WB_CHUNK`.
 - **dPMR and D-STAR voice now decode to PCM (experimental, unverified on
   air).** Following the NXDN precedent, both protocols gain end-to-end voice
   chains: dPMR anchors on the FS1/FS2 voice syncs, carves each 80 ms frame's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,71 @@ confirmation before any close-as-completed.
         silent ~0.1 s WAV still published to History) is inherent: the recorder only drops `dataBytes==0`
         or `StatProvider` zero-voice calls, and ACELP is neither, so a 2-frame call becomes a tiny
         bogus row. Staged, not shipped.
+- **DMO (#1003) ROOT-CAUSED on the 12 Sep 3-PTT capture: the TCH/S scramble seed is PER
+  TRANSMISSION — the transmitting radio's SOURCE ADDRESS under a fixed prefix — so every
+  "colour code" ever recovered (3, 39, 36, 31) was a partial-keystream artifact, and no
+  MNI/colour config could ever describe it.** The instrument that settled it is an EXACT
+  GF(2) seed solver (`tetra.SolveTCHScrambleSeed`, `dmo_seed.go`): the LFSR scrambler is
+  affine in its 30-bit seed and the TCH/S coding (CRC parity matrix + K=5 conv code +
+  puncturing + interleave) is a linear block code, so `H'·(r ⊕ PN(0)) = (H'·P)·seed` — 158
+  equations, 30 unknowns, one error-free DNB pins the seed with 128 redundant checks, no
+  colour space, no field layout, no config. Solving the 12 Sep capture burst by burst
+  (`TestTETRADMOSeedScan`, `GT_TETRA_DMO_SEEDS=1`) gave three seeds for three PTTs —
+  0x012915c0 / 0x015d9c07 / 0x01671384 — and each seed's low 24 bits sit verbatim at the
+  DSB SCH/H bits 42..65, immediately before a 24-bit field at 66..89 that decodes as
+  MCC 250 / MNC 1 (the operator's codeplug), i.e. the standard DMAC-SYNC layout
+  `… src addr type, SOURCE ADDRESS, MNI, message type …`; the top 6 bits were 000001 on all
+  three (capture-pinned, `DMScrambleSeedPrefix`; neither osmo-tetra-dmo nor
+  TetraDMO-Receiver has any DMO traffic-seed rule at all, so there is no reference to
+  quote). Lessons: (1) the earlier "MNI-fold" theory (`tetra_mcc`/`tetra_mnc`) was wrong
+  — the 250/1 A/B decodes NOTHING — and the "colour 36 with 58 CRC-valid bursts" the brute
+  force reported on this very capture was a wrong seed: a related wrong seed CRC-passes
+  ~9% of bursts (measured), so a CRC count is NOT proof of a seed; only an exact solve is.
+  (2) Production now runs `tetra.DMSeedTracker` in BOTH the pipeline and the voice chain:
+  the DSB SCH/H announces the seed as a hint (adopted only after 3 CRC-valid decodes on
+  slot-grid-qualified bursts — two was measurably too few against random payload), any
+  burst's exact solve adopts immediately and preempts a stale seed (a stale seed from the
+  previous PTT can still CRC-pass the next PTT's bursts, so the solve runs BEFORE the
+  decode-at-known-seed), and errored bursts get a soft-assisted solve (least-reliable bit
+  flips, then a reliability-ranked solve over LOCAL sparse parity checks — a bit error only
+  spoils the ~48-bit windows containing it). Re-arm droughts reset the seed; a
+  `tetra_colour_code` pins one. `RecoverDMColourCode` (the 64-way brute force) survives
+  only for the diagnostic colour scan. (3) Verdict on the capture: 159 CRC-valid TCH/S
+  across ALL THREE PTTs, speech in seconds [2-5, 13-16, 24-27], 9.5 s PCM (before: 58 of one
+  PTT at a bogus colour). Reproduce: `GT_TETRA_DMO_IQ=<flac> GT_TETRA_DMO_CLEAR=1
+  go test ./cmd/gophertrunk -run TestTETRADMOReplay -v` (the harness now reads wav/flac).
+  STILL ON-AIR-GATED for the daemon path (#764/#771): the operator must confirm a live
+  recording with intelligible audio; the synthetic stream builders now open a transmission
+  with THREE DSBs (as the capture shows) so the hint path is exercised realistically.
+- **12 Sep IPSC "missed a lot of calls" (442.3875 MHz, 20-min Signal Lab flac + live log):
+  NOT two colour codes, NOT the tuner — the live wideband Tier II tap goes deaf in
+  ~3-minute stretches, and the root cause is still open.** Facts pinned: every one of the
+  26 865 data bursts in the capture is colour code 12 (the EMB colour code of all 544
+  embedded LCs too, all tg 11), so the reporter's "IPSC runs two colour codes, one per
+  slot" is not what this repeater does (the 9 Sep cc=7 CSBK train was on the OTHER
+  repeater, 443.2375). Offline, the same capture decodes every one of its 26 transmissions
+  (37 grants, `TestDMRIPSCReplay` interleaved; `TestDMRIPSCBurstDump` is the burst-level
+  instrument), and so do the channelizer arm of `TestDMRIPSCWidebandReplay` over the whole
+  20 min AND with live-sized chunks (`GT_DMR_WB_CHUNK=500`). Live, aligned to the capture
+  (offset 23:41:31.28), the Fire2 tap logged `sync_hits=0` for six stretches of 180–210 s
+  (23:38:24, 23:42:58, 23:47:46, 23:52:07, 23:56:34, 00:00:35 — alive ~60–110 s between)
+  while its IQ power sat at its normal −51 dBFS and the Fire tap on the same channelizer
+  decoded throughout; ~10 of the 26 transmissions fell in those stretches (that is the
+  "missed calls"). The coarse carrier acquirer (the one frozen stage) never engages on the
+  capture, the MM loop/AGC/AFC have no long time constants, chunking is not it, nothing in
+  the daemon runs on a ~3-min timer, and an activity line cannot distinguish "no dibits"
+  from "junk dibits" — so the tier2 counters now carry `dibits`, and the engine self-heals:
+  `healDeafTier2` resets the receiver + `tier2.ResyncReset()` after 3 windows with no sync
+  at a power within 6 dB of the level the channel LAST SYNCED at (its own level, never an
+  absolute dBFS — the tap sits at −51 dBFS, below the −45 "strong signal" hint floor, which
+  is why no WARN ever fired), logging `mm_mu/mm_sps/agc_level/coarse_offset_hz` at the reset
+  as the instrument for the next log; `deaf_heals` in the activity line counts them. Pinned
+  by `engine_deafheal_test.go`. `dmrrx.Receiver.Reset` used to leave the timing loop and
+  demod history in place — a reset that is not a reset — now cleared. Do not re-chase the
+  channelizer bin edge (the 10 Sep fix holds: polyphase 37 grants vs DDC 36 over the full
+  capture); the next field log's `dibits` + heal WARN internals decide whether the latch is
+  in the receiver (heal works, internals show which loop) or upstream of it (heal does not
+  work ⇒ the tap's NCO/resampler or the stream).
 - **TETRA MAC fragment reassembly had off-by-bits at every seam — found via D-NWRK-BROADCAST,
   and the neighbour-cell decode is now live + capture-verified.** `macFragmentPayload` skipped
   only type+subtype on MAC-FRAG (the fill-bit indication leaked into the payload, +1 bit) and

--- a/cmd/gophertrunk/dmr_ipsc_dump_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_dump_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// TestDMRIPSCBurstDump is a burst-level instrument for a conventional DMR
+// capture: it prints every data-sync burst's slot type (colour code + data
+// type, BPTC validity) and every voice superframe (phase, embedded-LC
+// talkgroup/source, EMB colour code) against stream time, so a missed
+// transmission or a second colour code can be found by inspection rather than
+// inferred from grant counts. GT_DMR_IQ=<capture> GT_DMR_DUMP=<out file>.
+func TestDMRIPSCBurstDump(t *testing.T) {
+	out := os.Getenv("GT_DMR_DUMP")
+	path := os.Getenv("GT_DMR_IQ")
+	if out == "" || path == "" {
+		t.Skip("set GT_DMR_IQ and GT_DMR_DUMP to run the burst dump")
+	}
+	inRate := 50000.0
+	if v := os.Getenv("GT_DMR_IQ_RATE"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		inRate = f
+	}
+	iq, rate, err := siglab.DecodeContainerFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rate > 0 && os.Getenv("GT_DMR_IQ_RATE") == "" {
+		inRate = float64(rate)
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	ddc := ccdecoder.NewDownconverter(inRate, 48000)
+	var allDibits []uint8
+	rx := dmrrx.New(dmrrx.Options{
+		SampleRateHz: ddc.OutRateHz(),
+		DeviationHz:  1944.0,
+		ClockGain:    0.015,
+		DibitSink: func(d []uint8, _ int) {
+			allDibits = append(allDibits, d...)
+		},
+	})
+	const chunk = 65536
+	var scratch []complex64
+	for i := 0; i < len(iq); i += chunk {
+		e := i + chunk
+		if e > len(iq) {
+			e = len(iq)
+		}
+		scratch = ddc.Process(scratch[:0], iq[i:e])
+		rx.Process(scratch)
+	}
+
+	// Data bursts: every sync match, sliced like the Tier II adapter, slot type
+	// parsed at identity polarity when the sync is a data sync.
+	det := dmr.NewSyncDetector(nil, 2)
+	matches, _ := det.Process(nil, allDibits, 0)
+	const lookback = dmr.HalfPayloadDibits + dmr.SlotTypeDibits + dmr.SyncDibits - 1
+	for _, m := range matches {
+		start := m.Index - lookback
+		if start < 0 || start+dmr.BurstDibits > len(allDibits) {
+			continue
+		}
+		sec := float64(start) / 4800
+		if !dmr.SyncIsDataAtPolarity(m.Pattern, 0) {
+			fmt.Fprintf(f, "%9.3f sync %s pos=%d\n", sec, m.Pattern.Name, start)
+			continue
+		}
+		var b dmr.Burst
+		copy(b.Dibits[:], allDibits[start:start+dmr.BurstDibits])
+		slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
+		if err != nil {
+			fmt.Fprintf(f, "%9.3f data %s pos=%d slottype=bad\n", sec, m.Pattern.Name, start)
+			continue
+		}
+		_, errs := framing.DecodeBPTC196_96(b.PayloadBits())
+		info := ""
+		if errs >= 0 {
+			bits, _ := framing.DecodeBPTC196_96(b.PayloadBits())
+			bytes := make([]byte, 12)
+			for i := 0; i < 96; i++ {
+				if bits[i]&1 != 0 {
+					bytes[i>>3] |= 1 << uint(7-(i&7))
+				}
+			}
+			if slot.DataType == dmr.DTVoiceLCHeader || slot.DataType == dmr.DTTerminatorWithLC {
+				seed := framing.RS129SeedVoiceLCHeader
+				if slot.DataType == dmr.DTTerminatorWithLC {
+					seed = framing.RS129SeedTerminatorLC
+				}
+				if framing.VerifyRS12_9(bytes, seed) {
+					if flc, err := dmr.ParseFLC(bytes); err == nil {
+						if gv, ok := flc.AsGroupVoiceUser(); ok {
+							info = fmt.Sprintf(" lc=group tg=%d src=%d", gv.GroupAddress, gv.SourceID)
+						} else if uu, ok := flc.AsUnitToUnitVoice(); ok {
+							info = fmt.Sprintf(" lc=unit dst=%d src=%d", uu.DestinationID, uu.SourceID)
+						} else {
+							info = fmt.Sprintf(" lc=flco%d", flc.FLCO)
+						}
+					}
+				} else {
+					info = " rs=fail"
+				}
+			}
+		}
+		fmt.Fprintf(f, "%9.3f data %s pos=%d cc=%d dt=%d bptc_errs=%d%s\n", sec, m.Pattern.Name, start, slot.ColorCode, slot.DataType, errs, info)
+	}
+
+	// Voice superframes through the interleaved decoder.
+	vd := dmrvoice.NewInterleavedDecoder()
+	const dchunk = 4096
+	for i := 0; i < len(allDibits); i += dchunk {
+		e := i + dchunk
+		if e > len(allDibits) {
+			e = len(allDibits)
+		}
+		for _, sf := range vd.Process(allDibits[i:e], i) {
+			sec := float64(sf.StartDibit) / 4800
+			errs := 0
+			for k := range sf.Frames {
+				_, n, _ := dmrvoice.DecodeAMBEFrame(sf.Frames[k])
+				errs += n
+			}
+			lc := ""
+			if sf.HasLC {
+				if gv, ok := sf.LC.AsGroupVoiceUser(); ok {
+					lc = fmt.Sprintf(" lc=group tg=%d src=%d embcc=%d", gv.GroupAddress, gv.SourceID, sf.EMBColorCode)
+				} else if uu, ok := sf.LC.AsUnitToUnitVoice(); ok {
+					lc = fmt.Sprintf(" lc=unit dst=%d src=%d embcc=%d", uu.DestinationID, uu.SourceID, sf.EMBColorCode)
+				} else {
+					lc = fmt.Sprintf(" lc=flco%d embcc=%d", sf.LC.FLCO, sf.EMBColorCode)
+				}
+			}
+			fmt.Fprintf(f, "%9.3f sf %s pos=%d phase=%d ambe_errs=%d%s\n", sec, sf.SyncName, sf.StartDibit, sf.Phase, errs, lc)
+		}
+	}
+	t.Logf("dibits=%d (%.1fs) matches=%d written to %s", len(allDibits), float64(len(allDibits))/4800, len(matches), out)
+}

--- a/cmd/gophertrunk/dmr_ipsc_wideband_replay_test.go
+++ b/cmd/gophertrunk/dmr_ipsc_wideband_replay_test.go
@@ -108,8 +108,24 @@ func TestDMRIPSCWidebandReplay(t *testing.T) {
 		if i%(chunk*40) == 0 {
 			nco /= complex(math.Hypot(real(nco), imag(nco)), 0)
 		}
-		for _, a := range arms {
-			a.bank.Process(wide)
+		// GT_DMR_WB_CHUNK feeds the banks in wideband chunks of this many samples
+		// (the live daemon's SoapyRemote datagram is ~2000 samples at 6.25 MS/s,
+		// i.e. ~125 samples per channelizer bin per call); 0 = one call per
+		// resampled block.
+		if wbChunk := envInt("GT_DMR_WB_CHUNK", 0); wbChunk > 0 {
+			for k := 0; k < len(wide); k += wbChunk {
+				ke := k + wbChunk
+				if ke > len(wide) {
+					ke = len(wide)
+				}
+				for _, a := range arms {
+					a.bank.Process(wide[k:ke])
+				}
+			}
+		} else {
+			for _, a := range arms {
+				a.bank.Process(wide)
+			}
 		}
 		if (e/window) != (i/window) || e == len(iq) {
 			sec := startS + float64(e)/inRate

--- a/cmd/gophertrunk/tetra_dmo_replay_test.go
+++ b/cmd/gophertrunk/tetra_dmo_replay_test.go
@@ -12,19 +12,20 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/voice/acelp"
 )
 
 // TestTETRADMOReplay is the real-air validation gate for TETRA Direct Mode
 // Operation (DMO) voice decode — the acceptance criterion of issue #1003. Skip
-// unless GT_TETRA_DMO_IQ points at a cs16 (interleaved int16) IQ file of a DMO
-// transmission; GT_TETRA_DMO_RATE gives its sample rate (default 150000, the
-// reporter's Tetra_DMO_Two_TX_cs16_30sec_bw150.raw), GT_TETRA_DMO_COLOUR pins the
-// DM colour code the TCH/S traffic is scrambled with — but when it is UNSET the
-// harness now auto-recovers the colour via tetra.RecoverDMColourCode (the colour
-// that maximises CRC-valid TCH/S), so a clear DMO call decodes with no manual
-// override (on the 10aug capture it recovers colour 3). GT_TETRA_DMO_OUT
-// optionally names a dir for the decoded WAV.
+// unless GT_TETRA_DMO_IQ points at an IQ file of a DMO transmission — a headerless
+// cs16 (interleaved int16) file at GT_TETRA_DMO_RATE (default 150000), or a
+// wav/flac container, which carries its own rate. The TCH/S scramble seed is
+// learned per transmission by the production tetra.DMSeedTracker (the 12 Sep
+// capture: a different seed on every PTT — the transmitting radio's source
+// address), so nothing needs pinning; GT_TETRA_DMO_COLOUR pins ONE full 30-bit
+// seed for diagnostics. GT_TETRA_DMO_OUT optionally names a dir for the decoded
+// WAV.
 //
 // It resamples to the 144 kHz TETRA channel rate, runs the shared π/4-DQPSK
 // receiver, accumulates the whole dibit stream, then:
@@ -77,21 +78,24 @@ func TestTETRADMOReplay(t *testing.T) {
 	bursts, inRate, outRate, iqLen, enableEQ, enableLMS := loadDMOReplayBursts(t)
 	dibitRate := tetrarx.SymbolRate // 18000 dibits/sec
 
-	// Recover the DM colour code the TCH/S is scrambled with when it was not
-	// pinned via GT_TETRA_DMO_COLOUR (#1003). The DSB SCH/S is always colour-0
-	// scrambled and can't reveal the traffic colour, so RecoverDMColourCode
-	// learns it by maximising CRC-valid TCH/S. On the 10aug clear capture this
-	// auto-selects colour 3 (the value that lifts TCH/S off the chance floor)
-	// with no manual override — the C1 acceptance signal.
-	if !colourSet {
-		if rc, n, ok := tetra.RecoverDMColourCode(bursts, baseMNI); ok {
-			colour = rc
-			t.Logf("recovered DM colour code seed=%#x (crc-valid TCH/S=%d) — no GT_TETRA_DMO_COLOUR set", rc, n)
-		} else {
-			colour = baseMNI
-			t.Logf("DM colour code not recovered (no colour cleared the chance floor); using baseMNI %#x", colour)
-		}
+	// The TCH/S scramble seed is PER TRANSMISSION (12 Sep #1003 capture: a
+	// different 30-bit seed on each PTT — see tetra/dmo_seed_tracker.go), so the
+	// replay runs the production tetra.DMSeedTracker over the burst sequence:
+	// each DSB's SCH/H announces the seed as a hint, each DNB is solved exactly
+	// (GF(2), no colour search) or decoded through the confirmed hint. A
+	// GT_TETRA_DMO_COLOUR override pins one seed for the whole capture.
+	// GT_TETRA_DMO_MCC/MNC are accepted for the legacy colour scan only.
+	seeds := tetra.NewDMSeedTracker()
+	if colourSet {
+		seeds.Pin(colour)
 	}
+	type seedRun struct {
+		seed        uint32
+		first, last float64
+		bursts, crc int
+	}
+	var seedRuns []seedRun
+	_ = baseMNI
 
 	var dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly int
 	var syncSecs []int           // seconds carrying a CRC-valid SCH/S (transmission starts)
@@ -113,6 +117,7 @@ func TestTETRADMOReplay(t *testing.T) {
 		switch b.Kind {
 		case tetra.DMBurstSync:
 			dsbTotal++
+			seeds.ObserveDSB(b)
 			if type1, ok := tetra.DecodeDMSCHS(b); ok {
 				dsbCRC++
 				if pdu, pok := tetra.ParseSyncPDU(type1); pok {
@@ -128,25 +133,32 @@ func TestTETRADMOReplay(t *testing.T) {
 			}
 		case tetra.DMBurstNormal:
 			dnbTotal++
-			// Prefer soft-decision; fall back to hard when no differentials were
-			// carried for this burst (e.g. an edge burst).
-			frames := tetra.DMBurstTCHSpeechSoft(b, colour)
-			if len(frames) != 2 {
-				if hard := tetra.DMBurstTCHSpeech(b, colour); len(hard) == 2 {
-					frames = hard
-				}
-			} else if tetra.DMBurstTCHSpeech(b, colour) == nil {
-				tchSoftOnly++ // recovered by soft-decision that the hard path missed
+			frames, seed, adopted := seeds.ObserveDNB(b, true)
+			if adopted || len(seedRuns) == 0 || seedRuns[len(seedRuns)-1].seed != seed {
+				seedRuns = append(seedRuns, seedRun{seed: seed, first: float64(b.Lead) / dibitRate})
 			}
+			run := &seedRuns[len(seedRuns)-1]
+			run.last = float64(b.Lead) / dibitRate
+			run.bursts++
 			if len(frames) == 2 {
+				run.crc++
 				tchCRC++
 				speechBySec[sec]++
 				speechFrames = append(speechFrames, frames...)
+				if tetra.DMBurstTCHSpeech(b, seed) == nil {
+					tchSoftOnly++ // recovered by soft-decision that the hard path missed
+				}
 			}
 		}
 	}
+	colour, _ = seeds.Seed()
+	for _, r := range seedRuns {
+		t.Logf("seed %#010x (source field %#08x) %6.2fs..%6.2fs dnbs=%d tch_crc=%d",
+			r.seed, r.seed&0xFFFFFF, r.first, r.last, r.bursts, r.crc)
+	}
+	t.Logf("seed tracker: bursts_solved=%d exact_adopts=%d hint_adopts=%d", seeds.Solved, seeds.ExactAdopts, seeds.HintAdopts)
 
-	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs colour=%#x eq=%v lms=%v",
+	t.Logf("in=%.0fHz out=%.0fHz samples=%d dur=%.1fs last_seed=%#x eq=%v lms=%v",
 		inRate, outRate, iqLen, float64(iqLen)/inRate, colour, enableEQ, enableLMS)
 	t.Logf("bursts: dsb_total=%d dsb_schs_crc=%d dnb_total=%d tch_crc=%d (soft_only=%d)",
 		dsbTotal, dsbCRC, dnbTotal, tchCRC, tchSoftOnly)
@@ -249,11 +261,27 @@ func loadDMOReplayBursts(t *testing.T) (bursts []tetra.DMBurst, inRate, outRate 
 	if err != nil {
 		t.Fatal(err)
 	}
-	iq := make([]complex64, len(raw)/4)
-	for i := range iq {
-		re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
-		im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
-		iq[i] = complex(float32(re)/32768, float32(im)/32768)
+	// A wav/flac container (the Signal Lab "capture from tuner" output — the
+	// operator's 12 Sep DMO capture is a 144 kHz flac) is sniffed from its
+	// content and carries its own sample rate; a headerless file is cs16 at
+	// GT_TETRA_DMO_RATE, as before.
+	var iq []complex64
+	if _, isContainer := siglab.SniffContainer(raw); isContainer {
+		samples, rate, err := siglab.DecodeContainerFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		iq = samples
+		if rate > 0 && os.Getenv("GT_TETRA_DMO_RATE") == "" {
+			inRate = float64(rate)
+		}
+	} else {
+		iq = make([]complex64, len(raw)/4)
+		for i := range iq {
+			re := int16(binary.LittleEndian.Uint16(raw[i*4:]))
+			im := int16(binary.LittleEndian.Uint16(raw[i*4+2:]))
+			iq[i] = complex(float32(re)/32768, float32(im)/32768)
+		}
 	}
 	iqLen = len(iq)
 
@@ -323,8 +351,10 @@ func loadDMOReplayBursts(t *testing.T) (bursts []tetra.DMBurst, inRate, outRate 
 // capture (25 s of clear, colour-0 silent PTT) decodes SCH/S at ~90% yet TCH/S
 // sits near the chance floor at EVERY single colour — and a 64-colour sweep
 // shows several colours rising modestly above the floor at once (28/57/30),
-// which one radio scrambling with one label cannot produce. That signature
-// means the DM descramble model is missing a per-burst component. This scan
+// which one radio scrambling with one label cannot produce. RESOLVED (12 Sep):
+// the seed is the radio's 24-bit source address under a fixed prefix, outside
+// any 64-colour space — TestTETRADMOSeedScan solves it exactly; this scan is
+// kept as the legacy colour-space instrument. This scan
 // maps, for every DNB: which colours CRC-decode it, its slot-grid position,
 // and its frame number estimated from the CRC-valid DSBs' SYNC PDU FN — so the
 // burst→colour map reveals the rule (FN-dependent seed, cross-burst pairing,

--- a/cmd/gophertrunk/tetra_dmo_seed_scan_test.go
+++ b/cmd/gophertrunk/tetra_dmo_seed_scan_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+)
+
+// TestTETRADMOSeedScan is the #1003 instrument that reads the scramble seed
+// straight off the traffic: every error-free DNB of a capture is solved for its
+// 30-bit extended colour code (tetra.SolveTCHScrambleSeed — an exact GF(2)
+// solve, no candidate search, no MNI assumption), and every CRC-valid DSB's
+// SCH/S SYNC PDU and raw SCH/H bits are printed alongside, so the seed of each
+// transmission can be correlated with the DM-SYNC fields that announce it.
+//
+// Run with GT_TETRA_DMO_IQ=<capture> [GT_TETRA_DMO_RATE=…] GT_TETRA_DMO_SEEDS=1.
+func TestTETRADMOSeedScan(t *testing.T) {
+	if os.Getenv("GT_TETRA_DMO_SEEDS") == "" {
+		t.Skip("set GT_TETRA_DMO_SEEDS=1 (with GT_TETRA_DMO_IQ) to run the DMO seed scan")
+	}
+	bursts, _, _, _, _, _ := loadDMOReplayBursts(t)
+	dibitRate := tetrarx.SymbolRate
+
+	seedCounts := map[uint32]int{}
+	type seedRun struct {
+		seed        uint32
+		first, last float64
+		n           int
+	}
+	var runs []seedRun
+	solved, dnbs := 0, 0
+	for i := range bursts {
+		b := bursts[i]
+		sec := float64(b.Lead) / dibitRate
+		switch b.Kind {
+		case tetra.DMBurstSync:
+			type1, ok := tetra.DecodeDMSCHS(b)
+			schh, hok := tetra.DecodeDMSCHH(b)
+			if !ok && !hok {
+				continue
+			}
+			line := fmt.Sprintf("dsb  t=%6.2fs lead=%d rot=%d", sec, b.Lead, b.Rotation)
+			if ok {
+				pdu, _ := tetra.ParseSyncPDU(type1)
+				line += fmt.Sprintf(" schs_ok=1 schs=%s colour=%d TN=%d FN=%d MN=%d MCC=%d MNC=%d",
+					hex.EncodeToString(framing.PackBitsMSB(type1)), pdu.ColourCode, pdu.TN, pdu.FN, pdu.MN, pdu.MCC, pdu.MNC)
+			} else {
+				line += " schs_ok=0"
+			}
+			if hok {
+				line += fmt.Sprintf(" schh_ok=1 schh=%s", hex.EncodeToString(framing.PackBitsMSB(schh)))
+			} else {
+				line += " schh_ok=0"
+			}
+			t.Log(line)
+		case tetra.DMBurstNormal:
+			dnbs++
+			seed, ok := tetra.DMBurstScrambleSeed(b)
+			if !ok {
+				continue
+			}
+			solved++
+			seedCounts[seed]++
+			if n := len(runs); n > 0 && runs[n-1].seed == seed && sec-runs[n-1].last < 2 {
+				runs[n-1].last = sec
+				runs[n-1].n++
+			} else {
+				runs = append(runs, seedRun{seed: seed, first: sec, last: sec, n: 1})
+			}
+		}
+	}
+	t.Logf("dnbs=%d solved_exactly=%d distinct_seeds=%d", dnbs, solved, len(seedCounts))
+	type kv struct {
+		seed uint32
+		n    int
+	}
+	var kvs []kv
+	for s, n := range seedCounts {
+		kvs = append(kvs, kv{s, n})
+	}
+	sort.Slice(kvs, func(i, j int) bool { return kvs[i].n > kvs[j].n })
+	for _, e := range kvs {
+		t.Logf("seed %#010x = %030b  mcc=%d mnc=%d colour=%d  bursts=%d",
+			e.seed, e.seed, e.seed>>20, (e.seed>>6)&0x3FFF, e.seed&0x3F, e.n)
+	}
+	for _, r := range runs {
+		t.Logf("run seed=%#010x colour=%2d mcc=%d mnc=%d  %6.2fs .. %6.2fs  bursts=%d",
+			r.seed, r.seed&0x3F, r.seed>>20, (r.seed>>6)&0x3FFF, r.first, r.last, r.n)
+	}
+	seed, votes, ok := tetra.RecoverDMScrambleSeed(bursts)
+	t.Logf("RecoverDMScrambleSeed over the whole capture: seed=%#010x votes=%d confident=%v", seed, votes, ok)
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1199,14 +1199,15 @@ trunking:
   #   - name: "DMO-438.9"
   #     protocol: tetra-dmo             # TETRA Direct Mode (radio-to-radio);
   #     control_channels: [438_900_000] # the DMO carrier to camp on
-  #     tetra_mcc: 250                  # the radios' network MNI (CPS codeplug):
-  #     tetra_mnc: 1                    #   TCH/S is scrambled with the FULL
-  #                                     #   ExtendedColourCode(MCC, MNC, colour),
-  #                                     #   so a non-zero MNI must be configured
-  #                                     #   or colour recovery never reaches the
-  #                                     #   seed; 0 / 0 (default) = MNI-0 DMO
-  #     # tetra_colour_code: 39         # pin the DM colour (normally auto-
-  #                                     #   recovered from the traffic)
+  #                                     # The TCH/S scramble seed is learned per
+  #                                     # transmission (it is the transmitting
+  #                                     # radio's source address, announced in
+  #                                     # the DSB and solved exactly from the
+  #                                     # traffic) — nothing to configure.
+  #     # tetra_mcc: 250                # accepted, no longer needed for DMO
+  #     # tetra_mnc: 1                  #   (only the offline colour scan uses it)
+  #     # tetra_colour_code: 0x012915c0 # pin ONE full 30-bit seed for every
+  #                                     #   transmission (diagnostics only)
   #
   #   - name: "Legacy-EDACS"
   #     protocol: edacs

--- a/internal/dsp/demod/c4fm.go
+++ b/internal/dsp/demod/c4fm.go
@@ -90,3 +90,12 @@ func (c *C4FM) SliceMany(dst []int8, src []float32) []int8 {
 	}
 	return dst
 }
+
+// Reset clears the matched filter's sample history so a restarted stream does
+// not convolve against stale samples. The taps are kept.
+func (c *C4FM) Reset() {
+	for i := range c.hist {
+		c.hist[i] = 0
+	}
+	c.histPos = 0
+}

--- a/internal/dsp/demod/fm.go
+++ b/internal/dsp/demod/fm.go
@@ -28,3 +28,6 @@ func (f *FM) Process(dst []float32, src []complex64) []float32 {
 	}
 	return dst
 }
+
+// Reset clears the discriminator's previous-sample memory.
+func (f *FM) Reset() { f.last = complex(1, 0) }

--- a/internal/radio/dmr/receiver/receiver.go
+++ b/internal/radio/dmr/receiver/receiver.go
@@ -358,6 +358,13 @@ func (r *Receiver) Reset() {
 	if r.acq != nil {
 		r.acq.Reset()
 	}
+	// The timing loop and the discriminator / matched-filter history are
+	// receiver state too: a reset that leaves them in place is not a reset
+	// (the 12 Sep IPSC wideband self-heal relies on this one call returning
+	// the whole chain to its constructed state).
+	r.clock.Reset()
+	r.fm.Reset()
+	r.mf.Reset()
 }
 
 // CoarseCarrierOffsetHz reports the frozen coarse carrier-offset correction the

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -110,6 +110,12 @@ type LockState struct {
 //     Voice LC Header fails FEC (weak/dirty signal, clipping).
 //   - FECPass > 0                    → genuine DMR headers decoded.
 type Counters struct {
+	// Dibits counts demodulated dibits handed to Process — the receiver's
+	// output rate (4800/s on a live stream). It separates "the receiver
+	// emits nothing" from "the receiver emits junk that never syncs", which
+	// sync_hits alone cannot (the 12 Sep IPSC field log: a tap deaf for
+	// three-minute stretches at a steady -51 dBFS with sync_hits=0).
+	Dibits   uint64
 	SyncHits uint64 // FSW matches reported by the burst-sync detector
 	Bursts   uint64 // slot-type-parsed bursts handed to IngestBurst
 	FECPass  uint64 // Voice LC Header with BPTC + RS both valid
@@ -265,6 +271,7 @@ type ConventionalChannel struct {
 	// Counters(). Incremented on the existing hot paths with atomic
 	// adds so any goroutine can snapshot them without taking c.mu.
 	cnt struct {
+		dibits       atomic.Uint64
 		syncHits     atomic.Uint64
 		bursts       atomic.Uint64
 		fecPass      atomic.Uint64
@@ -303,6 +310,7 @@ type lateEntryCandidate struct {
 // counters. Safe to call concurrently with the decode path.
 func (c *ConventionalChannel) Counters() Counters {
 	return Counters{
+		Dibits:       c.cnt.dibits.Load(),
 		SyncHits:     c.cnt.syncHits.Load(),
 		Bursts:       c.cnt.bursts.Load(),
 		FECPass:      c.cnt.fecPass.Load(),
@@ -735,6 +743,22 @@ func (c *ConventionalChannel) ResetLateEntry() {
 	if c.voice != nil {
 		c.voice.Reset()
 	}
+}
+
+// ResyncReset drops the Process adapter's cross-call dibit buffer, its pending
+// sync matches and the late-entry / superframe state so a receiver-side Reset
+// (which restarts the dibit index at 0) can reacquire cleanly. Without it the
+// adapter's absolute bufStart stays at the pre-reset value while every new sync
+// match arrives at a small index, so each is discarded as "lookback already
+// trimmed" for ever — the trap tier3.ResyncReset documents. Tracked calls are
+// kept (the engine's own timers end them); the learned polarity is kept too, a
+// front end's inversion being a fixed property of the stream.
+//
+// Precondition: called on the same goroutine as Process (from the engine, after
+// the receiver's Process returns), so the proc swap never races a Process call.
+func (c *ConventionalChannel) ResyncReset() {
+	c.proc = nil
+	c.ResetLateEntry()
 }
 
 func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType) {

--- a/internal/radio/tetra/dmo_seed.go
+++ b/internal/radio/tetra/dmo_seed.go
@@ -1,0 +1,595 @@
+package tetra
+
+import (
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// Exact recovery of the TETRA scrambling seed from a single TCH/S burst.
+//
+// Every stage between the 30-bit extended colour code and the on-air type-5 bits
+// of a TCH/S slot is LINEAR over GF(2):
+//
+//   - the scrambling sequence p(k) is the output of a 32-stage LFSR whose state
+//     is initialised to (e(1..30), 1, 1) (EN 300 392-2 §8.2.5.2), so the
+//     432-bit PN sequence is an affine function of the seed:
+//     PN(seed) = PN(0) ⊕ Σ_i seed_i · (PN(1<<i) ⊕ PN(0));
+//   - the TCH/S channel coding (EN 300 395-2 §5.5) is a block code once the 4
+//     tail bits are fixed: class 1 + class 2 bits → CRC (a fixed parity-check
+//     matrix, tchCRCTaps) → K=5 convolutional mother code → puncturing. So the
+//     330 coded type-3 bits c satisfy H·c = 0 for the code's parity-check
+//     matrix H, whatever the speech content (the 102 class-0 bits are uncoded
+//     and carry no constraint);
+//   - the 24×18 interleave is a permutation.
+//
+// Hence for an error-free received type-5 block r = interleave(c) ⊕ PN(seed):
+//
+//	H' · (r ⊕ PN(0)) = (H' · P) · seed
+//
+// where H' is H moved to type-5 coordinates and P the 432×30 matrix of seed
+// impulse responses. That is 158 linear equations in 30 unknowns — an
+// error-free burst solves the seed EXACTLY, and a burst with bit errors is
+// almost surely inconsistent (128 redundant checks) and rejected. No search over
+// candidate colours, no assumption about how the seed is composed (MCC / MNC /
+// colour), and no knowledge of the speech: this is what makes it possible to
+// read the DM colour code straight off the traffic of a Direct Mode call whose
+// DM-SYNC field layout is not trusted (#1003).
+//
+// RecoverDMScrambleSeed votes the per-burst solutions across a transmission and
+// confirms the winner by CRC-decoding the bursts with it, so the result carries
+// the same evidence RecoverDMColourCode's brute force did, at a fraction of the
+// cost (one 158×31 elimination per burst instead of 64 Viterbi decodes).
+
+const (
+	tchSeedBits  = 30
+	tchCodedBits = tchClass1Coded + tchClass2Coded // 330
+	tchInfoBits  = tchClass1Bits + tchClass2Bits   // 172 free information bits
+	tchCheckBits = tchCodedBits - tchInfoBits      // 158 parity checks
+	tchWords     = (tchType3Bits + 63) / 64        // 7 uint64 words per 432-bit row
+)
+
+// tchSeedLinear is the precomputed linear structure (built once, lazily).
+type tchSeedLinear struct {
+	// pn0 is PN(seed 0) in type-5 order; pnCol[i] = PN(1<<i) ⊕ pn0.
+	pn0   [tchWords]uint64
+	pnCol [tchSeedBits][tchWords]uint64
+	// checks are the parity-check rows in type-5 coordinates (packed bits).
+	checks [][tchWords]uint64
+	// a[r] is row r of H'·P as a 30-bit mask (bit i = check r applied to pnCol[i]);
+	// b0[r] is check r applied to pn0.
+	a  []uint32
+	b0 []byte
+
+	// sparse are LOCAL parity checks (supported on a window of ~48 consecutive
+	// coded bits, from the convolutional code's short memory), with their
+	// type-5 support lists, seed masks and constants. A bit error only spoils
+	// the few sparse checks whose window contains it, so a burst that fails the
+	// dense solve can still be solved from its RELIABLE checks (see
+	// SolveTCHScrambleSeedSoft).
+	sparse []sparseCheck
+}
+
+type sparseCheck struct {
+	support []int // type-5 bit positions
+	a       uint32
+	b0      byte
+}
+
+// Sparse-check window geometry: tchSparseWindow consecutive coded type-3 bits
+// per window, windows tchSparseStep apart.
+const (
+	tchSparseWindow = 48
+	tchSparseStep   = 12
+)
+
+var (
+	tchSeedOnce sync.Once
+	tchSeedLin  *tchSeedLinear
+)
+
+func packBits432(bits []byte) (w [tchWords]uint64) {
+	for i, b := range bits {
+		if b&1 != 0 {
+			w[i>>6] |= 1 << uint(i&63)
+		}
+	}
+	return w
+}
+
+func parityWords(a, b *[tchWords]uint64) byte {
+	var x uint64
+	for i := range a {
+		x ^= a[i] & b[i]
+	}
+	return byte(popcount64(x) & 1)
+}
+
+func popcount64(v uint64) int {
+	v = v - ((v >> 1) & 0x5555555555555555)
+	v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333)
+	v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0F
+	return int((v * 0x0101010101010101) >> 56)
+}
+
+// tchCodedBitsFor encodes one 172-bit information vector (class 1 ++ class 2)
+// through the CRC + RCPC chain to the 330 coded type-3 bits, exactly as
+// EncodeTCHS does.
+func tchCodedBitsFor(info []byte) []byte {
+	class1 := info[:tchClass1Bits]
+	class2 := info[tchClass1Bits:]
+	conv := make([]byte, 0, tchConvIn)
+	conv = append(conv, class1...)
+	conv = append(conv, class2...)
+	conv = append(conv, crcTCHClass2(class2)...)
+	conv = append(conv, make([]byte, tchTailBits)...)
+	mother := framing.EncodeRCPCTetraMother(conv)
+	split := 3 * tchClass1Bits
+	c1 := framing.PunctureRCPCTetra(mother[:split], framing.RCPCTetraPeriod23, framing.RCPCTetraPuncture23, tchClass1Coded)
+	c2 := framing.PunctureRCPCTetra(mother[split:], framing.RCPCTetraPeriod818, framing.RCPCTetraPuncture818, tchClass2Coded)
+	out := make([]byte, 0, tchCodedBits)
+	out = append(out, c1...)
+	out = append(out, c2...)
+	return out
+}
+
+// tchType5IndexOfCoded maps coded type-3 bit k (0..329, following the 102
+// class-0 bits) to its type-5 position through the 24×18 interleave
+// (tchInterleave: type4[i*24+j] = type3[j*18+i]).
+func tchType5IndexOfCoded(k int) int {
+	t := tchClass0Bits + k
+	return (t%18)*24 + t/18
+}
+
+// buildTCHSeedLinear derives the parity checks of the TCH/S coded block by
+// Gaussian elimination on the generator matrix, then moves them to type-5
+// coordinates and precomputes their action on the seed impulse responses.
+func buildTCHSeedLinear() *tchSeedLinear {
+	lin := &tchSeedLinear{}
+
+	// PN structure.
+	pn0 := framing.NewScramblerTetra(0).Generate(tchType3Bits)
+	lin.pn0 = packBits432(pn0)
+	for i := 0; i < tchSeedBits; i++ {
+		pi := framing.NewScramblerTetra(1 << uint(i)).Generate(tchType3Bits)
+		for k := range pi {
+			pi[k] ^= pn0[k]
+		}
+		lin.pnCol[i] = packBits432(pi)
+	}
+
+	// Generator rows: g[j] = coded bits for information unit vector j, packed
+	// as 330-bit rows (6 words).
+	const codedWords = (tchCodedBits + 63) / 64
+	type row [codedWords]uint64
+	gen := make([]row, tchInfoBits)
+	for j := 0; j < tchInfoBits; j++ {
+		info := make([]byte, tchInfoBits)
+		info[j] = 1
+		for k, b := range tchCodedBitsFor(info) {
+			if b&1 != 0 {
+				gen[j][k>>6] |= 1 << uint(k&63)
+			}
+		}
+	}
+	// Reduced row echelon form of the 172×330 generator; record pivot columns.
+	pivotCol := make([]int, 0, tchInfoBits)
+	r := 0
+	for col := 0; col < tchCodedBits && r < tchInfoBits; col++ {
+		sel := -1
+		for i := r; i < tchInfoBits; i++ {
+			if gen[i][col>>6]&(1<<uint(col&63)) != 0 {
+				sel = i
+				break
+			}
+		}
+		if sel < 0 {
+			continue
+		}
+		gen[r], gen[sel] = gen[sel], gen[r]
+		for i := 0; i < tchInfoBits; i++ {
+			if i != r && gen[i][col>>6]&(1<<uint(col&63)) != 0 {
+				for w := range gen[i] {
+					gen[i][w] ^= gen[r][w]
+				}
+			}
+		}
+		pivotCol = append(pivotCol, col)
+		r++
+	}
+	isPivot := make([]bool, tchCodedBits)
+	for _, c := range pivotCol {
+		isPivot[c] = true
+	}
+	// Null-space basis: for each free column f, the vector with h[f]=1 and
+	// h[pivot_i] = gen[i][f] satisfies h·g_j = 0 for every generator row.
+	for f := 0; f < tchCodedBits; f++ {
+		if isPivot[f] {
+			continue
+		}
+		var h [tchWords]uint64
+		set := func(k int) { h[k>>6] |= 1 << uint(k&63) }
+		set(tchType5IndexOfCoded(f))
+		for i, pc := range pivotCol {
+			if gen[i][f>>6]&(1<<uint(f&63)) != 0 {
+				set(tchType5IndexOfCoded(pc))
+			}
+		}
+		lin.checks = append(lin.checks, h)
+	}
+	lin.a = make([]uint32, len(lin.checks))
+	lin.b0 = make([]byte, len(lin.checks))
+	for ri := range lin.checks {
+		h := &lin.checks[ri]
+		lin.b0[ri] = parityWords(h, &lin.pn0)
+		for i := 0; i < tchSeedBits; i++ {
+			if parityWords(h, &lin.pnCol[i]) == 1 {
+				lin.a[ri] |= 1 << uint(i)
+			}
+		}
+	}
+
+	// Sparse checks: for each window of coded positions, the null space of the
+	// generator restricted to those columns — vectors h on the window with
+	// h·g_j = 0 for every information bit j. The original (un-reduced)
+	// generator columns are rebuilt here since gen above is in RREF.
+	orig := make([]row, tchInfoBits)
+	for j := 0; j < tchInfoBits; j++ {
+		info := make([]byte, tchInfoBits)
+		info[j] = 1
+		for k, b := range tchCodedBitsFor(info) {
+			if b&1 != 0 {
+				orig[j][k>>6] |= 1 << uint(k&63)
+			}
+		}
+	}
+	for start := 0; start+tchSparseWindow <= tchCodedBits; start += tchSparseStep {
+		// m[j] = generator row j restricted to the window (W bits in a uint64).
+		m := make([]uint64, tchInfoBits)
+		for j := 0; j < tchInfoBits; j++ {
+			var v uint64
+			for w := 0; w < tchSparseWindow; w++ {
+				k := start + w
+				if orig[j][k>>6]&(1<<uint(k&63)) != 0 {
+					v |= 1 << uint(w)
+				}
+			}
+			m[j] = v
+		}
+		// RREF over the window's columns; free columns yield null vectors.
+		pivots := make([]int, 0, tchSparseWindow)
+		rr := 0
+		for col := 0; col < tchSparseWindow && rr < tchInfoBits; col++ {
+			sel := -1
+			for i := rr; i < tchInfoBits; i++ {
+				if m[i]&(1<<uint(col)) != 0 {
+					sel = i
+					break
+				}
+			}
+			if sel < 0 {
+				continue
+			}
+			m[rr], m[sel] = m[sel], m[rr]
+			for i := 0; i < tchInfoBits; i++ {
+				if i != rr && m[i]&(1<<uint(col)) != 0 {
+					m[i] ^= m[rr]
+				}
+			}
+			pivots = append(pivots, col)
+			rr++
+		}
+		isPiv := make([]bool, tchSparseWindow)
+		for _, c := range pivots {
+			isPiv[c] = true
+		}
+		for f := 0; f < tchSparseWindow; f++ {
+			if isPiv[f] {
+				continue
+			}
+			var h [tchWords]uint64
+			sc := sparseCheck{}
+			add := func(k int) {
+				i := tchType5IndexOfCoded(start + k)
+				h[i>>6] |= 1 << uint(i&63)
+				sc.support = append(sc.support, i)
+			}
+			add(f)
+			for i, pc := range pivots {
+				if m[i]&(1<<uint(f)) != 0 {
+					add(pc)
+				}
+			}
+			sc.b0 = parityWords(&h, &lin.pn0)
+			for i := 0; i < tchSeedBits; i++ {
+				if parityWords(&h, &lin.pnCol[i]) == 1 {
+					sc.a |= 1 << uint(i)
+				}
+			}
+			lin.sparse = append(lin.sparse, sc)
+		}
+	}
+	return lin
+}
+
+// solveSeedRows solves the augmented rows (low 30 bits coefficients, bit 30 the
+// right-hand side) for the seed. ok is false when the system is inconsistent
+// or does not determine every seed bit.
+func solveSeedRows(rows []uint32) (seed uint32, ok bool) {
+	rank := 0
+	for col := 0; col < tchSeedBits; col++ {
+		sel := -1
+		for i := rank; i < len(rows); i++ {
+			if rows[i]&(1<<uint(col)) != 0 {
+				sel = i
+				break
+			}
+		}
+		if sel < 0 {
+			return 0, false
+		}
+		rows[rank], rows[sel] = rows[sel], rows[rank]
+		for i := range rows {
+			if i != rank && rows[i]&(1<<uint(col)) != 0 {
+				rows[i] ^= rows[rank]
+			}
+		}
+		rank++
+	}
+	for i := rank; i < len(rows); i++ {
+		if rows[i] != 0 {
+			return 0, false
+		}
+	}
+	for i := 0; i < rank; i++ {
+		if rows[i]>>tchSeedBits&1 != 0 {
+			pivot := 0
+			for pivot < tchSeedBits && rows[i]&(1<<uint(pivot)) == 0 {
+				pivot++
+			}
+			seed |= 1 << uint(pivot)
+		}
+	}
+	return seed, true
+}
+
+func tchSeedLinearInstance() *tchSeedLinear {
+	tchSeedOnce.Do(func() { tchSeedLin = buildTCHSeedLinear() })
+	return tchSeedLin
+}
+
+// SolveTCHScrambleSeed returns the 30-bit scrambling seed (the value
+// framing.NewScramblerTetra takes — tetra.ExtendedColourCode packing) that a
+// single still-scrambled 432-bit TCH/S type-5 block was scrambled with, by
+// solving the block's parity checks for the seed. ok is false when the block is
+// not an error-free TCH/S codeword under ANY seed (bit errors, a non-TCH/S
+// burst, or too little rank) — the system is over-determined by 128 checks, so
+// a false positive is negligible. Bits are bit-per-byte, de-rotated, in type-5
+// (on-air) order.
+func SolveTCHScrambleSeed(type5 []byte) (seed uint32, ok bool) {
+	if len(type5) < tchType3Bits {
+		return 0, false
+	}
+	lin := tchSeedLinearInstance()
+	r := packBits432(type5[:tchType3Bits])
+	// Augmented rows: low 30 bits = coefficients, bit 30 = right-hand side.
+	rows := make([]uint32, len(lin.checks))
+	for i := range lin.checks {
+		y := parityWords(&lin.checks[i], &r) ^ lin.b0[i]
+		rows[i] = lin.a[i] | uint32(y)<<tchSeedBits
+	}
+	return solveSeedRows(rows)
+}
+
+// DMBurstScrambleSeed solves the scramble seed of one DNB's TCH/S block (see
+// SolveTCHScrambleSeed); ok is false for a DSB, a malformed DNB, or a DNB whose
+// bit errors the soft-assisted search cannot place. When the burst carries the
+// receiver's soft differentials (ExtractDMBurstsSoft) the hard bits are solved
+// first and, failing that, the least reliable coded bits are flipped one and
+// two at a time (SolveTCHScrambleSeedSoft) — a marginal burst with a couple of
+// errors among its weakest symbols still solves, which is most of what a live
+// tap delivers between the clean bursts.
+func DMBurstScrambleSeed(b DMBurst) (seed uint32, ok bool) {
+	type5 := dmDNBType5(b)
+	if type5 == nil {
+		return 0, false
+	}
+	if seed, ok = SolveTCHScrambleSeed(type5); ok {
+		return seed, true
+	}
+	if len(b.SoftBKN1) != dmBlockDibits || len(b.SoftBKN2) != dmBlockDibits {
+		return 0, false
+	}
+	diffs := make([]complex64, 0, 2*dmBlockDibits)
+	diffs = append(diffs, b.SoftBKN1...)
+	diffs = append(diffs, b.SoftBKN2...)
+	return SolveTCHScrambleSeedSoft(type5, softType5FromDiffs(diffs, (4-b.Rotation)&3))
+}
+
+// tchSeedSoftSingles / tchSeedSoftPairs bound the soft-assisted search: single
+// flips among the least reliable tchSeedSoftSingles coded bits, then pairs among
+// the least reliable tchSeedSoftPairs. ~1 + 12 + 28 eliminations of a 158×31
+// system — well under a millisecond per burst.
+const (
+	tchSeedSoftSingles = 12
+	tchSeedSoftPairs   = 8
+)
+
+// SolveTCHScrambleSeedSoft is SolveTCHScrambleSeed for a block that did not
+// solve as received: it re-tries with the least reliable coded bits (by |LLR|)
+// flipped, singly then in pairs. llr is parallel to type5 (the soft convention
+// of framing/soft_tetra.go; only magnitudes are used). Class-0 bits are uncoded
+// and take no part in the checks, so they are never flipped.
+func SolveTCHScrambleSeedSoft(type5 []byte, llr []float32) (seed uint32, ok bool) {
+	if len(type5) < tchType3Bits || len(llr) < tchType3Bits {
+		return 0, false
+	}
+	// Rank the coded positions by reliability (partial selection of the
+	// weakest tchSeedSoftSingles is all that is needed).
+	type cand struct {
+		idx int
+		mag float32
+	}
+	weak := make([]cand, 0, tchSeedSoftSingles)
+	for k := 0; k < tchCodedBits; k++ {
+		i := tchType5IndexOfCoded(k)
+		m := llr[i]
+		if m < 0 {
+			m = -m
+		}
+		if len(weak) < tchSeedSoftSingles {
+			weak = append(weak, cand{i, m})
+			continue
+		}
+		// Replace the strongest of the kept set if this one is weaker.
+		maxJ := 0
+		for j := 1; j < len(weak); j++ {
+			if weak[j].mag > weak[maxJ].mag {
+				maxJ = j
+			}
+		}
+		if m < weak[maxJ].mag {
+			weak[maxJ] = cand{i, m}
+		}
+	}
+	// Sort ascending by magnitude (tiny slice).
+	for a := 1; a < len(weak); a++ {
+		for b := a; b > 0 && weak[b].mag < weak[b-1].mag; b-- {
+			weak[b], weak[b-1] = weak[b-1], weak[b]
+		}
+	}
+	buf := append([]byte(nil), type5[:tchType3Bits]...)
+	for a := 0; a < len(weak); a++ {
+		buf[weak[a].idx] ^= 1
+		if seed, ok = SolveTCHScrambleSeed(buf); ok {
+			return seed, true
+		}
+		buf[weak[a].idx] ^= 1
+	}
+	n := len(weak)
+	if n > tchSeedSoftPairs {
+		n = tchSeedSoftPairs
+	}
+	for a := 0; a < n; a++ {
+		buf[weak[a].idx] ^= 1
+		for c := a + 1; c < n; c++ {
+			buf[weak[c].idx] ^= 1
+			if seed, ok = SolveTCHScrambleSeed(buf); ok {
+				return seed, true
+			}
+			buf[weak[c].idx] ^= 1
+		}
+		buf[weak[a].idx] ^= 1
+	}
+	return solveTCHSeedReliableChecks(type5, llr)
+}
+
+// tchSparseMinChecks is how many of the most reliable sparse checks must agree
+// on a seed for the reliable-check solve to accept it: 30 to determine the seed
+// plus 24 redundant ones, so a burst that is not a TCH/S codeword (noise, a
+// signalling DNB) passes by chance ~2^-24 per attempt.
+const tchSparseMinChecks = tchSeedBits + 24
+
+// solveTCHSeedReliableChecks solves the seed from the burst's most reliable
+// LOCAL parity checks: each sparse check spans ~48 consecutive coded bits, so a
+// bit error spoils only the checks whose window contains it, and ranking checks
+// by their weakest symbol's |LLR| keeps the erroneous ones out of the system.
+// Tries the most reliable tchSparseMinChecks checks first, widening in steps
+// while the system stays consistent — the widest consistent set wins.
+func solveTCHSeedReliableChecks(type5 []byte, llr []float32) (seed uint32, ok bool) {
+	lin := tchSeedLinearInstance()
+	r := packBits432(type5[:tchType3Bits])
+	type scored struct {
+		row uint32
+		rel float32
+	}
+	all := make([]scored, 0, len(lin.sparse))
+	for i := range lin.sparse {
+		sc := &lin.sparse[i]
+		rel := float32(0)
+		var parity byte
+		for k, pos := range sc.support {
+			m := llr[pos]
+			if m < 0 {
+				m = -m
+			}
+			if k == 0 || m < rel {
+				rel = m
+			}
+			parity ^= byte(r[pos>>6]>>uint(pos&63)) & 1
+		}
+		all = append(all, scored{row: sc.a | uint32(parity^sc.b0)<<tchSeedBits, rel: rel})
+	}
+	// Sort by reliability, descending (n log n on ~300 entries).
+	for i := 1; i < len(all); i++ {
+		for j := i; j > 0 && all[j].rel > all[j-1].rel; j-- {
+			all[j], all[j-1] = all[j-1], all[j]
+		}
+	}
+	if len(all) < tchSparseMinChecks {
+		return 0, false
+	}
+	rows := make([]uint32, 0, len(all))
+	best, found := uint32(0), false
+	for n := tchSparseMinChecks; n <= len(all); n += 8 {
+		rows = rows[:0]
+		for i := 0; i < n; i++ {
+			rows = append(rows, all[i].row)
+		}
+		s, ok := solveSeedRows(rows)
+		if !ok {
+			break
+		}
+		best, found = s, true
+	}
+	return best, found
+}
+
+// dmSeedMinVotes is how many error-free DNBs must solve to the same seed before
+// RecoverDMScrambleSeed trusts it. Two agreeing exact solutions already have a
+// ~2^-30 chance of coinciding by accident; the CRC confirmation on top makes the
+// result at least as strong as the brute-force colour search's dominance gate.
+const dmSeedMinVotes = 2
+
+// RecoverDMScrambleSeed recovers the full 30-bit extended colour code a DMO
+// transmission's TCH/S traffic is scrambled with, by solving each DNB exactly
+// (DMBurstScrambleSeed) and voting. It needs no configured MNI and makes no
+// assumption about how the transmitter composed the seed — on air (the 12 Sep
+// #1003 capture) the DM colour code turned out to change from one PTT to the
+// next, so no per-network constant could ever have described it.
+//
+// Returns the winning seed, how many error-free bursts solved to it, and
+// whether it is trustworthy: at least dmSeedMinVotes agreeing solutions AND the
+// seed CRC-decodes at least as many bursts as it was solved from (an exact
+// solution of a real TCH/S block always CRC-decodes with its own seed, so this
+// is the cross-check that the linear model matches the decoder).
+func RecoverDMScrambleSeed(bursts []DMBurst) (seed uint32, votes int, confident bool) {
+	counts := map[uint32]int{}
+	for i := range bursts {
+		if bursts[i].Kind != DMBurstNormal {
+			continue
+		}
+		if s, ok := DMBurstScrambleSeed(bursts[i]); ok {
+			counts[s]++
+		}
+	}
+	best, bestN := uint32(0), 0
+	for s, n := range counts {
+		if n > bestN || (n == bestN && s < best) {
+			best, bestN = s, n
+		}
+	}
+	if bestN < dmSeedMinVotes {
+		return best, bestN, false
+	}
+	crc := 0
+	for i := range bursts {
+		if bursts[i].Kind != DMBurstNormal {
+			continue
+		}
+		if len(DMBurstTCHSpeechSoft(bursts[i], best)) == 2 || len(DMBurstTCHSpeech(bursts[i], best)) == 2 {
+			crc++
+		}
+	}
+	return best, bestN, crc >= bestN
+}

--- a/internal/radio/tetra/dmo_seed_test.go
+++ b/internal/radio/tetra/dmo_seed_test.go
@@ -1,0 +1,151 @@
+package tetra
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// The seed solver rests on two linearity claims about code GT already ships;
+// pin both numerically rather than by argument.
+func TestTCHSeedLinearStructure(t *testing.T) {
+	lin := tchSeedLinearInstance()
+	if got := len(lin.checks); got != tchCheckBits {
+		t.Fatalf("parity checks = %d, want %d (330 coded bits − 172 information bits)", got, tchCheckBits)
+	}
+	// Every check annihilates every codeword: random speech, no scrambling.
+	rng := rand.New(rand.NewSource(1))
+	for trial := 0; trial < 20; trial++ {
+		info := make([]byte, tchInfoBits)
+		for i := range info {
+			info[i] = byte(rng.Intn(2))
+		}
+		coded := tchCodedBitsFor(info)
+		var type5 [tchType3Bits]byte
+		for k, b := range coded {
+			type5[tchType5IndexOfCoded(k)] = b
+		}
+		w := packBits432(type5[:])
+		for ri := range lin.checks {
+			if parityWords(&lin.checks[ri], &w) != 0 {
+				t.Fatalf("trial %d: parity check %d does not annihilate a valid codeword", trial, ri)
+			}
+		}
+	}
+	// PN(seed) is affine in the seed: PN(s1^s2) = PN(s1) ^ PN(s2) ^ PN(0).
+	for trial := 0; trial < 20; trial++ {
+		s1, s2 := uint32(rng.Intn(1<<30)), uint32(rng.Intn(1<<30))
+		p0 := framing.NewScramblerTetra(0).Generate(tchType3Bits)
+		p1 := framing.NewScramblerTetra(s1).Generate(tchType3Bits)
+		p2 := framing.NewScramblerTetra(s2).Generate(tchType3Bits)
+		p12 := framing.NewScramblerTetra(s1 ^ s2).Generate(tchType3Bits)
+		for k := range p0 {
+			if p12[k] != p1[k]^p2[k]^p0[k] {
+				t.Fatalf("scrambler is not affine in its seed at bit %d", k)
+			}
+		}
+	}
+	// H'·P has full column rank: every seed bit is observable from one burst.
+	rows := append([]uint32(nil), lin.a...)
+	rank := 0
+	for col := 0; col < tchSeedBits; col++ {
+		sel := -1
+		for i := rank; i < len(rows); i++ {
+			if rows[i]&(1<<uint(col)) != 0 {
+				sel = i
+				break
+			}
+		}
+		if sel < 0 {
+			continue
+		}
+		rows[rank], rows[sel] = rows[sel], rows[rank]
+		for i := range rows {
+			if i != rank && rows[i]&(1<<uint(col)) != 0 {
+				rows[i] ^= rows[rank]
+			}
+		}
+		rank++
+	}
+	if rank != tchSeedBits {
+		t.Fatalf("H'·P rank = %d, want %d", rank, tchSeedBits)
+	}
+}
+
+// A scrambled TCH/S block solves to exactly the seed it was scrambled with —
+// for arbitrary 30-bit seeds, not just the 64 colours the brute force tried —
+// and a single bit error is rejected rather than mis-solved.
+func TestSolveTCHScrambleSeedRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	for trial := 0; trial < 200; trial++ {
+		frameA, frameB := randomSpeechFrames(rng)
+		seed := uint32(rng.Intn(1 << 30))
+		switch trial % 4 { // include the structured shapes an operator meets
+		case 1:
+			seed = uint32(rng.Intn(64)) // MNI 0, bare colour
+		case 2:
+			seed = ExtendedColourCode(250, 1, uint8(rng.Intn(64)))
+		}
+		type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+		type5 := framing.ScrambleTetra(type4, seed)
+		got, ok := SolveTCHScrambleSeed(type5)
+		if !ok || got != seed {
+			t.Fatalf("trial %d: seed %#x solved to %#x ok=%v", trial, seed, got, ok)
+		}
+		// Flip one bit inside the coded region: no seed explains it.
+		flipped := append([]byte(nil), type5...)
+		k := tchType5IndexOfCoded(rng.Intn(tchCodedBits))
+		flipped[k] ^= 1
+		if _, ok := SolveTCHScrambleSeed(flipped); ok {
+			t.Fatalf("trial %d: a corrupted block solved to a seed", trial)
+		}
+		// Flipping an UNCODED class-0 bit must not disturb the solve.
+		flipped = append([]byte(nil), type5...)
+		t3 := rng.Intn(tchClass0Bits)
+		flipped[(t3%18)*24+t3/18] ^= 1
+		if got, ok := SolveTCHScrambleSeed(flipped); !ok || got != seed {
+			t.Fatalf("trial %d: class-0 bit flip broke the solve (got %#x ok=%v)", trial, got, ok)
+		}
+	}
+}
+
+// RecoverDMScrambleSeed on a synthetic DNB train: bursts scrambled with one
+// arbitrary seed (a non-zero MNI and colour, as on air) vote it in, and the
+// CRC cross-check confirms it. Noise bursts (random dibits) neither vote nor
+// confuse it, and a train with no agreeing solutions is not trusted.
+func TestRecoverDMScrambleSeed(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	seed := ExtendedColourCode(250, 13, 39)
+	var bursts []DMBurst
+	for i := 0; i < 12; i++ {
+		frameA, frameB := randomSpeechFrames(rng)
+		type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+		type5 := framing.ScrambleTetra(type4, seed)
+		dibits := TetraBitsToDibits(type5)
+		bursts = append(bursts, DMBurst{Kind: DMBurstNormal, BKN1: dibits[:dmBlockDibits], BKN2: dibits[dmBlockDibits:]})
+		// Interleave a noise burst.
+		noise := make([]uint8, 2*dmBlockDibits)
+		for k := range noise {
+			noise[k] = uint8(rng.Intn(4))
+		}
+		bursts = append(bursts, DMBurst{Kind: DMBurstNormal, BKN1: noise[:dmBlockDibits], BKN2: noise[dmBlockDibits:]})
+	}
+	got, votes, ok := RecoverDMScrambleSeed(bursts)
+	if !ok || got != seed || votes != 12 {
+		t.Fatalf("recovered %#x votes=%d ok=%v, want %#x votes=12 ok=true", got, votes, ok, seed)
+	}
+	if _, _, ok := RecoverDMScrambleSeed(bursts[1:2]); ok {
+		t.Fatal("a single noise burst must not yield a confident seed")
+	}
+}
+
+func randomSpeechFrames(rng *rand.Rand) (frameA, frameB []byte) {
+	frameA = make([]byte, tchSpeechFrameBits)
+	frameB = make([]byte, tchSpeechFrameBits)
+	for i := range frameA {
+		frameA[i] = byte(rng.Intn(2))
+		frameB[i] = byte(rng.Intn(2))
+	}
+	return frameA, frameB
+}

--- a/internal/radio/tetra/dmo_seed_tracker.go
+++ b/internal/radio/tetra/dmo_seed_tracker.go
@@ -1,0 +1,231 @@
+package tetra
+
+// Per-transmission scramble-seed tracking for TETRA DMO traffic.
+//
+// What the 12 Sep #1003 capture (three consecutive PTTs on 438.9 MHz, clear
+// TEA0, Motorola MTP8500Ex) established, by solving each DNB's scramble seed
+// exactly (dmo_seed.go) and lining it up against the DSB's decoded DM-SYNC:
+//
+//   - the TCH/S scramble seed CHANGES FROM ONE PTT TO THE NEXT (0x012915c0,
+//     0x015d9c07, 0x01671384 on the three transmissions) — it is not a network
+//     constant, so no configured colour / MNI can describe it and any brute
+//     force over "colour codes" was doomed to pick a partial-keystream artifact
+//     (colour 36 / 31 / 39 / 3 on the earlier runs: all bogus);
+//   - the seed's low 24 bits are, bit for bit, the 24-bit field at SCH/H bits
+//     42..65 of that transmission's DM-SYNC PDU — the field immediately before
+//     the 24-bit MNI at bits 66..89, which decodes as MCC 250 / MNC 1, exactly
+//     the operator's codeplug (so the surrounding layout is the standard
+//     DMAC-SYNC SCH/H: … source address type, source address, MNI, message
+//     type …, and the field is the transmitting MS's source address);
+//   - the seed's top 6 bits (e(1..6)) were 000001 on all three.
+//
+// Neither reference decoder (osmo-tetra-dmo, TetraDMO-Receiver) carries a DMO
+// traffic seed rule at all, so the constants below are capture-pinned rather
+// than spec-quoted; they are only ever used as a HINT that traffic must confirm.
+// The exact per-burst solve is the authority: it needs no field layout, no
+// prefix and no configuration, and a single error-free DNB is enough.
+
+const (
+	// DMSCHHSeedFieldOffset / DMSCHHSeedFieldBits locate the 24-bit DM-SYNC
+	// SCH/H field the traffic seed's low 24 bits are copied from.
+	DMSCHHSeedFieldOffset = 42
+	DMSCHHSeedFieldBits   = 24
+	// DMScrambleSeedPrefix is e(1..6) of the DMO traffic seed as observed on air
+	// (three transmissions, one network). Capture-pinned; see the file comment.
+	DMScrambleSeedPrefix uint32 = 1
+)
+
+// DMSyncSCHHScrambleSeed derives the traffic scramble seed a transmission
+// announces in its DSB SCH/H (the decoded 124 type-1 bits of the DM-SYNC PDU's
+// SCH/H half): DMScrambleSeedPrefix || bits 42..65. It is a hint — the
+// DMSeedTracker confirms it against the DNB traffic before trusting it.
+func DMSyncSCHHScrambleSeed(schh []byte) (seed uint32, ok bool) {
+	if len(schh) < DMSCHHSeedFieldOffset+DMSCHHSeedFieldBits {
+		return 0, false
+	}
+	return DMScrambleSeedPrefix<<24 | bitsToUint(schh, DMSCHHSeedFieldOffset, DMSCHHSeedFieldBits), true
+}
+
+// dmSeedHintMinCRC is how many CRC-valid TCH/S decodes at a hinted seed confirm
+// the hint when no burst solves exactly (a weak transmission). A wrong seed
+// passes the 8-bit class-2 CRC ~1/128 of bursts (soft and hard attempts), so
+// three passes inside a dmSeedHintWindow-burst window is a ~1e-4 false accept
+// per window (two was measurably not enough: a synthetic 90-burst random
+// payload confirmed a wrong hint); a correct hint on a real transmission clears
+// it in three bursts. The exact solve, which any error-free burst delivers,
+// overrides a hint either way.
+const (
+	dmSeedHintMinCRC = 3
+	dmSeedHintWindow = 12
+)
+
+// DMSeedTracker learns the scramble seed of the DMO transmission in progress
+// from its bursts, per transmission. Feed it every DSB (ObserveDSB: the SCH/H
+// hint) and every slot-grid-qualified DNB (ObserveDNB: the exact solve, and the
+// decode itself). It is shared by the control pipeline and the voice chain so
+// both see the same rule. Not safe for concurrent use.
+//
+// Precedence: an exact solve (SolveTCHScrambleSeed) adopts immediately — a
+// solution is a 128-check-redundant proof that the burst is a TCH/S codeword
+// under that seed, so it cannot be a chance hit — and it also preempts a
+// previously adopted seed, which is how a new PTT with a new seed takes over.
+// The SCH/H hint (or an external hint, e.g. the pipeline's answer polled by the
+// voice chain) is adopted only after dmSeedHintMinCRC CRC-valid decodes, and
+// only while no exact solve has spoken for the current transmission. A pinned
+// seed (configuration) is never changed.
+type DMSeedTracker struct {
+	seed     uint32
+	known    bool
+	verified bool // known by exact solve or a CRC-confirmed hint (never the fallback)
+	pinned   bool
+
+	hint     uint32
+	hintSet  bool
+	hintCRC  int
+	hintSeen int
+
+	// Counters for the status/ended logs.
+	ExactAdopts int // seeds adopted from an exact per-burst solve
+	HintAdopts  int // seeds adopted from a CRC-confirmed hint
+	Solved      int // bursts that solved exactly
+}
+
+// NewDMSeedTracker returns an empty tracker (no seed known).
+func NewDMSeedTracker() *DMSeedTracker { return &DMSeedTracker{} }
+
+// Seed returns the seed currently in use and whether one is known at all
+// (verified or fallback).
+func (t *DMSeedTracker) Seed() (uint32, bool) { return t.seed, t.known }
+
+// Verified reports whether the current seed was confirmed by the traffic (an
+// exact solve or a CRC-confirmed hint), as opposed to a fallback guess.
+func (t *DMSeedTracker) Verified() bool { return t.known && t.verified }
+
+// Pin fixes the seed from configuration; nothing observed afterwards changes it.
+func (t *DMSeedTracker) Pin(seed uint32) {
+	t.seed, t.known, t.verified, t.pinned = seed, true, true, true
+}
+
+// Adopt installs an externally verified seed (the control pipeline's answer,
+// carried on the grant). Ignored when pinned.
+func (t *DMSeedTracker) Adopt(seed uint32) {
+	if t.pinned {
+		return
+	}
+	t.seed, t.known, t.verified = seed, true, true
+	t.hintCRC, t.hintSeen = 0, 0
+}
+
+// Fallback installs an unverified seed to decode at when nothing better is
+// known (the voice chain's give-up path). A later exact solve replaces it.
+func (t *DMSeedTracker) Fallback(seed uint32) {
+	if t.pinned || t.known {
+		return
+	}
+	t.seed, t.known, t.verified = seed, true, false
+}
+
+// Hint offers a candidate seed from outside the burst stream (the pipeline's
+// live colour polled by the voice chain). It is confirmed like an SCH/H hint.
+func (t *DMSeedTracker) Hint(seed uint32) {
+	if t.pinned || (t.hintSet && t.hint == seed) {
+		return
+	}
+	t.hint, t.hintSet, t.hintCRC, t.hintSeen = seed, true, 0, 0
+}
+
+// Reset forgets the transmission's seed and hint (a traffic drought ended it);
+// a pinned seed survives.
+func (t *DMSeedTracker) Reset() {
+	if t.pinned {
+		t.hintSet, t.hintCRC, t.hintSeen = false, 0, 0
+		return
+	}
+	*t = DMSeedTracker{ExactAdopts: t.ExactAdopts, HintAdopts: t.HintAdopts, Solved: t.Solved}
+}
+
+// ObserveDSB decodes a DSB's SCH/H and records the seed it announces as the
+// current hint. Returns the hint and whether the SCH/H decoded CRC-clean.
+func (t *DMSeedTracker) ObserveDSB(b DMBurst) (hint uint32, ok bool) {
+	schh, ok := DecodeDMSCHH(b)
+	if !ok {
+		return 0, false
+	}
+	hint, ok = DMSyncSCHHScrambleSeed(schh)
+	if !ok {
+		return 0, false
+	}
+	t.Hint(hint)
+	return hint, true
+}
+
+// HintKnown returns the pending hint (from a DSB SCH/H or Hint) and whether one
+// is set.
+func (t *DMSeedTracker) HintKnown() (uint32, bool) { return t.hint, t.hintSet }
+
+// ObserveDNB decodes one DNB at the best seed available, learning the seed on
+// the way. frames are the two 137-bit speech frames (nil when the burst yields
+// none — noise, an SCH/F DNB, or a seed not yet known), seed is the seed in use
+// after the call, and adopted reports that this burst changed it.
+//
+// qualified says the burst passed the caller's slot-grid gate (tetra.DMSlotGrid).
+// The exact solve is allowed on any burst — a solution cannot come from noise —
+// but only a qualified burst may CRC-confirm a hint, since a correlator false
+// alarm passes the 8-bit CRC at any seed ~1/128 of the time.
+func (t *DMSeedTracker) ObserveDNB(b DMBurst, qualified bool) (frames [][]byte, seed uint32, adopted bool) {
+	if b.Kind != DMBurstNormal {
+		return nil, t.seed, false
+	}
+	// Solve first, even with a seed in hand: a stale seed from the previous PTT
+	// can still CRC-pass an occasional burst of the new one (related seeds share
+	// keystream structure — measured ~9% on air for a "close" wrong seed, and
+	// the 8-bit CRC alone admits 1/256 at random), which would emit garbage
+	// speech and delay the switch. The solve costs microseconds and is exact.
+	if s, ok := DMBurstScrambleSeed(b); ok && !t.pinned {
+		t.Solved++
+		if !t.known || s != t.seed {
+			t.seed, t.known, t.verified = s, true, true
+			t.ExactAdopts++
+			t.hintCRC, t.hintSeen = 0, 0
+			adopted = true
+		}
+		return dmDecodeDNB(b, t.seed), t.seed, adopted
+	}
+	if t.known {
+		if frames = dmDecodeDNB(b, t.seed); frames != nil {
+			return frames, t.seed, false
+		}
+		if t.pinned {
+			return nil, t.seed, false
+		}
+	}
+	// No exact solution (bit errors): let a pending hint earn adoption by CRC.
+	if qualified && t.hintSet && (!t.known || t.hint != t.seed) {
+		if t.hintSeen++; t.hintSeen > dmSeedHintWindow {
+			t.hintSeen, t.hintCRC = 1, 0
+		}
+		if frames = dmDecodeDNB(b, t.hint); frames != nil {
+			t.hintCRC++
+			if t.hintCRC >= dmSeedHintMinCRC {
+				t.seed, t.known, t.verified = t.hint, true, true
+				t.HintAdopts++
+				t.hintCRC, t.hintSeen = 0, 0
+				adopted = true
+			}
+			return frames, t.seed, adopted
+		}
+	}
+	return nil, t.seed, false
+}
+
+// dmDecodeDNB decodes a DNB's TCH/S at seed, soft-decision first with the hard
+// fallback the production paths use.
+func dmDecodeDNB(b DMBurst, seed uint32) [][]byte {
+	if frames := DMBurstTCHSpeechSoft(b, seed); len(frames) == 2 {
+		return frames
+	}
+	if frames := DMBurstTCHSpeech(b, seed); len(frames) == 2 {
+		return frames
+	}
+	return nil
+}

--- a/internal/radio/tetra/dmo_seed_tracker_test.go
+++ b/internal/radio/tetra/dmo_seed_tracker_test.go
@@ -1,0 +1,151 @@
+package tetra
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// Literal on-air vectors from the 12 Sep #1003 capture (438.9 MHz DMO, three
+// consecutive PTTs): each transmission's decoded DSB SCH/H (124 type-1 bits,
+// hex, MSB-first) and the scramble seed its DNBs solved to exactly
+// (TestTETRADMOSeedScan). The seed's low 24 bits sit at SCH/H bits 42..65 with
+// the MNI (MCC 250 / MNC 1 — the operator's codeplug) at 66..89; the top 6
+// bits were 000001 on all three. A field-layout pin against real air, not a
+// round trip.
+var dmoFieldSCHH = []struct {
+	schh string
+	seed uint32
+}{
+	{"00200000034a45700fa0005ae0000440", 0x012915c0},
+	{"0020000003576701cfa0005ae0000440", 0x015d9c07},
+	{"002000000359c4e10fa0005ae0000440", 0x01671384},
+}
+
+func TestDMSyncSCHHScrambleSeedFieldCapture(t *testing.T) {
+	for _, v := range dmoFieldSCHH {
+		raw, err := hex.DecodeString(v.schh)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bits := framing.UnpackBitsMSB(raw, 124)
+		got, ok := DMSyncSCHHScrambleSeed(bits)
+		if !ok || got != v.seed {
+			t.Errorf("SCH/H %s: seed %#010x ok=%v, want %#010x", v.schh, got, ok, v.seed)
+		}
+		// The MNI right after the field is the operator's network.
+		if mcc, mnc := bitsToUint(bits, 66, 10), bitsToUint(bits, 76, 14); mcc != 250 || mnc != 1 {
+			t.Errorf("SCH/H %s: MNI after the seed field = %d/%d, want 250/1", v.schh, mcc, mnc)
+		}
+	}
+}
+
+// dmoTrackerDNB builds one TCH/S DNB scrambled with seed (optionally with bit
+// errors so it cannot solve exactly).
+func dmoTrackerDNB(rng *rand.Rand, seed uint32, flips int) DMBurst {
+	frameA, frameB := randomSpeechFrames(rng)
+	type4 := framing.UnpackBitsMSB(EncodeTCHS(frameA, frameB), tchType3Bits)
+	type5 := framing.ScrambleTetra(type4, seed)
+	for i := 0; i < flips; i++ {
+		type5[tchType5IndexOfCoded(rng.Intn(tchCodedBits))] ^= 1
+	}
+	dibits := TetraBitsToDibits(type5)
+	return DMBurst{Kind: DMBurstNormal, BKN1: dibits[:dmBlockDibits], BKN2: dibits[dmBlockDibits:]}
+}
+
+// dmoTrackerDSB builds a DSB whose SCH/H announces seed's low 24 bits at the
+// capture-pinned field.
+func dmoTrackerDSB(seed uint32) DMBurst {
+	type1 := make([]byte, 124)
+	for i := 0; i < 124; i++ {
+		type1[i] = byte((i * 7) % 2)
+	}
+	for i := 0; i < DMSCHHSeedFieldBits; i++ {
+		type1[DMSCHHSeedFieldOffset+i] = byte(seed >> uint(DMSCHHSeedFieldBits-1-i) & 1)
+	}
+	return DMBurst{Kind: DMBurstSync, BKN2: TetraBitsToDibits(EncodeSCHHD(type1, 0))}
+}
+
+// A transmission whose seed changes at the next PTT (the on-air behaviour) is
+// followed: the exact solve adopts each new seed on its first clean burst, and
+// every burst decodes at its own transmission's seed. The old 64-colour brute
+// force could not represent either seed (both > 63 with MNI 0).
+func TestDMSeedTrackerFollowsPerTransmissionSeeds(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	tr := NewDMSeedTracker()
+	for _, seed := range []uint32{0x012915c0, 0x015d9c07, 0x01671384} {
+		for i := 0; i < 10; i++ {
+			frames, got, _ := tr.ObserveDNB(dmoTrackerDNB(rng, seed, 0), true)
+			if frames == nil || got != seed {
+				t.Fatalf("seed %#x burst %d: frames=%v seed=%#x", seed, i, frames != nil, got)
+			}
+		}
+		if !tr.Verified() {
+			t.Fatalf("seed %#x not verified", seed)
+		}
+	}
+	if tr.ExactAdopts != 3 {
+		t.Errorf("exact adopts = %d, want 3", tr.ExactAdopts)
+	}
+}
+
+// Weak bursts (bit errors, no exact solution) are decoded through the SCH/H
+// hint once two of them CRC-confirm it; a wrong hint (another radio's DSB
+// during the call) never latches, and the exact solve still wins when a clean
+// burst arrives.
+func TestDMSeedTrackerHintNeedsCRCConfirmation(t *testing.T) {
+	rng := rand.New(rand.NewSource(5))
+	const seed, wrong = 0x015d9c07, 0x012915c0
+	tr := NewDMSeedTracker()
+	if _, ok := tr.ObserveDSB(dmoTrackerDSB(wrong)); !ok {
+		t.Fatal("DSB SCH/H did not decode")
+	}
+	// Errored bursts at the true seed cannot confirm the wrong hint.
+	for i := 0; i < 8; i++ {
+		if frames, _, adopted := tr.ObserveDNB(dmoTrackerDNB(rng, seed, 3), true); adopted || frames != nil {
+			t.Fatalf("burst %d: wrong hint produced frames=%v adopted=%v", i, frames != nil, adopted)
+		}
+	}
+	if _, known := tr.Seed(); known {
+		t.Fatal("a seed was adopted from an unconfirmed hint")
+	}
+	// The transmitting radio's DSB: the right hint confirms on the third
+	// CRC-valid decode even though no burst solves exactly.
+	tr.ObserveDSB(dmoTrackerDSB(seed))
+	decoded, adoptedAt := 0, -1
+	for i := 0; i < 12; i++ {
+		frames, got, adopted := tr.ObserveDNB(dmoTrackerDNB(rng, seed, 3), true)
+		if frames != nil {
+			decoded++
+		}
+		if adopted && adoptedAt < 0 {
+			adoptedAt = i
+			if got != seed {
+				t.Fatalf("adopted %#x, want %#x", got, seed)
+			}
+		}
+	}
+	if adoptedAt < 0 || tr.HintAdopts != 1 || decoded < 6 {
+		t.Fatalf("hint adoption at %d, hint_adopts=%d, decoded=%d", adoptedAt, tr.HintAdopts, decoded)
+	}
+	// A clean burst from a NEW transmission preempts the hint-adopted seed.
+	if _, got, adopted := tr.ObserveDNB(dmoTrackerDNB(rng, 0x01671384, 0), true); !adopted || got != 0x01671384 {
+		t.Fatalf("exact solve did not preempt: adopted=%v seed=%#x", adopted, got)
+	}
+}
+
+// A pinned (configured) seed is used as is and never displaced; Reset keeps it.
+func TestDMSeedTrackerPinnedSeed(t *testing.T) {
+	rng := rand.New(rand.NewSource(9))
+	tr := NewDMSeedTracker()
+	tr.Pin(0x2c)
+	if frames, got, adopted := tr.ObserveDNB(dmoTrackerDNB(rng, 0x012915c0, 0), true); adopted || got != 0x2c || frames != nil {
+		t.Fatalf("pinned seed changed: frames=%v seed=%#x adopted=%v", frames != nil, got, adopted)
+	}
+	tr.Reset()
+	if s, known := tr.Seed(); !known || s != 0x2c {
+		t.Fatalf("pinned seed lost on Reset: %#x known=%v", s, known)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines_dmo.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo.go
@@ -2,6 +2,7 @@ package ccdecoder
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"time"
@@ -28,8 +29,12 @@ import (
 //     DM channel. The lock is sticky (no cc.lost on inter-transmission silence) —
 //     re-hunting a camped DMO frequency every quiet gap is exactly the churn the TMO
 //     pipeline produced on a DMO capture.
-//   - COLOUR: recover the DM traffic colour code once (RecoverDMColourCode), so the
-//     voice chain can descramble TCH/S. A non-zero tetra_colour_code overrides.
+//   - SEED: learn the transmission's TCH/S scramble seed (tetra.DMSeedTracker — the
+//     DSB SCH/H hint confirmed by traffic, or an exact per-burst solve), so the
+//     voice chain can descramble TCH/S. The seed is PER TRANSMISSION on air (the
+//     12 Sep #1003 capture: a different 30-bit seed on each of three PTTs, none of
+//     them a "colour code" a 64-way brute force could reach), so it is re-learned
+//     after every traffic drought. A non-zero tetra_colour_code pins it.
 //   - GRANT: publish events.KindGrant (Protocol "tetra-dmo") on the rising edge of a
 //     DNB traffic burst train, so the engine starts a same-carrier voice chain that
 //     decodes the actual speech (composer.runTETRADMOVoiceChain). Edge-triggered and
@@ -48,7 +53,7 @@ import (
 // noise hits spread uniformly over all 255.
 //
 // The actual TCH/S → ACELP audio is decoded in the voice chain, not here; this
-// pipeline decodes SCH/S (lock) and brute-forces the colour, and only needs to detect
+// pipeline decodes SCH/S (lock) and learns the scramble seed, and only needs to detect
 // DNB *presence* to grant. This is #1003, design-first and on-air A/B gated: a green
 // synthetic decode is not proof of on-air correctness (the #764/#771 rule).
 
@@ -56,15 +61,6 @@ const (
 	// dmoStatusInterval throttles the DMO decode-status debug line (mirrors the TMO
 	// tetraStatusInterval).
 	dmoStatusInterval = 5 * time.Second
-	// dmoColourBatch is how many DNBs to buffer before brute-forcing the DM colour
-	// code (RecoverDMColourCode). ~one second of a full-rate call, enough for the
-	// confidence gate (dmColourMinCRC/dmColourDominance) to separate the true colour
-	// from the chance floor.
-	dmoColourBatch = 20
-	// dmoColourMaxAttempts caps how many recovery passes to try before giving up and
-	// falling back to colour 0 (a channel that never clears the confidence gate is
-	// encrypted or unreceivable — chasing it forever would burn CPU on every DNB).
-	dmoColourMaxAttempts = 6
 	// dmoGrantMinDNB is how many SLOT-GRID-QUALIFIED DNBs must follow a lock before a
 	// grant fires — a short guard on top of the grid gate so a call is not spawned
 	// before the burst train is unambiguous.
@@ -96,19 +92,14 @@ func newTETRADMOPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		rateHz:       opts.SampleRateHz,
 		now:          time.Now,
 		configColour: opts.System.TETRAColourCode,
-		// baseMNI is the network's MNI (MCC<<20 | MNC<<6) — the non-colour half of
-		// the extended colour code. On a DMO network with a non-zero MNI the TCH/S
-		// traffic seed is ExtendedColourCode(MCC, MNC, colour), so colour recovery
-		// must search on top of this base or it never reaches the true seed (the
-		// reporter's Motorola DMO at MCC 250 / MNC 1 — #1003 follow-up).
-		baseMNI:    tetra.ExtendedColourCode(opts.System.TETRAMCC, opts.System.TETRAMNC, 0),
-		colourSink: opts.TETRADMOColourSink,
-		fnSeen:     map[uint8]struct{}{},
-		debug:      log.Enabled(context.Background(), slog.LevelDebug),
+		seeds:        tetra.NewDMSeedTracker(),
+		colourSink:   opts.TETRADMOColourSink,
+		fnSeen:       map[uint8]struct{}{},
+		debug:        log.Enabled(context.Background(), slog.LevelDebug),
 	}
 	if p.configColour != 0 {
-		p.colour = p.configColour
-		p.colourKnown = true
+		p.seeds.Pin(p.configColour)
+		p.colour, p.colourKnown = p.configColour, true
 		if p.colourSink != nil {
 			p.colourSink(p.colour)
 		}
@@ -159,23 +150,18 @@ type tetraDMOPipeline struct {
 	// SoftSink → DibitSink hand-off (both fire on the single rx.Process goroutine).
 	pendingSoft []complex64
 
-	// Colour recovery: 0 = auto-recover via RecoverDMColourCode; a non-zero
-	// tetra_colour_code overrides.
+	// Scramble seed: 0 = learn it per transmission (seeds); a non-zero
+	// tetra_colour_code pins it. colour/colourKnown mirror the tracker's
+	// current answer for the status line, the grant and the tests.
 	configColour uint32
-	// baseMNI is ExtendedColourCode(MCC, MNC, 0) from tetra_mcc/tetra_mnc — the
-	// network MNI folded into every colour-recovery candidate so a non-zero-MNI
-	// DMO network decodes (its traffic seed is baseMNI | colour). 0 = MNI 0.
-	baseMNI     uint32
-	colour      uint32
-	colourKnown bool
-	colourCand  []tetra.DMBurst
-	colourTries int
-	// colourSink, when non-nil, is told the DM colour the moment it is known
-	// (config override at construction, or a confident recovery). The decoder
-	// exposes it to the same-carrier voice chain, which typically starts
-	// before recovery completes (the grant fires at dmoGrantMinDNB=4 bursts,
-	// recovery needs dmoColourBatch=20) and would otherwise brute-force the
-	// colour all over again — or fail to, on a noisy tap.
+	seeds        *tetra.DMSeedTracker
+	colour       uint32
+	colourKnown  bool
+	// colourSink, when non-nil, is told the scramble seed the moment it is
+	// known or changes (config override at construction, or a verified
+	// recovery). The decoder exposes it to the same-carrier voice chain,
+	// which typically starts before this pipeline's first solve lands (the
+	// grant fires at dmoGrantMinDNB=4 bursts) and polls it as a hint.
 	colourSink func(colour uint32)
 
 	// Lock + liveness.
@@ -208,6 +194,10 @@ func (p *tetraDMOPipeline) onBurst(b tetra.DMBurst) {
 	switch b.Kind {
 	case tetra.DMBurstSync:
 		p.dsbTotal++
+		// The DSB's SCH/H announces the transmission's scramble seed (the source
+		// address field, capture-pinned in tetra/dmo_seed_tracker.go); the tracker
+		// keeps it as a hint the DNB traffic must confirm.
+		p.seeds.ObserveDSB(b)
 		type1, ok := tetra.DecodeDMSCHS(b)
 		if !ok {
 			return
@@ -231,20 +221,7 @@ func (p *tetraDMOPipeline) onBurst(b tetra.DMBurst) {
 		p.dnbQualified++
 		p.lastDNB = now
 		p.dnbSinceLock++
-		p.recoverColour(b)
-		// Telemetry only: count CRC-valid TCH/S when the colour is known (the voice
-		// chain does the real decode). This is a full Viterbi pass per burst (two when
-		// the soft decode fails and the hard fallback runs), which was unbounded while
-		// noise detections reached here; qualified bursts cap it at the ~17/s a real
-		// transmission produces, and only while one is in progress. Debug-gated: the
-		// counter only feeds the debug status line, so at INFO level the decode is
-		// pure waste on the control decode goroutine.
-		if p.debug && p.colourKnown {
-			if len(tetra.DMBurstTCHSpeechSoft(b, p.colour)) == 2 ||
-				len(tetra.DMBurstTCHSpeech(b, p.colour)) == 2 {
-				p.tchCRC++
-			}
-		}
+		p.learnSeed(b)
 		p.maybeGrant()
 	}
 }
@@ -262,15 +239,12 @@ func (p *tetraDMOPipeline) maybeRearmGrant(now time.Time) {
 	p.dnbSinceLock = 0
 	p.lastDNB = time.Time{}
 	p.grid.Reset()
-	// A drought ends the transmission, so the colour-recovery attempt budget is
-	// per-transmission, not per-process: without this, six failed attempts (a
-	// weak first PTT, or noise-diluted early batches) disabled recovery for the
-	// daemon's lifetime — the operator's run showed colour_known=false forever
-	// while hundreds of later, perfectly decodable qualified DNBs arrived.
-	// Buffered candidates are stale for the same reason: bursts carried across
-	// a transmission boundary dilute the next attempt's dominance gate.
-	p.colourTries = 0
-	p.colourCand = p.colourCand[:0]
+	// A drought ends the transmission, and the scramble seed is per transmission
+	// (a new PTT carries a new source-address seed), so forget it — the next
+	// transmission's DSB hint / first clean DNB re-learns it in well under a
+	// second. A pinned tetra_colour_code survives the reset.
+	p.seeds.Reset()
+	p.colour, p.colourKnown = p.seeds.Seed()
 }
 
 // maybeLock publishes cc.locked once, on the first CRC-valid SCH/S with a parseable
@@ -288,30 +262,28 @@ func (p *tetraDMOPipeline) maybeLock() {
 	p.log.Info("tetra dmo cc locked", "freq", p.freqHz, "system", p.system)
 }
 
-// recoverColour brute-forces the DM traffic colour code once (RecoverDMColourCode),
-// buffering DNBs until a batch is available. No-op once the colour is known (config
-// override or a prior successful recovery) or after dmoColourMaxAttempts give up.
-func (p *tetraDMOPipeline) recoverColour(b tetra.DMBurst) {
-	if p.colourKnown || p.colourTries >= dmoColourMaxAttempts {
-		return
+// learnSeed feeds one qualified DNB to the seed tracker: an exact solve adopts
+// the burst's seed on the spot (and preempts a stale one from the previous PTT),
+// the DSB hint is adopted once traffic CRC-confirms it, and every CRC-valid
+// decode feeds the tch_crc telemetry. The solve is a microsecond GF(2)
+// elimination and the decode one or two Viterbi passes per qualified burst — the
+// ~17/s a real transmission produces — so this replaces the 64-colour brute
+// force (64 Viterbi passes per burst per attempt) at a fraction of its cost, with
+// no confidence gate to mis-clear and no colour space to be outside of.
+func (p *tetraDMOPipeline) learnSeed(b tetra.DMBurst) {
+	frames, seed, adopted := p.seeds.ObserveDNB(b, true)
+	if frames != nil {
+		p.tchCRC++
 	}
-	p.colourCand = append(p.colourCand, b)
-	if len(p.colourCand) < dmoColourBatch {
-		return
-	}
-	p.colourTries++
-	if c, n, confident := tetra.RecoverDMColourCode(p.colourCand, p.baseMNI); confident {
-		p.colour = c
-		p.colourKnown = true
-		p.log.Info("tetra dmo colour code recovered", "colour", c, "crc_valid_tchs", n, "system", p.system)
+	if adopted {
+		p.colour, p.colourKnown = seed, true
+		p.log.Info("tetra dmo scramble seed recovered",
+			"seed", fmt.Sprintf("%#010x", seed), "source_field", fmt.Sprintf("%#08x", seed&0xFFFFFF),
+			"exact_adopts", p.seeds.ExactAdopts, "hint_adopts", p.seeds.HintAdopts, "system", p.system)
 		if p.colourSink != nil {
-			p.colourSink(c)
+			p.colourSink(seed)
 		}
 	}
-	// Keep only the freshest half so the next attempt reflects current channel
-	// conditions rather than re-scoring stale bursts.
-	keep := len(p.colourCand) / 2
-	p.colourCand = append(p.colourCand[:0], p.colourCand[keep:]...)
 }
 
 // maybeGrant publishes a tetra-dmo grant on the rising edge of a QUALIFIED DNB
@@ -335,16 +307,15 @@ func (p *tetraDMOPipeline) maybeGrant() {
 	p.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
-			System:          p.system,
-			Protocol:        "tetra-dmo",
-			FrequencyHz:     p.freqHz,
-			TETRAColourExt:  p.colour,
-			TETRADMOBaseMNI: p.baseMNI,
-			At:              p.now(),
+			System:         p.system,
+			Protocol:       "tetra-dmo",
+			FrequencyHz:    p.freqHz,
+			TETRAColourExt: p.colour,
+			At:             p.now(),
 		},
 	})
 	p.log.Info("tetra dmo grant (traffic detected)",
-		"freq", p.freqHz, "colour", p.colour, "system", p.system)
+		"freq", p.freqHz, "seed", fmt.Sprintf("%#010x", p.colour), "seed_known", p.colourKnown, "system", p.system)
 }
 
 func (p *tetraDMOPipeline) maybeLogStatus() {
@@ -370,8 +341,10 @@ func (p *tetraDMOPipeline) maybeLogStatus() {
 		"dnb_qualified", p.dnbQualified,
 		"tch_crc", p.tchCRC,
 		"distinct_fn", len(p.fnSeen),
-		"colour", p.colour,
-		"colour_known", p.colourKnown,
+		"seed", fmt.Sprintf("%#010x", p.colour),
+		"seed_known", p.colourKnown,
+		"seed_verified", p.seeds.Verified(),
+		"bursts_solved", p.seeds.Solved,
 		"grant_active", p.grantActive,
 	)
 }
@@ -396,11 +369,10 @@ func (p *tetraDMOPipeline) Reset() {
 	p.lastDNB = time.Time{}
 	p.pendingSoft = nil
 	p.lastLog = time.Time{}
-	// Buffered colour candidates predate the re-anchor and the attempt budget is
-	// per-transmission (see maybeRearmGrant); a recovered/configured colour itself
-	// stays — the DM colour is a network constant, not receiver state.
-	p.colourTries = 0
-	p.colourCand = p.colourCand[:0]
+	// The transmission's seed is forgotten with the grid (see maybeRearmGrant);
+	// a pinned tetra_colour_code survives.
+	p.seeds.Reset()
+	p.colour, p.colourKnown = p.seeds.Seed()
 }
 
 func (p *tetraDMOPipeline) Close() error { return nil }

--- a/internal/scanner/ccdecoder/pipelines_dmo_test.go
+++ b/internal/scanner/ccdecoder/pipelines_dmo_test.go
@@ -40,6 +40,17 @@ func dmoSeqBits(seed, n int) []byte {
 	return out
 }
 
+// dmoSCHHBits is a DM-SYNC SCH/H whose capture-pinned seed field (bits 42..65,
+// tetra.DMSCHHSeedFieldOffset) announces seed's low 24 bits, as a real
+// transmitter's does; the rest is a fixed pattern.
+func dmoSCHHBits(seed uint32) []byte {
+	bits := dmoSeqBits(2, 124)
+	for i := 0; i < tetra.DMSCHHSeedFieldBits; i++ {
+		bits[tetra.DMSCHHSeedFieldOffset+i] = byte(seed >> uint(tetra.DMSCHHSeedFieldBits-1-i) & 1)
+	}
+	return bits
+}
+
 func dmoFiller(seed, n int) []uint8 {
 	out := make([]uint8, n)
 	for i := range out {
@@ -60,6 +71,7 @@ func dmoFiller(seed, n int) []uint8 {
 // timeslot from one clock, so all its DNB leads share one residue mod 255 — the
 // property tetra.DMSlotGrid uses to tell traffic from correlator noise.
 const (
+	dmoTestDSBs       = 3 // DSBs a transmission opens with (12 Sep capture: three consecutive slots)
 	dmoTestSlotDibits = 255
 	dmoTestDSBLead    = 107
 	dmoTestDNBLead    = 115
@@ -81,27 +93,39 @@ func dmoSlot(seed int, fields ...[]uint8) []uint8 {
 	return slot
 }
 
+// dmoTestSeed is the scramble seed the synthetic transmissions use where a
+// specific on-air value is not the point: source-address field 3 under the
+// capture-pinned prefix (tetra.DMScrambleSeedPrefix), so the DSB SCH/H hint the
+// stream carries is faithful to the traffic, as on air.
+const dmoTestSeed = tetra.DMScrambleSeedPrefix<<24 | 3
+
 // buildDMODibitStream synthesizes a DMO transmission's demodulated dibit stream: a
-// long receiver lead-in, one DSB (SCH/S + SCH/H), then nDNB TCH/S DNBs scrambled with
-// colour — every burst on its own 255-dibit timeslot, as a real radio transmits them.
+// long receiver lead-in, one DSB (SCH/S + SCH/H announcing colour's low 24 bits in
+// the seed field), then nDNB TCH/S DNBs scrambled with colour — every burst on its
+// own 255-dibit timeslot, as a real radio transmits them.
 // It mirrors the buildDSB/buildDNB layout the tetra package tests use (EN 300 396-2
 // Tables 15/16), built from the exported encoders so it can live in the ccdecoder
 // package.
 func buildDMODibitStream(colour uint32, nDNB int) []uint8 {
 	b2d := tetra.TetraBitsToDibits
 	schs := b2d(tetra.EncodeBSCH(dmoSeqBits(1, 60)))
-	schh := b2d(tetra.EncodeSCHHD(dmoSeqBits(2, 124), 0))
+	schh := b2d(tetra.EncodeSCHHD(dmoSCHHBits(colour), 0))
 
 	var out []uint8
 	// Lead-in (a whole number of slots): let Gardner/AFC/equalizer converge.
 	out = append(out, dmoFiller(0, 4*dmoTestSlotDibits)...)
 
-	out = append(out, dmoSlot(1,
-		dmoFiller(3, dmoTestDSBLead-dmoTestBurstStart-60), // 40-dibit freq-corr field
-		schs,
-		tetra.SyncTrainingDibits(),
-		schh,
-	)...)
+	// A transmission opens with DSBs in consecutive slots (the 12 Sep capture
+	// shows three, 255 dibits apart) before the DNB train — the receiver gets
+	// more than one chance at the SCH/S lock and the SCH/H seed hint.
+	for k := 0; k < dmoTestDSBs; k++ {
+		out = append(out, dmoSlot(1+k,
+			dmoFiller(3, dmoTestDSBLead-dmoTestBurstStart-60), // 40-dibit freq-corr field
+			schs,
+			tetra.SyncTrainingDibits(),
+			schh,
+		)...)
+	}
 
 	for i := 0; i < nDNB; i++ {
 		frameA := dmoSeqBits(7+i, dmoTestSpeechBits)
@@ -132,7 +156,10 @@ func TestTETRADMOPipelineLocksAndGrants(t *testing.T) {
 		span       = 8
 		alpha      = 0.35
 		freqHz     = 438_900_000
-		testColour = uint32(3) // the DM traffic colour to recover (0 = config default)
+		// The TCH/S scramble seed to recover: a real on-air value from the 12 Sep
+		// #1003 capture, outside the 0..63 "colour" space the old brute force
+		// searched (this test fails against the old recovery).
+		testColour = uint32(0x012915c0)
 		nDNB       = 40
 	)
 
@@ -200,12 +227,12 @@ func TestTETRADMOPipelineLocksAndGrants(t *testing.T) {
 		t.Errorf("no CRC-valid DSB SCH/S decoded")
 	}
 	if !dmo.colourKnown {
-		t.Errorf("DM colour code not recovered (dnb_total=%d tch_crc=%d)", dmo.dnbTotal, dmo.tchCRC)
+		t.Errorf("scramble seed not recovered (dnb_total=%d tch_crc=%d)", dmo.dnbTotal, dmo.tchCRC)
 	} else if dmo.colour != testColour {
-		t.Errorf("recovered colour=%d, want %d", dmo.colour, testColour)
+		t.Errorf("recovered seed=%#x, want %#x", dmo.colour, testColour)
 	}
 	if dmo.tchCRC == 0 {
-		t.Errorf("no CRC-valid TCH/S decoded at the recovered colour")
+		t.Errorf("no CRC-valid TCH/S decoded at the recovered seed")
 	}
 
 	bus.Close()
@@ -369,7 +396,7 @@ func TestTETRADMOPipelineGrantsOnlyAfterLock(t *testing.T) {
 	if p.locked {
 		t.Fatalf("locked on the idle lead-in")
 	}
-	dmoFeed(p, dmoModulate(buildDMODibitStream(3, 40), 7))
+	dmoFeed(p, dmoModulate(buildDMODibitStream(dmoTestSeed, 40), 7))
 
 	bus.Close()
 	<-w.drainEnd
@@ -408,7 +435,7 @@ func dmoRandDibits(seed, n int) []uint8 {
 func buildDMOUndecodableDibitStream(nDNB int) []uint8 {
 	b2d := tetra.TetraBitsToDibits
 	schs := b2d(tetra.EncodeBSCH(dmoSeqBits(1, 60)))
-	schh := b2d(tetra.EncodeSCHHD(dmoSeqBits(2, 124), 0))
+	schh := b2d(tetra.EncodeSCHHD(dmoSCHHBits(0), 0))
 
 	var out []uint8
 	out = append(out, dmoFiller(0, 4*dmoTestSlotDibits)...)
@@ -450,10 +477,6 @@ func TestTETRADMOPipelineRecoversColourAfterRearm(t *testing.T) {
 	if p.colourKnown {
 		t.Fatalf("recovered a colour from undecodable payload (colour=%d)", p.colour)
 	}
-	if p.colourTries < dmoColourMaxAttempts {
-		t.Fatalf("burned %d attempts, want %d — the scenario is not exercising the cap",
-			p.colourTries, dmoColourMaxAttempts)
-	}
 
 	// Silence past the re-arm drought: the attempt budget must reset with the grid.
 	gap := dmoNoiseIQ(1, 99)
@@ -461,22 +484,21 @@ func TestTETRADMOPipelineRecoversColourAfterRearm(t *testing.T) {
 		clock = clock.Add(time.Second)
 		dmoFeed(p, gap)
 	}
-	if p.colourTries != 0 {
-		t.Errorf("colourTries = %d after the re-arm drought, want 0", p.colourTries)
-	}
-	if len(p.colourCand) != 0 {
-		t.Errorf("%d stale colour candidates survived the re-arm, want 0", len(p.colourCand))
+	if p.colourKnown {
+		t.Errorf("a seed survived the re-arm drought (seed=%#x); it is per transmission", p.colour)
 	}
 
-	// Second transmission: clean colour-3 traffic must now recover.
+	// Second transmission: clean traffic must now recover its seed (through the
+	// DSB hint if the post-gap receiver leaves the bursts too errored to solve).
 	clock = clock.Add(time.Second)
-	dmoFeed(p, dmoModulate(buildDMODibitStream(3, 40), 11))
+	dmoFeed(p, dmoModulate(buildDMODibitStream(dmoTestSeed, 40), 11))
 	if !p.colourKnown {
-		t.Fatalf("colour not recovered on a clean transmission after re-arm (tries=%d, qualified=%d)",
-			p.colourTries, p.dnbQualified)
+		hint, hintSet := p.seeds.HintKnown()
+		t.Fatalf("seed not recovered on a clean transmission after re-arm (qualified=%d dsb_crc=%d solved=%d hint=%#x hint_set=%v tch_crc=%d)",
+			p.dnbQualified, p.dsbCRC, p.seeds.Solved, hint, hintSet, p.tchCRC)
 	}
-	if p.colour != 3 {
-		t.Errorf("recovered colour=%d, want 3", p.colour)
+	if p.colour != dmoTestSeed {
+		t.Errorf("recovered seed=%#x, want %#x", p.colour, dmoTestSeed)
 	}
 
 	bus.Close()
@@ -504,9 +526,9 @@ func TestTETRADMOPipelinePublishesColourToSink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newTETRADMOPipeline: %v", err)
 	}
-	dmoFeed(pl, dmoModulate(buildDMODibitStream(3, 40), 7))
-	if len(got) != 1 || got[0] != 3 {
-		t.Errorf("colour sink calls = %v, want exactly [3]", got)
+	dmoFeed(pl, dmoModulate(buildDMODibitStream(dmoTestSeed, 40), 7))
+	if len(got) != 1 || got[0] != dmoTestSeed {
+		t.Errorf("seed sink calls = %#x, want exactly [%#x]", got, dmoTestSeed)
 	}
 
 	// A configured colour publishes at construction, before any IQ.
@@ -566,7 +588,7 @@ func TestTETRADMOPipelineRearmsBetweenTransmissions(t *testing.T) {
 	clock := time.Unix(1_760_000_000, 0)
 	p := dmoTestPipeline(t, bus, &clock)
 
-	tx := dmoModulate(buildDMODibitStream(3, 40), 7)
+	tx := dmoModulate(buildDMODibitStream(dmoTestSeed, 40), 7)
 	gap := dmoNoiseIQ(1, 99) // idle channel, still raining false DNB detections
 
 	dmoFeed(p, tx)
@@ -588,7 +610,7 @@ func TestTETRADMOPipelineRearmsBetweenTransmissions(t *testing.T) {
 	}
 
 	clock = clock.Add(time.Second)
-	dmoFeed(p, dmoModulate(buildDMODibitStream(3, 40), 11))
+	dmoFeed(p, dmoModulate(buildDMODibitStream(dmoTestSeed, 40), 11))
 
 	if p.dnbQualified <= afterFirst {
 		t.Errorf("second transmission qualified no DNBs (%d → %d)", afterFirst, p.dnbQualified)

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -409,6 +409,16 @@ type engineChannel struct {
 	// control channel. See maybeLogDiagnostics.
 	lowPowerWarned bool
 
+	// deafWindows counts consecutive diagnostics windows in which a Tier II
+	// channel that HAS synced before saw no sync at all while its power stayed
+	// within tier2DeafHealMarginDb of the level it last decoded at — the
+	// signature of a receiver whose state has latched, not of an idle repeater
+	// (whose carrier drops away). decodeDbFS is that reference level;
+	// deafHeals counts the receiver resets the guard performed.
+	deafWindows int
+	decodeDbFS  float64
+	everSynced  bool
+	deafHeals   uint64
 	// strongNoSyncWindows counts consecutive diagnostics windows in which
 	// this channel carried a strong signal yet produced zero sync/FEC — the
 	// signature of an uncorrected tuner frequency offset (issue #836). It
@@ -1198,6 +1208,23 @@ const noSyncHintDbFS = -45.0
 // tripping it; a real mistuned transmission holds for seconds.
 const strongNoSyncWindowsNeeded = 3
 
+// tier2DeafHealWindows / tier2DeafHealMarginDb gate the conventional-DMR
+// self-heal (see healDeafTier2). The 12 Sep IPSC field log showed the
+// 442.3875 MHz wideband tap going deaf for ~3-minute stretches, six times in
+// 30 min, at a steady -51 dBFS (its normal decoding level) while the other
+// tap on the same channelizer decoded throughout and offline replays of the
+// same IQ (DDC, channelizer, live-sized chunks) decode every transmission —
+// state accumulated inside the live receiver chain, not RF and not the tuner.
+// Three consecutive windows (~15 s) with no sync at a power within 6 dB of
+// the level the channel last synced at ⇒ reset the receiver and the Tier II
+// stream state, which is exactly what a fresh offline receiver does. An
+// unkeyed repeater drops well below that level, so idle silence never trips
+// it; a keyed foreign/analog carrier trips it every 15 s, harmlessly.
+const (
+	tier2DeafHealWindows  = 3
+	tier2DeafHealMarginDb = 6.0
+)
+
 // lowPowerDecodeGrace suppresses the "iq power very low" WARN for a channel
 // that produced protocol decodes (CSBKs / TSBKs / FEC passes) this recently.
 // Absolute dBFS is a gain-staging number, not a health verdict: a Tier III /
@@ -1410,6 +1437,7 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 					now.Sub(ec.activityLogAt) >= parkedLogInterval {
 					e.log.Debug("widebandt2: channel decode activity",
 						"freq_hz", ec.freqHz, "system", ec.sysName,
+						"dibits", c.Dibits-ec.lastLogCnt.Dibits,
 						"sync_hits", c.SyncHits-ec.lastLogCnt.SyncHits,
 						"bursts", c.Bursts-ec.lastLogCnt.Bursts,
 						"fec_pass", c.FECPass-ec.lastLogCnt.FECPass,
@@ -1418,13 +1446,16 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 						"late_entries", c.LateEntries-ec.lastLogCnt.LateEntries,
 						"csbk_crc_fail", c.CSBKCRCFail-ec.lastLogCnt.CSBKCRCFail,
 						"rekeys", c.Rekeys-ec.lastLogCnt.Rekeys,
-						"locks_total", c.Locks)
+						"locks_total", c.Locks,
+						"deaf_heals", ec.deafHeals)
 					ec.activityLogAt = now
 					ec.activityCls = cls
 					ec.lastLogCnt = c
 				}
 			}
 			ec.lastCnt = c
+
+			e.healDeafTier2(ec, dbfs, syncDelta, fecPassDelta, c.Beacons-ec.lastCnt.Beacons)
 
 			// Strong-signal-but-no-sync hint (issue #836). A real transmission
 			// that never produces a single burst-sync match is the classic
@@ -1481,4 +1512,57 @@ func pickStrategy(requested string, channelCount int) (kind, tag string) {
 	default:
 		return requested, requested
 	}
+}
+
+// tier2Diag is the receiver-internals view the deaf-tap self-heal logs before
+// it resets a Tier II receiver (dmrrx.Receiver satisfies it), so the next field
+// log shows the latched state rather than only the fact of the reset.
+type tier2Diag interface {
+	CoarseCarrierOffsetHz() float64
+	AGCLevel() float64
+	MMClockMu() float64
+	MMClockSPS() float64
+}
+
+// healDeafTier2 is the conventional-DMR deaf-tap guard (constants above): a
+// channel that has synced before, now seeing no sync for tier2DeafHealWindows
+// consecutive windows at a power within tier2DeafHealMarginDb of its last
+// decoding level, gets its receiver reset together with the Tier II stream
+// state (tier2.ResyncReset — the receiver's dibit index restarts at 0, so the
+// adapter's absolute-index buffer must go with it). Gated on the channel's OWN
+// decoding level, never an absolute dBFS: a -51 dBFS tap is healthy when it
+// decodes there and deaf when it stops, and an idle repeater's carrier falls
+// well below either. Runs inline on the pump goroutine like the rest of the
+// diagnostics, so the reset never races the receiver's Process.
+func (e *Engine) healDeafTier2(ec *engineChannel, dbfs float64, syncDelta, fecPassDelta, beaconDelta uint64) {
+	if ec.tier2Cnt == nil {
+		return
+	}
+	if syncDelta > 0 || fecPassDelta > 0 || beaconDelta > 0 {
+		ec.everSynced = true
+		ec.decodeDbFS = dbfs
+		ec.deafWindows = 0
+		return
+	}
+	if !ec.everSynced || dbfs < ec.decodeDbFS-tier2DeafHealMarginDb {
+		ec.deafWindows = 0
+		return
+	}
+	ec.deafWindows++
+	if ec.deafWindows < tier2DeafHealWindows {
+		return
+	}
+	ec.deafWindows = 0
+	ec.deafHeals++
+	attrs := []any{"freq_hz", ec.freqHz, "system", ec.sysName, "dbfs", dbfs,
+		"decode_dbfs", ec.decodeDbFS, "heals", ec.deafHeals}
+	if d, ok := ec.receiver.(tier2Diag); ok {
+		attrs = append(attrs, "coarse_offset_hz", d.CoarseCarrierOffsetHz(),
+			"agc_level", d.AGCLevel(), "mm_mu", d.MMClockMu(), "mm_sps", d.MMClockSPS())
+	}
+	e.log.Warn("widebandt2: conventional DMR tap deaf at its decoding level — resetting the receiver (field report: 3-minute deaf stretches at a steady -51 dBFS; the receiver internals logged here are the instrument for pinning the latch)", attrs...)
+	if r, ok := ec.receiver.(interface{ Reset() }); ok {
+		r.Reset()
+	}
+	ec.tier2Cnt.ResyncReset()
 }

--- a/internal/scanner/widebandt2/engine_deafheal_test.go
+++ b/internal/scanner/widebandt2/engine_deafheal_test.go
@@ -1,0 +1,120 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+)
+
+// resetCountingReceiver stands in for the Tier II narrowband receiver: it
+// records how often the engine reset it.
+type resetCountingReceiver struct{ resets int }
+
+func (r *resetCountingReceiver) Process([]complex64) {}
+func (r *resetCountingReceiver) Reset()              { r.resets++ }
+
+// scaledIQ is n samples of a constant tone at the given dBFS.
+func scaledIQ(n int, dbfs float64) []complex64 {
+	a := float32(math.Pow(10, dbfs/20) / math.Sqrt2)
+	c := make([]complex64, n)
+	for i := range c {
+		c[i] = complex(a, a)
+	}
+	return c
+}
+
+// syncDibits is a dibit stream carrying one BS-Data sync word, enough for the
+// Tier II channel to count a sync hit (nothing decodes — the payload is zero).
+func syncDibits() []uint8 {
+	out := make([]uint8, 300)
+	copy(out[100:], dmr.BSData.Dibits[:])
+	return out
+}
+
+// runDeafHeal drives diagnostics windows on one Tier II channel: `synced`
+// windows in which the channel sees a sync at `syncDbFS`, then `deaf` windows
+// with no sync at `deafDbFS`. Returns the receiver reset count, the channel's
+// heal counter and the WARNs captured.
+func runDeafHeal(t *testing.T, synced, deaf int, syncIQ, deafIQ []complex64) (int, uint64, []capturedRecord) {
+	t.Helper()
+	handler, recs, mu := newRecordingHandler()
+	bus := events.NewBus(8)
+	defer bus.Close()
+	rx := &resetCountingReceiver{}
+	cc := tier2.New(tier2.Options{Bus: bus, SystemName: "ipsc", FrequencyHz: 442_387_500})
+	ec := &engineChannel{freqHz: 442_387_500, sysName: "ipsc", protoTag: "dmr-tier2", tier2Cnt: cc, receiver: rx}
+	e := &Engine{log: slog.New(handler), channels: []*engineChannel{ec}, now: time.Now}
+
+	base := time.Unix(1_700_000_000, 0)
+	e.maybeLogDiagnostics(base)
+	w := 1
+	pos := 0
+	for i := 0; i < synced; i++ {
+		d := syncDibits()
+		cc.Process(d, pos)
+		pos += len(d)
+		ec.pwr.Add(syncIQ)
+		e.maybeLogDiagnostics(base.Add(time.Duration(w) * (iqpower.Window + time.Second)))
+		w++
+	}
+	for i := 0; i < deaf; i++ {
+		ec.pwr.Add(deafIQ)
+		e.maybeLogDiagnostics(base.Add(time.Duration(w) * (iqpower.Window + time.Second)))
+		w++
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	var warns []capturedRecord
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "deaf") {
+			warns = append(warns, r)
+		}
+	}
+	return rx.resets, ec.deafHeals, warns
+}
+
+// TestDeafTier2TapIsResetAtItsDecodingLevel is the 12 Sep IPSC regression: a
+// conventional-DMR tap that synced at -51 dBFS and then sees no sync for three
+// windows while its power stays at that level is deaf, not idle — the receiver
+// is reset (and the Tier II stream state with it) so the next burst decodes on
+// a fresh chain, instead of the tap staying deaf for minutes. Fails against the
+// old engine, which never reset a Tier II receiver at all.
+func TestDeafTier2TapIsResetAtItsDecodingLevel(t *testing.T) {
+	const n = 4096
+	level := scaledIQ(n, -51)
+	resets, heals, warns := runDeafHeal(t, 2, tier2DeafHealWindows, level, level)
+	if resets != 1 || heals != 1 {
+		t.Fatalf("receiver resets=%d heals=%d after %d deaf windows, want 1/1", resets, heals, tier2DeafHealWindows)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("deaf-tap WARNs = %d, want 1", len(warns))
+	}
+	if _, ok := warns[0].attrs["decode_dbfs"]; !ok {
+		t.Errorf("WARN missing decode_dbfs attr; attrs=%v", warns[0].attrs)
+	}
+	// One window short of the threshold: no reset.
+	if resets, _, _ := runDeafHeal(t, 2, tier2DeafHealWindows-1, level, level); resets != 0 {
+		t.Errorf("reset after only %d deaf windows, want none before %d", tier2DeafHealWindows-1, tier2DeafHealWindows)
+	}
+}
+
+// TestIdleTier2TapIsNotReset: an unkeyed repeater drops well below the level
+// the tap decoded at — that is silence, not deafness, and must never reset the
+// receiver (a conventional channel is idle most of the time). A tap that never
+// synced at all has no reference level and is left alone too.
+func TestIdleTier2TapIsNotReset(t *testing.T) {
+	const n = 4096
+	if resets, _, _ := runDeafHeal(t, 2, 4*tier2DeafHealWindows, scaledIQ(n, -51), scaledIQ(n, -70)); resets != 0 {
+		t.Errorf("idle (carrier dropped) channel reset %d times, want 0", resets)
+	}
+	if resets, _, _ := runDeafHeal(t, 0, 4*tier2DeafHealWindows, nil, scaledIQ(n, -51)); resets != 0 {
+		t.Errorf("never-synced channel reset %d times, want 0", resets)
+	}
+}

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -81,14 +81,6 @@ type Grant struct {
 	// the scrambler seed the voice chain descrambles the granted call's traffic
 	// frames with. Zero on non-TETRA grants and until the colour code is learned.
 	TETRAColourExt uint32
-	// TETRADMOBaseMNI is the DMO network's MNI half of the extended colour code
-	// (ExtendedColourCode(MCC, MNC, 0)), stamped on a tetra-dmo grant when the
-	// operator configured tetra_mcc/tetra_mnc. The voice chain folds it into its
-	// own colour recovery so a non-zero-MNI DMO network decodes (the traffic seed
-	// is TETRADMOBaseMNI | colour). Distinct from TETRAColourExt, which is the
-	// FULL seed once the colour is known; this is only the search base while the
-	// colour is still unknown. Zero on non-DMO grants and on an MNI-0 network.
-	TETRADMOBaseMNI uint32
 	// TETRAUsageMarker is the call's downlink usage marker (ETSI EN 300 392-2
 	// §21.4.7), the per-slot control-vs-traffic identifier the AACH broadcasts in
 	// every downlink slot. On a same-carrier SCBS it — not the unreliable

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -676,7 +676,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		if dcs, ok := src.(dmoColourSource); ok {
 			liveColour = dcs.TETRADMOColour
 		}
-		go c.runTETRADMOVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.TETRAColourExt, cs.Grant.TETRADMOBaseMNI, liveColour, ch.done)
+		go c.runTETRADMOVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.TETRAColourExt, liveColour, ch.done)
 	case voiceKindNXDN:
 		go c.runNXDNVoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.GroupID, ch.done)
 	case voiceKindDPMR:

--- a/internal/voice/composer/tetra_dmo_voice.go
+++ b/internal/voice/composer/tetra_dmo_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -17,24 +18,21 @@ import (
 // marker routing across four slots) this is a self-contained single-call chain,
 // closest in shape to the solo-tap runTETRAVoiceChain. It decimates the tap IQ to the
 // TETRA symbol rate, recovers the π/4-DQPSK stream with the shared receiver (blind CMA
-// equalizer + soft differentials, as the offline DMO path requires), slices each DNB
-// with the streaming DMStreamExtractor, TCH/S-decodes it (soft, with a hard fallback)
-// and emits the 137-bit speech frames to the recorder — which renders them to PCM with
-// the same clean-room ACELP vocoder ("tetra-acelp") the TMO path uses.
+// equalizer + soft differentials, as the offline DMO path requires), slices each
+// DSB/DNB with the streaming DMStreamExtractor, TCH/S-decodes each DNB (soft, with a
+// hard fallback) and emits the 137-bit speech frames to the recorder — which renders
+// them to PCM with the same clean-room ACELP vocoder ("tetra-acelp") the TMO path uses.
 //
-// colourHint is the DM traffic colour code the pipeline stamped on the grant. Because
-// the grant fires on the first DNBs (before the pipeline finishes brute-forcing the
-// colour), the hint is often 0, so this chain recovers the colour on its own and
-// decodes the buffer retroactively once known — no leading speech is lost. Recovery
-// runs, in preference order: (1) liveColour — a poll of the control pipeline's own
-// recovery via the same-carrier source (dmoColourSource), verified against a few
-// buffered bursts before adoption, at ~1/64 the cost of a brute force; (2) the local
-// RecoverDMColourCode brute force, scored ONLY on slot-grid-qualified bursts — the DNB
-// correlator false-alarms ~18/s (tetra/dmo_grid.go), and un-gated scoring windows were
-// ~half noise, which is why the dominance gate never cleared on air and all six
-// attempts burned. This is #1003 work: on-air A/B still gates it (a green synthetic
-// decode is not proof — #764/#771).
-func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, colourHint, baseMNI uint32, liveColour func() (uint32, bool), done chan<- struct{}) {
+// The TCH/S scramble seed is PER TRANSMISSION on air (tetra/dmo_seed_tracker.go: the
+// 12 Sep #1003 capture carried a different 30-bit seed on each PTT — the
+// transmitting radio's source address under a fixed prefix), so the chain runs its
+// own tetra.DMSeedTracker: the DSB SCH/H it slices announces the seed, the first
+// error-free DNB solves it exactly, and until one of those has confirmed a seed the
+// DNBs are buffered and decoded retroactively — no leading speech is lost. seedHint
+// is the pipeline's answer stamped on the grant (verified there, so adopted as is
+// when non-zero); liveColour polls the pipeline for the answer it reaches after the
+// grant, which the tracker confirms against this chain's own bursts before use.
+func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, seedHint uint32, liveColour func() (uint32, bool), done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-tetra-dmo:"+serial, nil)
 
@@ -50,14 +48,15 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 		serial:     serial,
 		bt:         bt,
 		rs:         rs,
-		colour:     colourHint,
-		baseMNI:    baseMNI &^ 0x3F,
+		seeds:      tetra.NewDMSeedTracker(),
 		liveColour: liveColour,
 		grid:       tetra.NewDMSlotGrid(),
-		// A non-zero hint from the grant is the pipeline's already-recovered colour
-		// (or the operator's tetra_colour_code override), so it counts as recovered.
-		colourKnown:     colourHint != 0,
-		colourRecovered: colourHint != 0,
+	}
+	if seedHint != 0 {
+		// The grant's seed is the pipeline's verified answer (or the operator's
+		// tetra_colour_code override): use it from the first burst.
+		dec.seeds.Adopt(seedHint)
+		dec.colourFromPipeline = true
 	}
 	ext := tetra.NewDMStreamExtractor(dec.onBurst)
 
@@ -75,16 +74,19 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 	rx := tetrarx.New(rxOpts)
 
 	c.log.Info("composer: tetra DMO voice follow started — DNB TCH/S decode + ACELP vocoder",
-		"serial", serial, "colour_hint", colourHint, "rate_hz", symbolHz)
+		"serial", serial, "seed_hint", fmt.Sprintf("%#010x", seedHint), "rate_hz", symbolHz)
 	defer func() {
 		ext.Flush() // emit any tail burst still inside the extractor window
-		dec.flush() // decode any DNBs still buffered awaiting colour recovery
+		dec.flush() // decode any DNBs still buffered awaiting the seed
+		seed, known := dec.seeds.Seed()
 		c.log.Info("composer: tetra DMO voice follow ended",
 			"serial", serial, "dnb_bursts", dec.dnb.Load(),
 			"speech_frames", dec.speech.Load(), "bfi_count", dec.bfi.Load(),
-			"colour", dec.colour, "colour_recovered", dec.colourRecovered,
-			"colour_from_pipeline", dec.colourFromPipeline,
-			"colour_attempts", dec.colourTries)
+			"seed", fmt.Sprintf("%#010x", seed), "seed_known", known,
+			"seed_verified", dec.seeds.Verified(),
+			"seed_from_pipeline", dec.colourFromPipeline,
+			"bursts_solved", dec.seeds.Solved,
+			"exact_adopts", dec.seeds.ExactAdopts, "hint_adopts", dec.seeds.HintAdopts)
 	}()
 
 	// feBuf is the reused front-end output scratch: fe.Process(nil, …) allocated
@@ -115,272 +117,122 @@ func (c *Composer) runTETRADMOVoiceChain(ctx context.Context, serial string, iqC
 	}
 }
 
-const (
-	// dmoVoiceColourBatch is how many DNBs the voice chain buffers before attempting
-	// colour-code recovery (matches the pipeline's dmoColourBatch cadence).
-	dmoVoiceColourBatch = 20
-	// dmoVoiceColourMax caps the buffer: past this, if no colour has cleared the
-	// confidence gate, stop buffering and decode at the best colour available —
-	// the control pipeline's recovered colour if it has one (adopted even when
-	// this chain cannot re-verify it locally, see adoptLiveColourUnverified),
-	// else colour 0 on the known MNI (a clear radio-to-radio call). An
-	// encrypted/unrecoverable call then simply yields no speech.
-	dmoVoiceColourMax = 120
-	// dmoVoiceColourMaxAttempts caps how many recovery passes to run, mirroring the
-	// control pipeline's dmoColourMaxAttempts.
-	//
-	// RecoverDMColourCode is a 64-colour brute force and each candidate is a full
-	// soft-Viterbi TCH/S decode over every buffered burst, plus a hard decode on the
-	// (usually failing) fallback path. Retrying it on EVERY arriving burst from buffer
-	// size 20 up to 120 is 64·Σ(20..120) ≈ 450 000 Viterbi decodes per call, crammed
-	// into the few seconds it takes to accumulate them — enough to starve the
-	// same-carrier IQ tap feeding this very chain ("voice tap dropped IQ to a lagging
-	// voice consumer"). Attempting only at batch boundaries, over a decimated buffer,
-	// brings it to the ~10k the control pipeline already budgets for.
-	dmoVoiceColourMaxAttempts = 6
-	// dmoVoiceHintMinBursts / dmoVoiceHintMinValid gate adopting the control
-	// pipeline's recovered colour (liveColour): at least MinBursts slot-grid-
-	// qualified bursts must be buffered, and decoding them at the hinted colour
-	// must yield at least MinValid CRC-valid bursts. Verification is N single-
-	// colour decodes — ~1/64 of one brute-force pass — so a correct hint makes
-	// the local brute force unnecessary, and a wrong/stale one cannot blindly
-	// latch.
-	dmoVoiceHintMinBursts = 4
-	dmoVoiceHintMinValid  = 2
-)
+// dmoVoiceSeedMax caps the DNBs buffered while no seed is known: past this, if
+// neither an exact solve nor a confirmed hint has landed (an encrypted call, or
+// one too weak for a single error-free burst), stop buffering and decode at the
+// best guess available — the pipeline's live answer if it has one, else seed 0
+// (the spec default for a radio-to-radio DMO). An unrecoverable call then simply
+// yields no speech. ~7 s of a full-rate call.
+const dmoVoiceSeedMax = 120
 
-// dmoVoiceDecoder holds the streaming DMO voice decode state for one call. All methods
-// run on the single receiver goroutine (the voice chain's process loop), so the fields
-// need no locking; the atomic counters are read from the deferred ended-log on the
-// same goroutine after the loop exits.
+// dmoVoiceDecoder holds the streaming DMO voice decode state for one call. All
+// methods run on the single receiver goroutine (the voice chain's process loop), so
+// the fields need no locking; the atomic counters are read from the deferred
+// ended-log on the same goroutine after the loop exits.
 type dmoVoiceDecoder struct {
 	c      *Composer
 	serial string
 	bt     *boundaryTracker
 	rs     rawFrameSink
 
-	colour uint32
-	// baseMNI is the DMO network MNI (ExtendedColourCode(MCC, MNC, 0)) from the
-	// grant's tetra_mcc/tetra_mnc, folded into colour recovery so a non-zero-MNI
-	// network decodes, and used as the clear-fallback seed (base | colour 0)
-	// instead of a bare 0. Zero on an MNI-0 radio-to-radio DMO.
-	baseMNI     uint32
-	colourKnown bool
-	// colourRecovered distinguishes "a colour cleared verification (local brute
-	// force or an adopted pipeline hint)" from "we gave up and fell back to
-	// colour 0", which colourKnown alone conflates — the end-of-call log used to
-	// claim colour_known=true colour=0 on a call where nothing was ever recovered.
-	colourRecovered bool
-	// colourFromPipeline is set when the control pipeline's colour was adopted
-	// WITHOUT this chain verifying it on its own bursts (the give-up / flush
-	// paths, or a hint landing after give-up). The pipeline's answer is
-	// confidence-gated on the same carrier, so it beats the colour-0 fallback
-	// it replaces; on the 20 Aug #1003 run the chain fell back to 0 before
-	// ever adopting the pipeline's 39 and decoded 242 DNBs as BFI.
+	// seeds learns the transmission's scramble seed from this chain's own DSBs and
+	// DNBs (and from the pipeline's hint, which it confirms before use).
+	seeds *tetra.DMSeedTracker
+	// colourFromPipeline records that the seed in use came from the pipeline
+	// (grant or give-up adoption) rather than this chain's own bursts.
 	colourFromPipeline bool
-	buffer             []tetra.DMBurst // ALL DNBs awaiting colour recovery (retroactive decode)
-	// scored holds only the slot-grid-QUALIFIED DNBs (freshest
-	// dmoVoiceColourBatch), the set colour recovery and hint verification score
-	// against. The DNB correlator false-alarms ~18/s, so an un-gated scoring
-	// window is ~half noise on a live tap and RecoverDMColourCode's dominance
-	// gate can never clear — the on-air "colour_attempts=6, colour_recovered=
-	// false, all BFI" failure. Buffering/emission stay un-gated (the CRC gates
-	// output; a pre-latch real burst must not be dropped).
-	scored []tetra.DMBurst
-	// grid votes DNB leads onto the 255-dibit slot grid to qualify them (the
-	// same tetra.DMSlotGrid the control pipeline uses).
+	// buffer holds every DNB seen while no seed was known, in order, so the
+	// start of the transmission is decoded retroactively once the seed lands.
+	buffer []tetra.DMBurst
+	// grid votes DNB leads onto the 255-dibit slot grid to qualify them (the same
+	// tetra.DMSlotGrid the control pipeline uses): the DNB correlator false-alarms
+	// ~18/s, and only qualified bursts are allowed to teach the tracker a seed.
+	// Buffering/emission stay un-gated (the CRC gates output; a pre-latch real
+	// burst must not be dropped).
 	grid *tetra.DMSlotGrid
-	// liveColour, when non-nil, polls the control pipeline's own colour
-	// recovery (via the same-carrier source). lastHint/lastHintValid remember a
-	// hinted value that FAILED verification so it is not re-verified every
-	// burst — only a changed hint is retried.
-	liveColour    func() (uint32, bool)
-	lastHint      uint32
-	lastHintValid bool
-	// colourTries counts recovery passes run, capped at dmoVoiceColourMaxAttempts.
-	// sinceTry is how many QUALIFIED bursts arrived since the last pass, so the
-	// brute force runs once per batch instead of once per burst.
-	colourTries int
-	sinceTry    int
+	// liveColour, when non-nil, polls the control pipeline's own seed recovery
+	// (via the same-carrier source).
+	liveColour func() (uint32, bool)
 
 	dnb, speech, bfi atomic.Uint64
 }
 
-// tryRecoverColour runs one capped colour-recovery pass and reports whether the
-// confidence gate was cleared.
-//
-// It scores only the qualified window (d.scored — the freshest
-// dmoVoiceColourBatch slot-grid-qualified bursts), not the whole buffer: the
-// gate needs a couple of dozen REAL bursts to separate the true colour from the
-// ~1/256 chance floor, and correlator noise in the window dilutes the dominance
-// ratio it needs. The full buffer is deliberately left intact — unlike the
-// control pipeline, which only wants the colour and can decimate, this chain
-// must still decode every buffered burst retroactively once the colour lands,
-// or the start of the transmission is lost from the recording. A call whose
-// grid never latched (very short PTT) falls back to the buffer tail — worse
-// odds, but better than scoring nothing at flush.
-func (d *dmoVoiceDecoder) tryRecoverColour() bool {
-	d.colourTries++
-	d.sinceTry = 0
-	scored := d.scored
-	if len(scored) == 0 {
-		scored = d.buffer
-		if len(scored) > dmoVoiceColourBatch {
-			scored = scored[len(scored)-dmoVoiceColourBatch:]
-		}
-	}
-	c, _, ok := tetra.RecoverDMColourCode(scored, d.baseMNI)
-	if !ok {
-		return false
-	}
-	d.colour, d.colourKnown, d.colourRecovered = c, true, true
-	d.c.log.Info("composer: tetra DMO colour code recovered",
-		"serial", d.serial, "colour", c, "attempt", d.colourTries)
-	return true
-}
-
-// tryAdoptLiveColour polls the control pipeline's own colour recovery and, when
-// it has an answer this chain hasn't already rejected, verifies it against the
-// buffered qualified bursts before adopting: at least dmoVoiceHintMinValid of
-// them must TCH/S-decode CRC-valid at the hinted colour. Verification is a
-// handful of single-colour decodes (~1/64 of one brute-force pass), so a
-// correct hint replaces the local brute force almost for free, while a wrong
-// or stale hint cannot blindly latch. A hint that fails is remembered
-// (lastHint) and only re-verified if the pipeline's answer changes. Returns
-// true when a colour was adopted.
-func (d *dmoVoiceDecoder) tryAdoptLiveColour() bool {
-	if d.liveColour == nil || d.colourRecovered {
-		return false
-	}
-	c, known := d.liveColour()
-	if !known || (d.colourKnown && c == d.colour) {
-		return false
-	}
-	if d.lastHintValid && c == d.lastHint {
-		return false // this exact value already failed verification here
-	}
-	if len(d.scored) < dmoVoiceHintMinBursts {
-		return false // too few real bursts to verify; retry as more arrive
-	}
-	valid := 0
-	for i := len(d.scored) - 1; i >= 0 && valid < dmoVoiceHintMinValid; i-- {
-		bb := d.scored[i]
-		if len(tetra.DMBurstTCHSpeechSoft(bb, c)) == 2 || len(tetra.DMBurstTCHSpeech(bb, c)) == 2 {
-			valid++
-		}
-	}
-	if valid < dmoVoiceHintMinValid {
-		d.lastHint, d.lastHintValid = c, true
-		return false
-	}
-	d.colour, d.colourKnown, d.colourRecovered = c, true, true
-	d.c.log.Info("composer: tetra DMO colour adopted from control pipeline",
-		"serial", d.serial, "colour", c)
-	return true
-}
-
-// adoptLiveColourUnverified adopts the control pipeline's recovered colour
-// WITHOUT verifying it against this chain's own bursts. It is only used where the
-// alternative is the colour-0 fallback — the give-up cap, flush, or a hint that
-// lands after give-up — never while local recovery still has a chance, so a stale
-// hint can only ever replace a guess, not a locally recovered colour. The
-// pipeline's colour is confidence-gated (RecoverDMColourCode's dominance gate) on
-// the same carrier; the fallback is not evidence at all. This is what the 20 Aug
-// #1003 on-air run lacked: the chain gave up at colour 0 before adopting the
-// pipeline's 39, and tryAdoptLiveColour's re-verification then failed forever on a
-// receiver whose bursts differed from the pipeline's. Returns true when the colour
-// changed.
-func (d *dmoVoiceDecoder) adoptLiveColourUnverified() bool {
-	if d.liveColour == nil || d.colourRecovered {
-		return false
-	}
-	c, known := d.liveColour()
-	if !known || (d.colourKnown && c == d.colour) {
-		return false
-	}
-	d.colour, d.colourKnown, d.colourFromPipeline = c, true, true
-	d.c.log.Info("composer: tetra DMO colour adopted from control pipeline (not verified on this chain's bursts)",
-		"serial", d.serial, "colour", c)
-	return true
-}
-
-// onBurst handles one streamed DMO burst. DSBs carry no speech (signalling only), so
-// only DNBs are decoded. Until the colour code is known, DNBs are buffered; once
-// recovered/adopted (or the cap forces a colour-0 fallback) the buffer is decoded in
-// order and each subsequent DNB decodes immediately.
+// onBurst handles one streamed DMO burst. A DSB carries no speech but its SCH/H
+// announces the transmission's seed, so it feeds the tracker; a DNB is decoded at
+// once when the seed is known, else buffered until it is.
 func (d *dmoVoiceDecoder) onBurst(b tetra.DMBurst) {
-	if b.Kind != tetra.DMBurstNormal {
+	switch b.Kind {
+	case tetra.DMBurstSync:
+		d.seeds.ObserveDSB(b)
+		return
+	case tetra.DMBurstNormal:
+	default:
 		return
 	}
 	d.dnb.Add(1)
 	qualified := d.grid.Observe(b.Lead)
-	if d.colourKnown {
-		// A give-up latch (colourKnown without colourRecovered) can still be
-		// rescued by the pipeline's recovery landing later: keep the qualified
-		// window fresh and adopt a verified hint for the remaining bursts.
-		if !d.colourRecovered {
-			if qualified {
-				d.pushScored(b)
-			}
-			// A verified adoption is preferred; failing that, the pipeline's
-			// colour still beats the fallback this chain is decoding at.
-			if !d.tryAdoptLiveColour() {
-				d.adoptLiveColourUnverified()
-			}
+	if d.liveColour != nil && !d.seeds.Verified() {
+		if s, known := d.liveColour(); known {
+			d.seeds.Hint(s)
 		}
-		d.emit(b)
+	}
+	if _, known := d.seeds.Seed(); known {
+		d.emit(b, qualified)
 		return
 	}
 	d.buffer = append(d.buffer, b)
 	if qualified {
-		d.pushScored(b)
-		d.sinceTry++
-	}
-	// Attempt only once per batch of fresh QUALIFIED bursts, and only up to the
-	// attempt cap — re-running the 64-colour brute force on every arriving burst is
-	// what made this chain starve its own IQ tap.
-	canBrute := d.colourTries < dmoVoiceColourMaxAttempts &&
-		len(d.scored) >= dmoVoiceColourBatch &&
-		(d.colourTries == 0 || d.sinceTry >= dmoVoiceColourBatch)
-	switch {
-	case d.tryAdoptLiveColour():
-		// Adopted the pipeline's verified colour; fall through and flush.
-	case canBrute && d.tryRecoverColour():
-		// Recovered locally; fall through and flush.
-	case len(d.buffer) >= dmoVoiceColourMax || d.colourTries >= dmoVoiceColourMaxAttempts:
-		// Give up recovering locally. Prefer the control pipeline's colour even
-		// unverified; otherwise assume clear colour 0 on top of the known MNI
-		// (baseMNI | 0 — plain 0 when MNI is 0). A genuinely encrypted call then
-		// yields no CRC-valid speech (bfi), which the hangtime ends normally.
-		if !d.adoptLiveColourUnverified() {
-			d.colour, d.colourKnown = d.baseMNI, true
+		// Let the qualified burst teach the tracker (an exact solve, or a CRC
+		// confirmation of the hint). Its own frames are emitted with the buffer.
+		_, seed, adopted := d.seeds.ObserveDNB(b, true)
+		if adopted {
+			d.c.log.Info("composer: tetra DMO scramble seed recovered",
+				"serial", d.serial, "seed", fmt.Sprintf("%#010x", seed),
+				"exact_adopts", d.seeds.ExactAdopts, "hint_adopts", d.seeds.HintAdopts)
 		}
-	default:
+	}
+	if _, known := d.seeds.Seed(); !known && len(d.buffer) >= dmoVoiceSeedMax {
+		d.giveUp()
+	}
+	if _, known := d.seeds.Seed(); !known {
 		return // keep buffering
 	}
 	buf := d.buffer
 	d.buffer = nil
 	for _, bb := range buf {
-		d.emit(bb)
+		d.emit(bb, true)
 	}
 }
 
-// pushScored appends a qualified burst to the scoring window, keeping only the
-// freshest dmoVoiceColourBatch entries.
-func (d *dmoVoiceDecoder) pushScored(b tetra.DMBurst) {
-	d.scored = append(d.scored, b)
-	if len(d.scored) > dmoVoiceColourBatch {
-		d.scored = append(d.scored[:0], d.scored[len(d.scored)-dmoVoiceColourBatch:]...)
+// giveUp installs a fallback seed once the buffer cap is hit with nothing
+// confirmed: the pipeline's live answer if it has one, else seed 0. A later exact
+// solve still replaces it.
+func (d *dmoVoiceDecoder) giveUp() {
+	if d.liveColour != nil {
+		if s, known := d.liveColour(); known {
+			d.seeds.Fallback(s)
+			d.colourFromPipeline = true
+			d.c.log.Info("composer: tetra DMO seed adopted from control pipeline (not confirmed on this chain's bursts)",
+				"serial", d.serial, "seed", fmt.Sprintf("%#010x", s))
+			return
+		}
 	}
+	d.seeds.Fallback(0)
 }
 
-// emit TCH/S-decodes one DNB (soft with a hard fallback) at the known colour and writes
-// its speech frames to the recorder, refreshing call liveness on real speech. A DNB
-// that yields no CRC-valid speech is a Bad Frame Indication (encrypted/corrupt).
-func (d *dmoVoiceDecoder) emit(b tetra.DMBurst) {
-	frames := tetra.DMBurstTCHSpeechSoft(b, d.colour)
-	if len(frames) != 2 {
-		frames = tetra.DMBurstTCHSpeech(b, d.colour)
+// emit TCH/S-decodes one DNB through the tracker (which keeps learning: an exact
+// solve on a burst of a NEW transmission switches the seed) and writes its speech
+// frames to the recorder, refreshing call liveness on real speech. A DNB that
+// yields no CRC-valid speech is a Bad Frame Indication (noise/encrypted/corrupt).
+func (d *dmoVoiceDecoder) emit(b tetra.DMBurst, qualified bool) {
+	// Every burst goes through the tracker: the exact solve is safe on an
+	// unqualified (possibly noise) burst — no solution can come from noise —
+	// and it is what catches the first bursts of a fast re-key before the slot
+	// grid re-latches; only hint confirmation is withheld from unqualified ones.
+	frames, seed, adopted := d.seeds.ObserveDNB(b, qualified)
+	if adopted {
+		d.c.log.Info("composer: tetra DMO scramble seed changed",
+			"serial", d.serial, "seed", fmt.Sprintf("%#010x", seed))
 	}
 	if len(frames) != 2 {
 		d.bfi.Add(1)
@@ -397,34 +249,20 @@ func (d *dmoVoiceDecoder) emit(b tetra.DMBurst) {
 	}
 }
 
-// flush decodes any DNBs still buffered awaiting colour recovery at end-of-call. If the
-// colour never cleared the confidence gate, it makes a final best-effort attempt, then
-// falls back to colour 0 so a short clear call is not dropped.
-//
-// The fallback sets colourKnown (the buffer is about to be decoded at SOME colour) but
-// deliberately NOT colourRecovered, so the end-of-call log distinguishes "recovered
-// colour 0" from "never recovered anything". Setting the flag unconditionally is what
-// made a call that decoded nothing report `colour=0 colour_known=true`, which reads as
-// a successful recovery.
+// flush decodes any DNBs still buffered awaiting the seed at end-of-call. If no
+// seed was ever confirmed, it falls back (giveUp) so a short clear call is still
+// decoded at the best available guess; the ended-log reports seed_verified=false
+// so a fallback is never mistaken for a recovery.
 func (d *dmoVoiceDecoder) flush() {
 	if len(d.buffer) == 0 {
 		return
 	}
-	if !d.colourKnown {
-		if !d.tryAdoptLiveColour() {
-			d.tryRecoverColour()
-		}
-		if !d.colourRecovered && !d.adoptLiveColourUnverified() {
-			// Nothing cleared the gate and the pipeline has no answer — fall back
-			// to clear colour 0 on top of the known MNI (baseMNI | 0) so a short
-			// clear call still decodes.
-			d.colour = d.baseMNI
-		}
-		d.colourKnown = true
+	if _, known := d.seeds.Seed(); !known {
+		d.giveUp()
 	}
 	buf := d.buffer
 	d.buffer = nil
 	for _, bb := range buf {
-		d.emit(bb)
+		d.emit(bb, true)
 	}
 }

--- a/internal/voice/composer/tetra_dmo_voice_test.go
+++ b/internal/voice/composer/tetra_dmo_voice_test.go
@@ -98,7 +98,11 @@ func buildDMODNBBursts(t *testing.T, colour uint32, n int) ([]tetra.DMBurst, [][
 	all := tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0)
 	var dnbs []tetra.DMBurst
 	for _, b := range all {
-		if b.Kind == tetra.DMBurstNormal {
+		// Keep only the bursts on the transmitter's slot grid (lead at slot
+		// offset 7+108): a scrambled payload can contain chance 11-dibit
+		// training-sequence matches (the correlator's ~18/s false-alarm class),
+		// which the live chain drops via DMSlotGrid and the noise test covers.
+		if b.Kind == tetra.DMBurstNormal && b.Lead%dmoVSlotDibits == 115 {
 			dnbs = append(dnbs, b)
 		}
 	}
@@ -108,29 +112,37 @@ func buildDMODNBBursts(t *testing.T, colour uint32, n int) ([]tetra.DMBurst, [][
 	return dnbs, want
 }
 
-// TestDMOVoiceDecoderRecoversColourAndEmits pins the voice chain's core logic: when the
-// grant carries no colour (hint 0), the decoder buffers DNBs, brute-force-recovers the
-// DM colour code, decodes the buffered DNBs retroactively (so no leading speech is
-// lost), and emits every call's two 137-bit speech frames to the recorder sink — the
-// same frames that were encoded. This is the composer half of the #1003 DMO voice path
-// (the receiver→extractor half is covered by the pipeline test); on-air A/B still gates
-// closing #1003.
-func TestDMOVoiceDecoderRecoversColourAndEmits(t *testing.T) {
-	const colour = 3
-	bursts, want := buildDMODNBBursts(t, colour, 28)
+// newTestDMODecoder builds a voice decoder with the production wiring minus the
+// receiver: an empty seed tracker, a slot grid, a fake raw-frame sink.
+func newTestDMODecoder(sink *fakeDMOSink, live func() (uint32, bool)) *dmoVoiceDecoder {
+	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
+	return &dmoVoiceDecoder{
+		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
+		seeds: tetra.NewDMSeedTracker(), grid: tetra.NewDMSlotGrid(), liveColour: live,
+	}
+}
+
+// TestDMOVoiceDecoderRecoversSeedAndEmits pins the voice chain's core logic: when
+// the grant carries no seed, the decoder buffers DNBs, learns the scramble seed
+// from the first error-free burst (an exact GF(2) solve — no colour space, no
+// configuration), decodes the buffered DNBs retroactively (so no leading speech
+// is lost) and emits every burst's two 137-bit speech frames to the recorder —
+// the same frames that were encoded. The seed is a real on-air value from the
+// 12 Sep #1003 capture (0x012915c0), outside the 0..63 the old brute force
+// searched: this test fails against the old code, which never recovered it.
+func TestDMOVoiceDecoderRecoversSeedAndEmits(t *testing.T) {
+	const seed = 0x012915c0
+	bursts, want := buildDMODNBBursts(t, seed, 28)
 
 	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	bt := c.newBoundaryTracker("s", 0, nil)
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: bt, rs: sink, grid: tetra.NewDMSlotGrid()}
-
+	dec := newTestDMODecoder(sink, nil)
 	for _, b := range bursts {
 		dec.onBurst(b)
 	}
 	dec.flush()
 
-	if !dec.colourKnown || dec.colour != colour {
-		t.Fatalf("recovered colour=%d known=%v, want %d", dec.colour, dec.colourKnown, colour)
+	if got, known := dec.seeds.Seed(); !known || got != seed || !dec.seeds.Verified() {
+		t.Fatalf("recovered seed=%#x known=%v verified=%v, want %#x", got, known, dec.seeds.Verified(), seed)
 	}
 	if len(sink.frames) != 2*len(want) {
 		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
@@ -145,27 +157,58 @@ func TestDMOVoiceDecoderRecoversColourAndEmits(t *testing.T) {
 	}
 }
 
-// TestDMOVoiceDecoderUsesGrantColour checks the fast path: when the grant already
-// carries the recovered colour, the decoder uses it directly with no buffering — every
-// DNB decodes immediately.
-func TestDMOVoiceDecoderUsesGrantColour(t *testing.T) {
-	const colour = 3
-	bursts, want := buildDMODNBBursts(t, colour, 4)
+// TestDMOVoiceDecoderUsesGrantSeed checks the fast path: when the grant already
+// carries the pipeline's seed, the decoder uses it directly with no buffering —
+// every DNB decodes immediately.
+func TestDMOVoiceDecoderUsesGrantSeed(t *testing.T) {
+	const seed = 3
+	bursts, want := buildDMODNBBursts(t, seed, 4)
 	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{
-		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
-		grid:   tetra.NewDMSlotGrid(),
-		colour: colour, colourKnown: true, colourRecovered: true,
-	}
+	dec := newTestDMODecoder(sink, nil)
+	dec.seeds.Adopt(seed)
 	for _, b := range bursts {
 		dec.onBurst(b)
 	}
 	if len(dec.buffer) != 0 {
-		t.Errorf("decoder buffered %d bursts despite a known colour", len(dec.buffer))
+		t.Errorf("decoder buffered %d bursts despite a known seed", len(dec.buffer))
 	}
 	if len(sink.frames) != 2*len(want) {
 		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
+	}
+}
+
+// TestDMOVoiceDecoderFollowsSeedChangeMidStream is the on-air behaviour of the
+// 12 Sep capture: three back-to-back transmissions, each with its own seed, on
+// one chain (the grant re-arm did not separate them). Every burst must decode at
+// its own transmission's seed — the tracker switches on the first clean burst of
+// the next PTT — with no garbage from a stale seed.
+func TestDMOVoiceDecoderFollowsSeedChangeMidStream(t *testing.T) {
+	var bursts []tetra.DMBurst
+	var want [][2][]byte
+	for k, seed := range []uint32{0x012915c0, 0x015d9c07, 0x01671384} {
+		b, w := buildDMODNBBursts(t, seed, 10)
+		for i := range b {
+			b[i].Lead += k * 40 * dmoVSlotDibits // later transmissions sit later in the stream
+		}
+		bursts = append(bursts, b...)
+		want = append(want, w...)
+	}
+	sink := &fakeDMOSink{}
+	dec := newTestDMODecoder(sink, nil)
+	for _, b := range bursts {
+		dec.onBurst(b)
+	}
+	dec.flush()
+	if len(sink.frames) != 2*len(want) {
+		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
+	}
+	for i, w := range want {
+		if !reflect.DeepEqual(sink.frames[2*i], w[0]) || !reflect.DeepEqual(sink.frames[2*i+1], w[1]) {
+			t.Errorf("DNB %d: emitted speech frame mismatch", i)
+		}
+	}
+	if dec.seeds.ExactAdopts != 3 {
+		t.Errorf("exact seed adoptions = %d, want 3 (one per transmission)", dec.seeds.ExactAdopts)
 	}
 }
 
@@ -252,44 +295,33 @@ func buildDMOGoodWithNoise(t *testing.T, colour uint32, nGood int) ([]tetra.DMBu
 	return dnbs, want
 }
 
-// TestDMOVoiceDecoderAdoptsLiveColourHint pins the pipeline→voice-chain colour
-// hand-off: a DMO grant structurally fires before the control pipeline finishes
-// its own colour recovery, so the chain polls liveColour and must adopt a
-// verified answer with far fewer bursts than the local brute force needs. Only
-// 12 bursts are fed — below dmoVoiceColourBatch — so with no hint plumbing the
-// brute force could not have fired mid-stream at all; adoption must land with
-// zero local attempts and every burst's speech emitted. Fails against the old
-// code (no liveColour parameter existed).
-func TestDMOVoiceDecoderAdoptsLiveColourHint(t *testing.T) {
-	const colour = 44
-	bursts, want := buildDMODNBBursts(t, colour, 12)
+// TestDMOVoiceDecoderConfirmsLiveHint pins the pipeline→voice-chain hand-off: a
+// DMO grant structurally fires before the control pipeline has solved the seed, so
+// the chain polls liveColour. On bursts that carry bit errors (no exact solve) the
+// hint is what decodes them, once two of them CRC-confirm it; every burst's
+// speech is then emitted from the buffer.
+func TestDMOVoiceDecoderConfirmsLiveHint(t *testing.T) {
+	const seed = 0x015d9c07
+	bursts, want := buildDMODNBBurstsWithErrors(t, seed, 12, 3)
 
 	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
 	calls := 0
-	dec := &dmoVoiceDecoder{
-		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
-		grid: tetra.NewDMSlotGrid(),
-		liveColour: func() (uint32, bool) {
-			// The pipeline's recovery lands a few bursts into the call.
-			calls++
-			if calls > 3 {
-				return colour, true
-			}
-			return 0, false
-		},
-	}
+	dec := newTestDMODecoder(sink, func() (uint32, bool) {
+		// The pipeline's answer lands a few bursts into the call.
+		calls++
+		if calls > 3 {
+			return seed, true
+		}
+		return 0, false
+	})
 	for _, b := range bursts {
 		dec.onBurst(b)
 	}
 	dec.flush()
 
-	if !dec.colourRecovered || dec.colour != colour {
-		t.Fatalf("adopted colour=%d recovered=%v, want %d via the live hint",
-			dec.colour, dec.colourRecovered, colour)
-	}
-	if dec.colourTries != 0 {
-		t.Errorf("ran %d local brute-force attempts despite a valid live hint, want 0", dec.colourTries)
+	if got, _ := dec.seeds.Seed(); got != seed || !dec.seeds.Verified() || dec.seeds.HintAdopts != 1 {
+		t.Fatalf("seed=%#x verified=%v hint_adopts=%d, want %#x via the confirmed hint",
+			got, dec.seeds.Verified(), dec.seeds.HintAdopts, seed)
 	}
 	if len(sink.frames) != 2*len(want) {
 		t.Fatalf("emitted %d speech frames, want %d (buffered speech lost?)",
@@ -298,64 +330,47 @@ func TestDMOVoiceDecoderAdoptsLiveColourHint(t *testing.T) {
 }
 
 // TestDMOVoiceDecoderRejectsBadLiveHint is the companion: a wrong/stale hint
-// (different DMO net, cleared-too-late atomic) must NOT blindly latch — it
-// fails CRC verification against the buffered bursts and local recovery still
-// lands the true colour.
+// (another radio's DSB, a cleared-too-late atomic) must NOT latch — it never CRC-
+// confirms against the buffered bursts, and the exact solve lands the true seed.
 func TestDMOVoiceDecoderRejectsBadLiveHint(t *testing.T) {
-	const colour = 3
-	bursts, want := buildDMODNBBursts(t, colour, 30)
+	const seed = 3
+	bursts, want := buildDMODNBBursts(t, seed, 30)
 
 	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{
-		c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
-		grid:       tetra.NewDMSlotGrid(),
-		liveColour: func() (uint32, bool) { return 17, true }, // wrong colour
-	}
+	dec := newTestDMODecoder(sink, func() (uint32, bool) { return 17, true }) // wrong seed
 	for _, b := range bursts {
 		dec.onBurst(b)
 	}
 	dec.flush()
 
-	if dec.colour != colour || !dec.colourRecovered {
-		t.Fatalf("colour=%d recovered=%v, want %d recovered locally despite the bad hint",
-			dec.colour, dec.colourRecovered, colour)
-	}
-	if dec.colourTries == 0 {
-		t.Errorf("local recovery never ran — the bad hint was adopted?")
+	if got, _ := dec.seeds.Seed(); got != seed || !dec.seeds.Verified() || dec.seeds.HintAdopts != 0 {
+		t.Fatalf("seed=%#x verified=%v hint_adopts=%d, want %#x solved locally despite the bad hint",
+			got, dec.seeds.Verified(), dec.seeds.HintAdopts, seed)
 	}
 	if len(sink.frames) != 2*len(want) {
 		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
 	}
 }
 
-// TestDMOVoiceDecoderRecoversColourThroughNoise reproduces the on-air failure
-// that left every real DMO call at colour_attempts=6, colour_recovered=false,
-// all-BFI: on a live tap the DNB correlator's ~18/s false alarms outnumber real
-// traffic, and the old un-gated colour scoring windows were mostly noise, so
-// RecoverDMColourCode's dominance gate could never clear and the attempt budget
-// burned out before enough real bursts arrived. With slot-grid gating, only the
-// grid-qualified (real) bursts are scored, recovery lands, and every real
-// burst's speech is emitted. Fails against the old un-gated code.
-func TestDMOVoiceDecoderRecoversColourThroughNoise(t *testing.T) {
-	const colour = 3
-	bursts, want := buildDMOGoodWithNoise(t, colour, 30)
+// TestDMOVoiceDecoderRecoversSeedThroughNoise reproduces the live-tap condition:
+// the DNB correlator's ~18/s false alarms outnumber real traffic. Only slot-grid-
+// qualified bursts may teach the tracker, so the noise cannot steer it; the
+// first clean real burst solves the seed and every real burst's speech is
+// emitted in order, the noise bursts BFI.
+func TestDMOVoiceDecoderRecoversSeedThroughNoise(t *testing.T) {
+	const seed = 0x01671384
+	bursts, want := buildDMOGoodWithNoise(t, seed, 30)
 
 	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
-
+	dec := newTestDMODecoder(sink, nil)
 	for _, b := range bursts {
 		dec.onBurst(b)
 	}
 	dec.flush()
 
-	if !dec.colourRecovered || dec.colour != colour {
-		t.Fatalf("colour=%d recovered=%v (attempts=%d), want %d recovered through the noise",
-			dec.colour, dec.colourRecovered, dec.colourTries, colour)
+	if got, _ := dec.seeds.Seed(); got != seed || !dec.seeds.Verified() {
+		t.Fatalf("seed=%#x verified=%v, want %#x recovered through the noise", got, dec.seeds.Verified(), seed)
 	}
-	// Every GOOD burst's two speech frames must be present, in order; the noise
-	// bursts BFI at the recovered colour and contribute nothing.
 	if len(sink.frames) != 2*len(want) {
 		t.Fatalf("emitted %d speech frames, want %d", len(sink.frames), 2*len(want))
 	}
@@ -366,158 +381,74 @@ func TestDMOVoiceDecoderRecoversColourThroughNoise(t *testing.T) {
 	}
 }
 
-// TestDMOVoiceDecoderBoundsColourRecovery pins the cost bound on the 64-colour brute
-// force. RecoverDMColourCode is a full soft-Viterbi TCH/S decode per colour per burst
-// (plus a hard decode on the failing fallback), and it used to be re-run on EVERY
-// arriving burst from buffer size 20 to 120 — 64·Σ(20..120) ≈ 450 000 decodes per
-// call, on exactly the calls that cannot be recovered anyway. That is what starved the
-// same-carrier IQ tap feeding this chain. It must now run at most
-// dmoVoiceColourMaxAttempts times, scoring a bounded window.
-func TestDMOVoiceDecoderBoundsColourRecovery(t *testing.T) {
+// TestDMOVoiceDecoderDoesNotClaimUnrecoveredSeed is the honesty regression for the
+// end-of-call log: undecodable bursts (an encrypted call) must never produce a
+// "verified" seed — the give-up fallback decodes at a guess, emits nothing, and
+// reports seed_verified=false so a fallback is not mistaken for a recovery.
+func TestDMOVoiceDecoderDoesNotClaimUnrecoveredSeed(t *testing.T) {
 	bursts := buildDMOUndecodableDNBs(t, 200)
 	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
-
+	dec := newTestDMODecoder(sink, nil)
 	for _, b := range bursts {
 		dec.onBurst(b)
 	}
 	dec.flush()
 
-	if dec.colourTries > dmoVoiceColourMaxAttempts {
-		t.Errorf("ran %d colour-recovery passes, want at most %d",
-			dec.colourTries, dmoVoiceColourMaxAttempts)
+	if dec.seeds.Verified() {
+		s, _ := dec.seeds.Seed()
+		t.Errorf("reported seed %#x as verified on undecodable bursts", s)
 	}
-	if dec.colourTries == 0 {
-		t.Errorf("never attempted colour recovery — the test is not exercising the path")
+	if _, known := dec.seeds.Seed(); !known {
+		t.Errorf("no fallback seed after flush; the buffer would never be decoded")
+	}
+	if len(dec.buffer) != 0 {
+		t.Errorf("%d bursts still buffered past the cap", len(dec.buffer))
 	}
 	if len(sink.frames) != 0 {
 		t.Errorf("emitted %d speech frames from undecodable bursts, want 0", len(sink.frames))
 	}
 }
 
-// TestDMOVoiceDecoderDoesNotClaimUnrecoveredColour is the honesty regression for the
-// end-of-call log. flush() used to set colourKnown = true OUTSIDE the confidence-gate
-// branch, so a call where nothing was ever recovered reported `colour=0
-// colour_known=true` — which reads as "recovered colour 0" and sent the investigation
-// after the wrong thing. The fallback still has to pick a colour to decode at, so
-// colourKnown is separate from colourRecovered.
-func TestDMOVoiceDecoderDoesNotClaimUnrecoveredColour(t *testing.T) {
-	bursts := buildDMOUndecodableDNBs(t, 60)
-	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
-
-	for _, b := range bursts {
-		dec.onBurst(b)
+// buildDMODNBBurstsWithErrors is buildDMODNBBursts with flips random coded bits
+// corrupted in every burst, so no burst solves exactly and only a hinted seed
+// (confirmed by the soft decode's CRC) can decode them.
+func buildDMODNBBurstsWithErrors(t *testing.T, seed uint32, n, flips int) ([]tetra.DMBurst, [][2][]byte) {
+	t.Helper()
+	b2d := tetra.TetraBitsToDibits
+	var dibits []uint8
+	var want [][2][]byte
+	dibits = append(dibits, dmoVFiller(0, dmoVSlotDibits)...)
+	for i := 0; i < n; i++ {
+		fa := dmoVSeq(7+i, 137)
+		fb := dmoVSeq(9+i, 137)
+		t4 := framing.UnpackBitsMSB(tetra.EncodeTCHS(fa, fb), 432)
+		onair := framing.ScrambleTetra(t4, seed)
+		for k := 0; k < flips; k++ {
+			// Coded region only (type-3 bits 102..431 through the 24x18 interleave).
+			t3 := 102 + (i*53+k*97)%330
+			onair[(t3%18)*24+t3/18] ^= 1
+		}
+		dibits = append(dibits, dmoVSlot(11+i,
+			b2d(onair[:216]),
+			tetra.NormalSyncDibits(),
+			b2d(onair[216:]),
+		)...)
+		want = append(want, [2][]byte{framing.PackBitsMSB(fa), framing.PackBitsMSB(fb)})
 	}
-	dec.flush()
-
-	if dec.colourRecovered {
-		t.Errorf("reported colour %d as recovered when the confidence gate never cleared",
-			dec.colour)
-	}
-	if !dec.colourKnown {
-		t.Errorf("colourKnown = false after flush; the buffer would never be decoded")
-	}
-}
-
-// TestDMOVoiceDecoderKeepsBufferedSpeechAcrossAttempts guards the interaction between
-// the new attempt cap and the retroactive decode: the control pipeline decimates its
-// candidate buffer between passes because it only wants the colour, but this chain
-// must still emit every buffered burst once the colour lands, or the start of the
-// transmission is missing from the recording. Recovery is deliberately delayed past
-// the first attempt here by prefixing undecodable bursts.
-func TestDMOVoiceDecoderKeepsBufferedSpeechAcrossAttempts(t *testing.T) {
-	const colour = 3
-	good, want := buildDMODNBBursts(t, colour, 24)
-	bad := buildDMOUndecodableDNBs(t, dmoVoiceColourBatch)
-
-	sink := &fakeDMOSink{}
-	c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-	dec := &dmoVoiceDecoder{c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink, grid: tetra.NewDMSlotGrid()}
-
-	for _, b := range append(append([]tetra.DMBurst{}, bad...), good...) {
-		dec.onBurst(b)
-	}
-	dec.flush()
-
-	if !dec.colourRecovered || dec.colour != colour {
-		t.Fatalf("recovered colour=%d recovered=%v, want %d", dec.colour, dec.colourRecovered, colour)
-	}
-	// Every good burst's two speech frames must still be emitted, in order, even
-	// though they were buffered across more than one recovery attempt.
-	if len(sink.frames) != 2*len(want) {
-		t.Fatalf("emitted %d speech frames, want %d (buffered speech was dropped)",
-			len(sink.frames), 2*len(want))
-	}
-	for i, w := range want {
-		if !reflect.DeepEqual(sink.frames[2*i], w[0]) || !reflect.DeepEqual(sink.frames[2*i+1], w[1]) {
-			t.Errorf("DNB %d: emitted speech frame mismatch", i)
+	dibits = append(dibits, dmoVFiller(99, dmoVSlotDibits)...)
+	all := tetra.ExtractDMBurstsSoft(dibits, dmoVIdealDiffs(dibits), 0)
+	var dnbs []tetra.DMBurst
+	for _, b := range all {
+		// Keep only the bursts on the transmitter's slot grid (lead at slot
+		// offset 7+108): a scrambled payload can contain chance 11-dibit
+		// training-sequence matches (the correlator's ~18/s false-alarm class),
+		// which the live chain drops via DMSlotGrid and the noise test covers.
+		if b.Kind == tetra.DMBurstNormal && b.Lead%dmoVSlotDibits == 115 {
+			dnbs = append(dnbs, b)
 		}
 	}
-}
-
-// TestDMOVoiceDecoderPrefersPipelineColourOverFallback reproduces the 20 Aug
-// #1003 on-air run. The grant fired with colour_hint=0; the chain buffered past
-// dmoVoiceColourMax without its own recovery landing and the give-up path fell
-// back to colour 0 BEFORE it ever adopted the pipeline's colour (39 on that
-// run). tryAdoptLiveColour then never cleared, because its local re-verification
-// kept failing on this chain's own bursts (a receiver configured differently
-// from the pipeline's) and a hint that failed once was never retried — so all
-// 242 DNBs decoded as BFI and the call died on hangtime. The pipeline's colour is
-// confidence-gated on the same carrier; the fallback is a guess, so the
-// pipeline's answer must win wherever the fallback would otherwise be used.
-//
-// Here the chain's bursts are undecodable at ANY colour while the hint is up
-// (local recovery and hint verification both fail, as on air) and a few
-// decodable colour-39 bursts arrive afterwards. Old code: colour 0, nothing
-// emitted. Fixed: colour 39 adopted at give-up (or the moment the hint lands
-// after give-up) and every good burst's speech emitted.
-func TestDMOVoiceDecoderPrefersPipelineColourOverFallback(t *testing.T) {
-	const colour = 39
-	for _, tc := range []struct {
-		name         string
-		hintAfterDNB int // hint becomes known once this many DNBs were seen
-	}{
-		{"hint known from the start", 0},
-		{"hint lands after the give-up cap", dmoVoiceColourMax + 5},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			noise := buildDMOUndecodableDNBs(t, dmoVoiceColourMax+10)
-			good, want := buildDMODNBBursts(t, colour, 6)
-
-			sink := &fakeDMOSink{}
-			c := &Composer{log: slog.New(slog.NewTextHandler(io.Discard, nil)), hangtime: time.Second}
-			seen := 0
-			dec := &dmoVoiceDecoder{
-				c: c, serial: "s", bt: c.newBoundaryTracker("s", 0, nil), rs: sink,
-				grid: tetra.NewDMSlotGrid(),
-				liveColour: func() (uint32, bool) {
-					if seen >= tc.hintAfterDNB {
-						return colour, true
-					}
-					return 0, false
-				},
-			}
-			for _, b := range noise {
-				seen++
-				dec.onBurst(b)
-			}
-			for _, b := range good {
-				seen++
-				dec.onBurst(b)
-			}
-			dec.flush()
-
-			if !dec.colourKnown || dec.colour != colour {
-				t.Fatalf("decoding at colour=%d known=%v, want the pipeline's %d over the colour-0 fallback",
-					dec.colour, dec.colourKnown, colour)
-			}
-			if len(sink.frames) != 2*len(want) {
-				t.Fatalf("emitted %d speech frames, want %d (good bursts decoded BFI at the fallback colour?)",
-					len(sink.frames), 2*len(want))
-			}
-		})
+	if len(dnbs) != n {
+		t.Fatalf("built %d DNB bursts, want %d", len(dnbs), n)
 	}
+	return dnbs, want
 }


### PR DESCRIPTION
The 12 Sep three-PTT capture, solved burst by burst with a new exact GF(2)
scramble-seed solver (the LFSR scrambler is affine in its 30-bit seed and the
TCH/S coding is a linear block code, so one error-free DNB pins the seed with
128 redundant checks), carries a DIFFERENT seed on every PTT: the transmitting
radio's 24-bit source address — the DSB SCH/H field right before the MNI, which
reads MCC 250 / MNC 1 as the operator's codeplug says — under a fixed 6-bit
prefix. No colour code a 64-way brute force could reach; every colour it ever
reported was a partial-keystream artifact (a related wrong seed CRC-passes ~9%
of bursts, so a CRC count is not proof of a seed).

The pipeline and the voice chain now share tetra.DMSeedTracker: the DSB
announces the seed as a hint (adopted only after three CRC-valid decodes on
slot-grid-qualified bursts), any burst's exact solve adopts at once and
preempts a stale seed, errored bursts get a soft-assisted solve (least-reliable
bit flips, then a reliability-ranked solve over local sparse parity checks),
and a traffic drought forgets the seed. tetra_mcc / tetra_mnc are no longer
needed for DMO; tetra_colour_code pins one full seed for diagnostics.

On the capture: 159 CRC-valid TCH/S across all three PTTs and 9.5 s of speech,
versus 58 bursts of one PTT at a bogus colour before. The replay harness reads
wav/flac and reports per-transmission seed runs; TestTETRADMOSeedScan prints
each burst's solved seed next to the DSB SCH/H bits. Daemon-path on-air
verification (a recording with intelligible audio) remains the gate.

Refs #1003

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GQYKSDi5VFTGwZUDbt99Z8