### PR TITLE
web: high-contrast theme for bright-sunlight use (#1176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Web console high-contrast theme** (#1176). Settings → Theme gains a
+  fourth option, `high-contrast`: pure black on pure white, black hairlines
+  in place of tinted surfaces, and status colours pushed to dark shades that
+  hold ~7:1 against white, for reading the console in bright sunlight. The
+  choice is shared with the Config Builder, Signal Lab, RF Scope and Crypto
+  Lab SPAs like the existing themes, and the PWA `theme-color` now follows
+  the selected theme so the browser chrome matches the page.
 - **dPMR and D-STAR voice now decode to PCM (experimental, unverified on
   air).** Following the NXDN precedent, both protocols gain end-to-end voice
   chains: dPMR anchors on the FS1/FS2 voice syncs, carves each 80 ms frame's

--- a/docs/web.md
+++ b/docs/web.md
@@ -37,7 +37,7 @@ browser-only panels (e.g. Radio IDs, Import):
 | Tones       | `tone.alert` feed with per-device reset                         |
 | Metrics     | Curated `gophertrunk_*` Prometheus tiles + Chart.js trend       |
 | Scanner     | CC hunter, conventional channels, manual VFO tune, scan_mode    |
-| Settings    | Theme, write-mode toggle, **live config editing** (PATCH /api/v1/settings) |
+| Settings    | Theme (dark / monochrome / light / high-contrast), density, write-mode toggle, **live config editing** (PATCH /api/v1/settings) |
 | Import      | Upload PDFs / CSV bundles, preview, commit into config.yaml     |
 
 The headline scenario: run the daemon on a Raspberry Pi (or any host

--- a/web/README.md
+++ b/web/README.md
@@ -172,7 +172,7 @@ tap in the bottom nav can't fire one.
 - **React 18** + **React Router** (hash mode so `file://` works)
 - **Zustand** for shared state — see `src/store/shared.ts`
 - **Tailwind CSS** for layout + a tiny `tokens.css` for the
-  dark / monochrome themes
+  dark / monochrome / light / high-contrast themes
 - **Chart.js** + **react-chartjs-2** for metrics + scanner
   visualisations; **D3 scale** subpackage for custom axes
 - **vite-plugin-pwa** wraps Workbox; the service worker

--- a/web/configbuilder/src/main.tsx
+++ b/web/configbuilder/src/main.tsx
@@ -11,7 +11,13 @@ import "./styles.css";
   try {
     const theme = localStorage.getItem("gt.ui.theme");
     document.documentElement.dataset.theme =
-      theme === "monochrome" ? "mono" : theme === "light" ? "light" : "dark";
+      theme === "monochrome"
+        ? "mono"
+        : theme === "light"
+          ? "light"
+          : theme === "high-contrast"
+            ? "contrast"
+            : "dark";
     const density = localStorage.getItem("gt.ui.density");
     document.documentElement.dataset.density =
       density === "compact" ? "compact" : "comfortable";

--- a/web/configbuilder/src/styles.css
+++ b/web/configbuilder/src/styles.css
@@ -52,6 +52,22 @@
   color-scheme: light;
 }
 
+[data-theme="contrast"] {
+  --gt-bg: 255 255 255;
+  --gt-panel: 255 255 255;
+  --gt-muted: 0 0 0;
+  --gt-fg: 0 0 0;
+  --gt-accent: 0 0 0;
+  --gt-ok: 0 96 0;
+  --gt-warn: 124 58 0;
+  --gt-err: 160 0 0;
+  --gt-surface-1: 255 255 255;
+  --gt-surface-2: 255 255 255;
+  --gt-surface-3: 229 229 229;
+  --gt-border: 0 0 0;
+  color-scheme: light;
+}
+
 html,
 body,
 #root {

--- a/web/cryptolab/src/main.tsx
+++ b/web/cryptolab/src/main.tsx
@@ -11,7 +11,13 @@ import "./styles.css";
   try {
     const theme = localStorage.getItem("gt.ui.theme");
     document.documentElement.dataset.theme =
-      theme === "monochrome" ? "mono" : theme === "light" ? "light" : "dark";
+      theme === "monochrome"
+        ? "mono"
+        : theme === "light"
+          ? "light"
+          : theme === "high-contrast"
+            ? "contrast"
+            : "dark";
     const density = localStorage.getItem("gt.ui.density");
     document.documentElement.dataset.density =
       density === "compact" ? "compact" : "comfortable";

--- a/web/cryptolab/src/styles.css
+++ b/web/cryptolab/src/styles.css
@@ -52,6 +52,22 @@
   color-scheme: light;
 }
 
+[data-theme="contrast"] {
+  --gt-bg: 255 255 255;
+  --gt-panel: 255 255 255;
+  --gt-muted: 0 0 0;
+  --gt-fg: 0 0 0;
+  --gt-accent: 0 0 0;
+  --gt-ok: 0 96 0;
+  --gt-warn: 124 58 0;
+  --gt-err: 160 0 0;
+  --gt-surface-1: 255 255 255;
+  --gt-surface-2: 255 255 255;
+  --gt-surface-3: 229 229 229;
+  --gt-border: 0 0 0;
+  color-scheme: light;
+}
+
 html,
 body,
 #root {

--- a/web/rfscope/src/main.tsx
+++ b/web/rfscope/src/main.tsx
@@ -9,7 +9,13 @@ import "./styles.css";
   try {
     const theme = localStorage.getItem("gt.ui.theme");
     document.documentElement.dataset.theme =
-      theme === "monochrome" ? "mono" : theme === "light" ? "light" : "dark";
+      theme === "monochrome"
+        ? "mono"
+        : theme === "light"
+          ? "light"
+          : theme === "high-contrast"
+            ? "contrast"
+            : "dark";
     const density = localStorage.getItem("gt.ui.density");
     document.documentElement.dataset.density =
       density === "compact" ? "compact" : "comfortable";

--- a/web/rfscope/src/styles.css
+++ b/web/rfscope/src/styles.css
@@ -52,6 +52,22 @@
   color-scheme: light;
 }
 
+[data-theme="contrast"] {
+  --gt-bg: 255 255 255;
+  --gt-panel: 255 255 255;
+  --gt-muted: 0 0 0;
+  --gt-fg: 0 0 0;
+  --gt-accent: 0 0 0;
+  --gt-ok: 0 96 0;
+  --gt-warn: 124 58 0;
+  --gt-err: 160 0 0;
+  --gt-surface-1: 255 255 255;
+  --gt-surface-2: 255 255 255;
+  --gt-surface-3: 229 229 229;
+  --gt-border: 0 0 0;
+  color-scheme: light;
+}
+
 html,
 body,
 #root {

--- a/web/siglab/src/main.tsx
+++ b/web/siglab/src/main.tsx
@@ -11,7 +11,13 @@ import "./styles.css";
   try {
     const theme = localStorage.getItem("gt.ui.theme");
     document.documentElement.dataset.theme =
-      theme === "monochrome" ? "mono" : theme === "light" ? "light" : "dark";
+      theme === "monochrome"
+        ? "mono"
+        : theme === "light"
+          ? "light"
+          : theme === "high-contrast"
+            ? "contrast"
+            : "dark";
     const density = localStorage.getItem("gt.ui.density");
     document.documentElement.dataset.density =
       density === "compact" ? "compact" : "comfortable";

--- a/web/siglab/src/styles.css
+++ b/web/siglab/src/styles.css
@@ -52,6 +52,22 @@
   color-scheme: light;
 }
 
+[data-theme="contrast"] {
+  --gt-bg: 255 255 255;
+  --gt-panel: 255 255 255;
+  --gt-muted: 0 0 0;
+  --gt-fg: 0 0 0;
+  --gt-accent: 0 0 0;
+  --gt-ok: 0 96 0;
+  --gt-warn: 124 58 0;
+  --gt-err: 160 0 0;
+  --gt-surface-1: 255 255 255;
+  --gt-surface-2: 255 255 255;
+  --gt-surface-3: 229 229 229;
+  --gt-border: 0 0 0;
+  color-scheme: light;
+}
+
 html,
 body,
 #root {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,12 +4,12 @@ import { HashRouter } from "react-router-dom";
 import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { prefs, themeAttr } from "./store/prefs";
+import { applyTheme, prefs } from "./store/prefs";
 import "./styles.css";
 
 // Apply the stored theme + density before the first render so the UI
 // never flashes the default palette or spacing.
-document.documentElement.dataset.theme = themeAttr(prefs.theme());
+applyTheme(prefs.theme());
 document.documentElement.dataset.density = prefs.density();
 
 // Register the service worker. autoUpdate strategy: if a new bundle

--- a/web/src/panels/Settings.test.tsx
+++ b/web/src/panels/Settings.test.tsx
@@ -246,3 +246,28 @@ describe("Settings inline-edit (Live config)", () => {
     expect(formatRow.textContent).toMatch(/\[restart\]/);
   });
 });
+
+describe("Settings theme picker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    window.localStorage.clear();
+    delete document.documentElement.dataset.theme;
+    vi.mocked(api.configFiles).mockResolvedValue({ dirs: [], files: [] });
+    vi.mocked(api.runtime).mockResolvedValue({ config_path: "" });
+  });
+
+  // #1176: a black-on-white maximum-contrast mode for bright sunlight.
+  it("offers high-contrast and applies it to <html> when picked", async () => {
+    const user = userEvent.setup();
+    render(<Settings />);
+
+    const btn = await screen.findByRole("button", { name: "high-contrast" });
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    await user.click(btn);
+
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+    expect(document.documentElement.dataset.theme).toBe("contrast");
+    expect(window.localStorage.getItem("gt.ui.theme")).toBe("high-contrast");
+  });
+});

--- a/web/src/panels/Settings.tsx
+++ b/web/src/panels/Settings.tsx
@@ -7,7 +7,7 @@ import type {
   RuntimeDTO,
   SettingsPatch,
 } from "../api/types";
-import { prefs, themeAttr, type Density, type Theme } from "../store/prefs";
+import { applyTheme, prefs, THEMES, type Density, type Theme } from "../store/prefs";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Section } from "../components/ui/Section";
@@ -36,7 +36,7 @@ export function Settings() {
   const onTheme = (t: Theme) => {
     setTheme(t);
     prefs.setTheme(t);
-    document.documentElement.dataset.theme = themeAttr(t);
+    applyTheme(t);
   };
 
   const onDensity = (d: Density) => {
@@ -71,7 +71,7 @@ export function Settings() {
         <div className="space-y-2">
           <h3 className="panel-title">Theme</h3>
           <div className="flex flex-wrap gap-2">
-            {(["dark", "monochrome", "light"] as const).map((t) => (
+            {THEMES.map((t) => (
               <button
                 key={t}
                 className={theme === t ? "btn-primary" : "btn-ghost"}
@@ -82,6 +82,10 @@ export function Settings() {
               </button>
             ))}
           </div>
+          <p className="text-xs text-muted">
+            High-contrast is pure black on white for reading the console in
+            bright sunlight.
+          </p>
         </div>
         <div className="space-y-2">
           <h3 className="panel-title">Density</h3>

--- a/web/src/store/prefs.test.ts
+++ b/web/src/store/prefs.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyTheme, prefs, themeAttr, themeColor, THEMES } from "./prefs";
+
+// The theme axis (#1176 added "high-contrast"). These pin the two things
+// that have to agree for a theme to render: the stored preference and the
+// `data-theme` attribute the stylesheets key their token blocks on.
+describe("prefs theme", () => {
+  let meta: HTMLMetaElement;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    delete document.documentElement.dataset.theme;
+    meta = document.createElement("meta");
+    meta.name = "theme-color";
+    meta.content = "#0f172a";
+    document.head.appendChild(meta);
+  });
+
+  afterEach(() => {
+    meta.remove();
+  });
+
+  it("maps every theme to the attribute value its CSS block uses", () => {
+    expect(themeAttr("dark")).toBe("dark");
+    expect(themeAttr("monochrome")).toBe("mono");
+    expect(themeAttr("light")).toBe("light");
+    expect(themeAttr("high-contrast")).toBe("contrast");
+  });
+
+  it("lists high-contrast as a selectable theme", () => {
+    expect(THEMES).toContain("high-contrast");
+  });
+
+  it("round-trips high-contrast through storage", () => {
+    prefs.setTheme("high-contrast");
+    expect(prefs.theme()).toBe("high-contrast");
+    expect(window.localStorage.getItem("gt.ui.theme")).toBe("high-contrast");
+  });
+
+  it("falls back to dark on an unknown stored value", () => {
+    window.localStorage.setItem("gt.ui.theme", "sepia");
+    expect(prefs.theme()).toBe("dark");
+  });
+
+  it("applyTheme stamps data-theme and the theme-color meta", () => {
+    applyTheme("high-contrast");
+    expect(document.documentElement.dataset.theme).toBe("contrast");
+    expect(meta.content).toBe(themeColor("high-contrast"));
+    expect(meta.content).toBe("#ffffff");
+
+    applyTheme("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(meta.content).toBe("#0f172a");
+  });
+});

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -51,13 +51,48 @@ const SS_KEYS = {
   noConfigDismissed: "gt.ui.noConfigDismissed",
 } as const;
 
-export type Theme = "dark" | "monochrome" | "light";
+export type Theme = "dark" | "monochrome" | "light" | "high-contrast";
 export type Density = "comfortable" | "compact";
 
+export const THEMES: readonly Theme[] = ["dark", "monochrome", "light", "high-contrast"];
+
 // Maps a stored Theme to the `data-theme` attribute value the CSS uses
-// ("monochrome" → "mono"). Centralized so main.tsx and Settings agree.
+// ("monochrome" → "mono", "high-contrast" → "contrast"). Centralized so
+// main.tsx, Settings, and the sister SPAs' bootstrap agree.
 export function themeAttr(theme: Theme): string {
-  return theme === "monochrome" ? "mono" : theme;
+  switch (theme) {
+    case "monochrome":
+      return "mono";
+    case "high-contrast":
+      return "contrast";
+    default:
+      return theme;
+  }
+}
+
+// The browser-chrome colour (PWA status bar, Android task switcher) per
+// theme. A white high-contrast page under a slate-900 status bar reads
+// as a broken theme outdoors, which is the one case this theme exists for.
+export function themeColor(theme: Theme): string {
+  switch (theme) {
+    case "light":
+      return "#f1f5f9";
+    case "high-contrast":
+      return "#ffffff";
+    case "monochrome":
+      return "#111111";
+    default:
+      return "#0f172a";
+  }
+}
+
+// Apply a theme to the document: the `data-theme` attribute the CSS keys
+// on, plus the `theme-color` meta. Shared by the pre-render bootstrap in
+// main.tsx and the Settings panel so they cannot drift.
+export function applyTheme(theme: Theme) {
+  document.documentElement.dataset.theme = themeAttr(theme);
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (meta) meta.content = themeColor(theme);
 }
 
 function readLS(key: string): string | null {
@@ -116,7 +151,8 @@ export const prefs = {
   },
 
   theme(): Theme {
-    return (readLS(LS_KEYS.theme) as Theme | null) ?? "dark";
+    const raw = readLS(LS_KEYS.theme);
+    return (THEMES as readonly string[]).includes(raw ?? "") ? (raw as Theme) : "dark";
   },
   setTheme(theme: Theme) {
     writeLS(LS_KEYS.theme, theme);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3,8 +3,8 @@
 @tailwind utilities;
 
 /* Theme tokens. Swap these via the `data-theme` attribute on <html>;
-   the Settings panel toggles between "dark" (default), "mono", and
-   "light". Density is a separate axis on `data-density`. */
+   the Settings panel toggles between "dark" (default), "mono", "light",
+   and "contrast". Density is a separate axis on `data-density`. */
 :root,
 [data-theme="dark"] {
   --gt-bg: 15 23 42;        /* slate-900 */
@@ -53,6 +53,29 @@
   --gt-surface-2: 255 255 255; /* raised card = white */
   --gt-surface-3: 226 232 240; /* hover */
   --gt-border: 203 213 225; /* slate-300 hairline */
+  color-scheme: light;
+}
+
+/* High-contrast: pure black on pure white for outdoor / bright-sunlight
+   use (#1176). Every surface is white and every hairline is black, so
+   the layering that the other themes express through tinted surfaces
+   is expressed here through borders instead (see the overrides below).
+   Status colours stay semantic but are pushed to very dark shades that
+   hold ~7:1 against white; accent collapses to black so buttons and
+   focus rings read as solid ink. */
+[data-theme="contrast"] {
+  --gt-bg: 255 255 255;
+  --gt-panel: 255 255 255;
+  --gt-muted: 0 0 0;
+  --gt-fg: 0 0 0;
+  --gt-accent: 0 0 0;
+  --gt-ok: 0 96 0;          /* dark green */
+  --gt-warn: 124 58 0;      /* dark amber */
+  --gt-err: 160 0 0;        /* dark red */
+  --gt-surface-1: 255 255 255;
+  --gt-surface-2: 255 255 255;
+  --gt-surface-3: 229 229 229; /* hover / active: the one grey allowed */
+  --gt-border: 0 0 0;
   color-scheme: light;
 }
 
@@ -165,4 +188,39 @@ body {
   .pill-err {
     @apply pill bg-err/15 text-err;
   }
+}
+
+/* High-contrast theme: the component classes above lean on translucent
+   panel tints (bg-panel/60, ring-white/5, bg-ok/15) to separate layers,
+   which is invisible when panel == bg == white. Give every container and
+   control a solid black hairline instead, and drop the tinted pill fills
+   so their dark text sits on plain white. Kept out of the token block
+   because these are structural, not palette, changes. */
+[data-theme="contrast"] .panel,
+[data-theme="contrast"] .card,
+[data-theme="contrast"] .btn-ghost,
+[data-theme="contrast"] .input,
+[data-theme="contrast"] .pill {
+  border-color: rgb(var(--gt-border));
+  --tw-ring-color: rgb(var(--gt-border));
+  box-shadow: none;
+}
+[data-theme="contrast"] .pill {
+  border-width: 1px;
+  background-color: rgb(var(--gt-bg));
+}
+[data-theme="contrast"] .btn-ghost:hover {
+  background-color: rgb(var(--gt-surface-3));
+}
+[data-theme="contrast"] .btn-primary {
+  border: 1px solid rgb(var(--gt-border));
+}
+/* Structural dividers (sidebar rail, top bar, list separators, chart
+   frames) are drawn with the panel tint, which is white-on-white here.
+   `.border-border` is not a token the Tailwind config defines, so those
+   frames otherwise fall back to preflight's pale grey. */
+[data-theme="contrast"] .border-panel,
+[data-theme="contrast"] .border-border,
+[data-theme="contrast"] .divide-panel > :not([hidden]) ~ :not([hidden]) {
+  border-color: rgb(var(--gt-border));
 }


### PR DESCRIPTION
## Summary

Issue #1176 asked for a high-contrast web console theme for reading the console in bright sunlight. PR #1178 implemented it but was never merged: its `CHANGELOG.md` entry conflicted with main, so the theme is in **no** release, and the reporter (davidsrsb) correctly found no fourth theme in v1.1.3 on Windows 11. This PR carries #1178's change onto current main with the conflict resolved, so the theme actually ships in the next release. It supersedes #1178.

## Changes

- `web/src/store/prefs.ts`: `Theme` gains `high-contrast`; the `THEMES` list drives the picker; `themeAttr` stamps `data-theme="contrast"` and `applyTheme` also sets the PWA `theme-color` meta so the browser chrome follows the page.
- `web/src/styles.css`: `[data-theme="contrast"]` token block — pure black on pure white, black hairlines in place of tinted surfaces, status colours pushed to dark shades that hold ~7:1 against white. Plot canvases keep their own palettes.
- `web/src/panels/Settings.tsx`: Theme picker renders from `THEMES`.
- `web/{configbuilder,siglab,rfscope,cryptolab}/src/{main.tsx,styles.css}`: the sister SPAs honour the shared theme preference like the existing themes.
- Tests: `web/src/store/prefs.test.ts` (new) and `web/src/panels/Settings.test.tsx`.
- Docs: `docs/web.md`, `web/README.md`, and the CHANGELOG bullet moved from the v1.1.3 section (where #1178 had it) to `[Unreleased]`, since v1.1.3 was tagged without it — that was the only conflict.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a, web-only
- [x] Added or updated tests where appropriate — `npx vitest run`: 62 files / 377 tests pass; `npm run typecheck` passes in all five SPAs (`web`, `web/configbuilder`, `web/siglab`, `web/rfscope`, `web/cryptolab`); `scripts/release-refs.py check` passes
- [ ] Smoke-tested against real hardware — n/a; the reporter's sunlight check on the rig is the verification gate

## Breaking changes

none. The theme preference key is unchanged; existing `light`/`dark`/`auto` values behave as before.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/web.md` and `web/README.md`

## Linked issues

Refs #1176. Supersedes #1178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9WB59U3aoZLxe2n3B8y5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9WB59U3aoZLxe2n3B8y5G)_